### PR TITLE
MapQuest Open tilesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Concept
 -------
 Folium makes it easy to visualize data that's been manipulated in Python on an interactive Leaflet map. It enables both the binding of data to a map for choropleth visualizations as well as passing Vincent/Vega visualizations as markers on the map.
 
-The library has a number of built-in tilesets from OpenStreetMap, Mapbox, and Stamen, and supports custom tilesets with Mapbox or Cloudmade API keys. Folium supports both GeoJSON and TopoJSON overlays, as well as the binding of data to those overlays to create choropleth maps with color-brewer color schemes.
+The library has a number of built-in tilesets from OpenStreetMap, MapQuest Open, MapQuest Open Aerial, Mapbox, and Stamen, and supports custom tilesets with Mapbox or Cloudmade API keys. Folium supports both GeoJSON and TopoJSON overlays, as well as the binding of data to those overlays to create choropleth maps with color-brewer color schemes.
 
 Installation
 ---------------

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -41,6 +41,8 @@ class Map(object):
         tilesets or a custom tileset URL. The following tilesets are built-in
         to Folium. Pass any of the following to the "tiles" keyword:
             -"OpenStreetMap"
+            -"MapQuest Open"
+            -"MapQuest Open Aerial"
             -"Mapbox Bright" (Limited levels of zoom for free tiles)
             -"Mapbox Control Room" (Limited levels of zoom for free tiles)
             -"Stamen Terrain"
@@ -120,6 +122,7 @@ class Map(object):
                              ' or non-default Mapbox tiles.')
 
         self.default_tiles = ['openstreetmap', 'mapboxcontrolroom',
+                              'mapquestopen', 'mapquestopenaerial',
                               'mapboxbright', 'mapbox', 'cloudmade',
                               'stamenterrain', 'stamentoner']
         self.tile_types = {}

--- a/folium/templates/mapquestopen_att.txt
+++ b/folium/templates/mapquestopen_att.txt
@@ -1,0 +1,1 @@
+Map tiles by <a href="http://open.mapquest.com/">MapQuest</a> Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/mapquestopen_tiles.txt
+++ b/folium/templates/mapquestopen_tiles.txt
@@ -1,0 +1,1 @@
+http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png

--- a/folium/templates/mapquestopenaerial_att.txt
+++ b/folium/templates/mapquestopenaerial_att.txt
@@ -1,0 +1,1 @@
+Map tiles by <a href="http://open.mapquest.com/">MapQuest Open Aerial</a>.Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture, FarmService Agency.

--- a/folium/templates/mapquestopenaerial_tiles.txt
+++ b/folium/templates/mapquestopenaerial_tiles.txt
@@ -1,0 +1,1 @@
+http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png


### PR DESCRIPTION
Add support for MapQuest Open (alternative OpenStreetMap rendering) and MapQuest Open (public domain satellite imagery) tile sets.

Annoyance: because *_tiles.txt files in templates directory do not allow us to set subdomains to use, this will only fetch tiles from 1 server instead of load-balancing over MapQuest's CDN.
