### PR TITLE
Set zip_save=False.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(
                  'Programming Language :: Python :: 3.4',
                  'License :: OSI Approved :: MIT License'],
     packages=['folium'],
-    package_data=pkg_data
+    package_data=pkg_data,
+    zip_safe=False
 )


### PR DESCRIPTION
Folium is not zip safe and this causes problems when packaging with setuptools (like https://github.com/ioos/conda-recipes/issues/3). 