### PR TITLE
Sets width to auto.

### DIFF
--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -44,7 +44,9 @@
         right:0;
         left:0;
       }
-
+    .leaflet-popup-content {
+        width:auto !important;
+        }
    </style>
 </head>
 


### PR DESCRIPTION
**This PR is not ready to merge!!!**

I just want to start a discussion on how to solve #49.

(Take a look at PR #69 after reading this one.)

In this PR I override the min/max width with the css:
```css
    .leaflet-popup-content {
        width:auto !important;
        }
```

That allows the user to use HTML popup with custom width and height without implementing a "new HTML popup category."  However, that modifications seems to set the simple text width to the [default](http://leafletjs.com/reference.html#popup) `minWidth: 50px`.

The simple texts look awful that way.  User would need to always use HTML and set the width manually.  I am not happy with this solution, but it was the only one I got after reading leaflet docs.