### PR TITLE
Remove non existent css from the MANIFEST.in file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include *.md
 include *.txt
 
 recursive-include folium *.py
-recursive-include folium *.css
 recursive-include folium *.js
 recursive-include folium/plugins *
 recursive-include folium/templates *


### PR DESCRIPTION
Harmless modification to suppress pip warning *.css not found.