### PR TITLE
Using zip_safe=False.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ config = dict(name='folium',
                            'Programming Language :: Python :: 3.4',
                            'License :: OSI Approved :: MIT License'],
               packages=['folium'],
-              package_data=pkg_data)
+              package_data=pkg_data,
+              zip_safe=False)
 
 
 if sys.argv[-1] == 'publish':


### PR DESCRIPTION
Folium is not zip safe and this causes problems when packaging with setuptools (like ioos/conda-recipes#3).