### PR TITLE
Reverted change to mathchColor in attempt to fix choropleth coloring bug.

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -570,7 +570,7 @@ class Map(object):
             self.template_vars.setdefault('map_legends', []).append(legend)
 
             #Style with color brewer colors
-            matchColor = 'matchKey({0}, {1})'.format(key_on, data_var)
+            matchColor = 'color(matchKey({0}, {1}))'.format(key_on, data_var)
             style = json_style(style_count, line_color, line_weight,
                                line_opacity, None, fill_opacity, matchColor)
         else:


### PR DESCRIPTION
We're using folium on a project, [bikeability](https://github.com/cfa-nm/bikeability) (THANKS!) and it seems that a change made in commit 8269f81b0b932f49a76bc20412b47a939805dab3 has caused our choropleths to turn out all grey.

The images below are the before/after shots of the same map.

![map-ok](https://f.cloud.github.com/assets/747219/1222713/19999092-2700-11e3-988f-51b349107cc4.png)
![map-notok](https://f.cloud.github.com/assets/747219/1222712/19877cd6-2700-11e3-841d-116e44f26cb4.png)

By changing the line below back to what it was our chorpleths are nice and colorful again.
