### PR TITLE
Adding fit_bounds to fol template

### DIFF
--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -148,6 +148,8 @@
 
       {{ click_pop }}
 
+      {{ fit_bounds }}
+
    </script>
 
 </body>


### PR DESCRIPTION
I had forgotten to add the fit_bounds template tag from the fol template. This fixes the issue.