### PR TITLE
Set width

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -269,7 +269,7 @@ class Map(object):
     @iter_obj('simple')
     def simple_marker(self, location=None, popup='Pop Text', popup_on=True,
                       marker_color='blue', marker_icon='info-sign',
-                      clustered_marker=False, icon_angle=0):
+                      clustered_marker=False, icon_angle=0, width=300):
         '''Create a simple stock Leaflet marker on the map, with optional
         popup text or Vincent visualization.
 
@@ -280,6 +280,8 @@ class Map(object):
         popup: string or tuple, default 'Pop Text'
             Input text or visualization for object. Can pass either text,
             or a tuple of the form (Vincent object, 'vis_path.json')
+            It is possible to adjust the width of text/HTML popups
+            using the optional keywords `width`.  (Leaflet default is 300px.)
         popup_on: boolean, default True
             Pass false for no popup information on the marker
         marker_color
@@ -322,8 +324,8 @@ class Map(object):
                                    })
 
         popup_out = self._popup_render(popup=popup, mk_name='marker_',
-                                       count=count,
-                                       popup_on=popup_on)
+                                       count=count, popup_on=popup_on,
+                                       width=width)
 
 
 
@@ -545,7 +547,7 @@ class Map(object):
         self.template_vars.update({'click_pop': click_str})
 
     def _popup_render(self, popup=None, mk_name=None, count=None,
-                      popup_on=True):
+                      popup_on=True, width=300):
         '''Popup renderer: either text or Vincent/Vega.
 
         Parameters
@@ -565,7 +567,8 @@ class Map(object):
             if isinstance(popup, str):
                 popup_temp = self.env.get_template('simple_popup.js')
                 return popup_temp.render({'pop_name': mk_name + str(count),
-                                          'pop_txt': json.dumps(popup)})
+                                          'pop_txt': json.dumps(popup),
+                                          'width': width})
             elif isinstance(popup, tuple):
                 #Update template with JS libs
                 vega_temp = self.env.get_template('vega_ref.txt').render()

--- a/folium/templates/simple_popup.js
+++ b/folium/templates/simple_popup.js
@@ -1,1 +1,2 @@
 {{ pop_name }}.bindPopup({{ pop_txt }});
+      {{ pop_name }}._popup.options.maxWidth = {{ width }};

--- a/tests/folium_tests.py
+++ b/tests/folium_tests.py
@@ -151,7 +151,8 @@ class testFolium(object):
                                     'lon': -122.7,
                                     'icon': "{'icon':marker_1_icon}"})
         popup_1 = popup_templ.render({'pop_name': 'marker_1',
-                                      'pop_txt': json.dumps('Pop Text')})
+                                      'pop_txt': json.dumps('Pop Text'),
+                                      'width': 300})
         assert self.map.template_vars['custom_markers'][0][1] == mark_1
         assert self.map.template_vars['custom_markers'][0][2] == popup_1
 
@@ -161,7 +162,8 @@ class testFolium(object):
                                     'lon': -122.8,
                                     'icon': "{'icon':marker_2_icon}"})
         popup_2 = popup_templ.render({'pop_name': 'marker_2',
-                                      'pop_txt': json.dumps('Hi')})
+                                      'pop_txt': json.dumps('Hi'),
+                                      'width': 300})
         assert self.map.mark_cnt['simple'] == 2
         assert self.map.template_vars['custom_markers'][1][1] == mark_2
         assert self.map.template_vars['custom_markers'][1][2] == popup_2


### PR DESCRIPTION
**This PR is not ready to merge!!!**

I just want to start a discussion on how to solve #49.

(Before reading this go to PR #68 to see an alternative implementation.)

In this I added an extra keyword `width` that allows the user to change leaflet's `maxWidth`.  If `width` is omitted it defaults to 300px ([Leaflet default](http://leafletjs.com/reference.html#popup)).

With this modification I do not break simple text behavior like in #68, but I force the user to jump an extra hoop by defining the width twice.  One in the HTML popup text and another in the keyword.

Maybe there is no escape... we have to implement a HTML popup category.  Something like `HTML=True` and activate a `HTML_popup.js` with the width and height options.  But, for now at least, I prefer this solution because it does not break folium's API and adds quick workaround for #49.

@birdage and @wrobstory Can I pick your brains on this issue?  Any ideas on how to do this in a better way?

[notebook example](https://gist.github.com/ocefpaf/ad8c4e60c65eb0d9b835)