### PR TITLE
Ignore IPython Notebook Checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ nosetests.xml
 #Mac
 *.DS_Store
 
+# IPython Notebook Checkpoints
+.ipynb_checkpoints
+
 #Virtualenv
 ENV


### PR DESCRIPTION
This should help prevent accidentally committing IPyNB checkpoints.
