### PR TITLE
Add map JSON for geojson template

### DIFF
--- a/folium/templates/geojson_template.html
+++ b/folium/templates/geojson_template.html
@@ -13,6 +13,14 @@
 
    <style>
 
+      #map {
+        position:absolute;
+        top:0;
+        bottom:0;
+        right:0;
+        left:0;
+      }
+
       .legend {
           padding: 0px 0px;
           font: 10px sans-serif;


### PR DESCRIPTION
If I create a basic map like:

map = folium.Map(location=center, zoom_start=zoom, width='100%', height='100%')
map.create_map(path="maps/test.html")

Things work fine.  If I then add geojson to the map:

map = folium.Map(location=center, zoom_start=zoom, width='100%', height='100%')
map.geo_json(geo_path=filename)
map.create_map(path="maps/test2.html")

I get a blank page.

It appears the difference is this bit of CSS, which is present in my first test.html file but not in test2.html:
# map {

  position:absolute;
  top:0;
  bottom:0;
  right:0;
  left:0;
}

Let me know if there's a cleaner way to fix this, or if I'm way off base!
