### PR TITLE
simple popups correctly escape internal quotes

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -437,7 +437,7 @@ class Map(object):
             if isinstance(popup, str):
                 popup_temp = self.env.get_template('simple_popup.js')
                 return popup_temp.render({'pop_name': mk_name + str(count),
-                                          'pop_txt': popup})
+                                          'pop_txt': json.dumps(popup)})
             elif isinstance(popup, tuple):
                 #Update template with JS libs
                 vega_temp = self.env.get_template('vega_ref.txt').render()

--- a/folium/templates/simple_popup.js
+++ b/folium/templates/simple_popup.js
@@ -1,1 +1,1 @@
-{{ pop_name }}.bindPopup("{{ pop_txt }}");
+{{ pop_name }}.bindPopup({{ pop_txt }});


### PR DESCRIPTION
Currently, Folium doesn't perform any string escaping in simple popups. As a result, if the popup text includes a double quote `"` character, javascript interprets it as the end of the string and causes an error.

For example, the following simple test case will run correctly but cause an error in the resultant javascript.

``` python
import folium

ex_map = folium.Map(location=[0,0])
popup_text = 'a very "special" popup'
ex_map.polygon_marker([0,0],popup=popup_text)
ex_map.create_map("example.html")
```

The generated javascript contains the line `polygon_1.bindPopup("a very "special" popup");`, which is a syntax error.

This pull request fixes the problem by using the `json.dumps` command to escape quotes and other special characters in the popup string.
