### PR TITLE
TemplateNotFound: tiles/openstreetmap/tiles.txt

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -157,10 +157,11 @@ class Map(object):
                               'stamenterrain', 'stamentoner']
         self.tile_types = {}
         for tile in self.default_tiles:
-            join_tile_path = functools.partial(os.path.join, 'tiles', tile)
+            template_tiles = '/tiles/' + tile + '/tiles.txt'
+            template_attr = '/tiles/' + tile + '/attr.txt'
             self.tile_types[tile] = {
-                'templ': self.env.get_template(join_tile_path('tiles.txt')),
-                'attr': self.env.get_template(join_tile_path('attr.txt')),
+                'templ': self.env.get_template(template_tiles),
+                'attr': self.env.get_template(template_attr),
             }
 
         if self.tiles in self.tile_types:


### PR DESCRIPTION
Still had this problem with python 3.4 under Windows. This fix is working for me.
