### PR TITLE
Added max and min zoom keywords.

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -56,8 +56,9 @@ class Map(object):
     '''Create a Map with Folium'''
 
     def __init__(self, location=None, width=960, height=500,
-                 tiles='OpenStreetMap', API_key=None, max_zoom=18,
-                 zoom_start=10, attr=None):
+                 tiles='OpenStreetMap', API_key=None, max_zoom=18, min_zoom=1,
+                 zoom_start=10, attr=None, min_lat=-90, max_lat=90,
+                 min_lon=-180, max_lon=180):
         '''Create a Map with Folium and Leaflet.js
 
         Generate a base map of given width and height with either default
@@ -139,10 +140,17 @@ class Map(object):
 
         #Templates
         self.env = ENV
-        self.template_vars = {'lat': location[0], 'lon': location[1],
-                              'size': self._size, 'max_zoom': max_zoom,
-                              'zoom_level': zoom_start,
-                              'map_id': self.map_id}
+        self.template_vars = dict(lat=location[0],
+                                  lon=location[1],
+                                  size=self._size,
+                                  max_zoom=max_zoom,
+                                  zoom_level=zoom_start,
+                                  map_id=self.map_id,
+                                  min_zoom=min_zoom,
+                                  min_lat=min_lat,
+                                  max_lat=max_lat,
+                                  min_lon=min_lon,
+                                  max_lon=max_lon)
 
         #Tiles
         self.tiles = ''.join(tiles.lower().strip().split())

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -58,21 +58,22 @@
 
       var base_tile = L.tileLayer('{{ Tiles }}', {
           maxZoom: {{ max_zoom }},
+          minZoom: {{ min_zoom }},
           attribution: '{{ attr }}'
       });
 
-      var baseLayer = {        
+      var baseLayer = {
         "Base Layer": base_tile
       };
 
       /*
       addition of the wms layers
-      */ 
+      */
 
       {% for wms in wms_layers %}
       {{ wms }}
       {% endfor %}
-      
+
       /*
       addition of the tile layers
       */
@@ -82,7 +83,7 @@
 
       /*
       list of layers to be added
-      */ 
+      */
       var layer_list = {
       {% for data_string in data_layers %}
       {{ data_string }}
@@ -90,11 +91,19 @@
       };
 
       /*
+      Bounding box.
+      */
+      var southWest = L.latLng({{ min_lat }}, {{ min_lon }}),
+          northEast = L.latLng({{ max_lat }}, {{ max_lon }}),
+          bounds = L.latLngBounds(southWest, northEast);
+
+      /*
       Creates the map and adds the selected layers
       */
       var map = L.map('{{ map_id }}', {
                                        center:[{{ lat }}, {{ lon }}],
                                        zoom: {{ zoom_level }},
+                                       maxBounds: bounds,
                                        layers: [base_tile]
                                      });
 

--- a/folium/templates/geojson_template.html
+++ b/folium/templates/geojson_template.html
@@ -74,6 +74,7 @@
 
           L.tileLayer('{{ Tiles }}', {
               maxZoom: {{ max_zoom }},
+              minZoom: {{ min_zoom }},
               attribution: '{{ attr }}'
           }).addTo(map);
 

--- a/folium/templates/ipynb_geojson_repr.html
+++ b/folium/templates/ipynb_geojson_repr.html
@@ -43,6 +43,7 @@
 
           L.tileLayer('{{ Tiles }}', {
               maxZoom: {{ max_zoom }},
+              minZoom: {{ min_zoom }},
               attribution: '{{ attr }}'
           }).addTo(map);
 

--- a/folium/templates/ipynb_repr.html
+++ b/folium/templates/ipynb_repr.html
@@ -17,6 +17,7 @@
 
       L.tileLayer('{{ Tiles }}', {
           maxZoom: {{ max_zoom }},
+          minZoom: {{ min_zoom }},
           attribution: '{{ attr }}'
       }).addTo(map);
 

--- a/tests/folium_tests.py
+++ b/tests/folium_tests.py
@@ -64,9 +64,18 @@ class testFolium(object):
                 'attr': ('Map data (c) <a href="http://openstreetmap.org">'
                          'OpenStreetMap</a> contributors'),
                 'map_id': 'folium_' + '0' * 32,
-                'lat': 45.5236, 'lon': -122.675, 'max_zoom': 20,
+                'lat': 45.5236,
+                'lon': -122.675,
+                'max_zoom': 20,
                 'size': 'style="width: 900px; height: 400px"',
-                'zoom_level': 4, 'tile_layers': [], 'wms_layers': []}
+                'zoom_level': 4,
+                'tile_layers': [],
+                'wms_layers': [],
+                'min_zoom': 1,
+                'min_lat': -90,
+                'max_lat': 90,
+                'min_lon': -180,
+                'max_lon': 180}
 
         assert self.map.template_vars == tmpl
 
@@ -354,7 +363,12 @@ class testFolium(object):
                 'map_id': 'folium_' + '0' * 32,
                 'lat': 45.5236, 'lon': -122.675, 'max_zoom': 20,
                 'size': 'style="width: 900px; height: 400px"',
-                'zoom_level': 4}
+                'zoom_level': 4,
+                'min_zoom': 1,
+                'min_lat': -90,
+                'max_lat': 90,
+                'min_lon': -180,
+                'max_lon': 180}
         HTML = html_templ.render(tmpl)
 
         assert self.map.HTML == HTML


### PR DESCRIPTION
This PR supersedes #53.  It implements adds a keywords for `min_zoom ` to limit the zoom level.

I am not a leaflet expert but I think that to properly solve issue #29 we have to use `map.fitBounds(bounds);`, but it is unclear to me how to proper implement this now.   Maybe another keyqord `bounds=True`? @birdage what do you think?