### PR TITLE
Moved version string to `folium/__init__.py`.

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
+__version__ = '0.1.3'
+
 from folium.folium import Map, initialize_notebook

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,43 @@
 # -*- coding: utf-8 -*-
 import os
 
+import re
+VERSIONFILE = "folium/__init__.py"
+verstrline = open(VERSIONFILE, "rt").read()
+VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+mo = re.search(VSRE, verstrline, re.M)
+if mo:
+    verstr = mo.group(1)
+else:
+    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
+
 def walk_subpkg(name):
     data_files = []
     package_dir = 'folium'
     for parent, dirs, files in os.walk(os.path.join(package_dir, name)):
-        sub_dir = os.sep.join(parent.split(os.sep)[1:]) # remove package_dir from the path
+        # Remove package_dir from the path.
+        sub_dir = os.sep.join(parent.split(os.sep)[1:])
         for f in files:
             data_files.append(os.path.join(sub_dir, f))
     return data_files
 
 pkg_data = {
-'': ['*.js',
-     'plugins/*.js',
-     'templates/*.html',
-     'templates/*.js',
-     'templates/*.txt'] + walk_subpkg('templates/tiles')
+    '': ['*.js',
+         'plugins/*.js',
+         'templates/*.html',
+         'templates/*.js',
+         'templates/*.txt'] + walk_subpkg('templates/tiles')
 }
 
 setup(
     name='folium',
-    version='0.1.3',
+    version=verstr,
     description='Make beautiful maps with Leaflet.js & Python',
     author='Rob Story',
     author_email='wrobstory@gmail.com',
@@ -34,6 +46,8 @@ setup(
     keywords='data visualization',
     classifiers=['Development Status :: 4 - Beta',
                  'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3.3',
+                 'Programming Language :: Python :: 3.4',
                  'License :: OSI Approved :: MIT License'],
     packages=['folium'],
     package_data=pkg_data


### PR DESCRIPTION
This PR makes it possible check the module version via:

``` python
import folium
print9folium.__version)
```

That is important for projects that needs to freeze or check what version is being used.

@birdage Care to review?  That is my last commit before the new release!

PS: It also pep8'd `setup.py` and added python 3 to the classifiers.
