### PR TITLE
Add button to enable/disable scrolling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 0.1.5
 ~~~~~
-- `zoom_toggler` option in Map (bibmartin fb2ef74)
+- `zoom_toggler` option in Map (bibmartin 6dac9d7)
 - Popups on lines. (themiurgo)
 - `fit_bounds` method. (themiurgo)
 - GeoJSON popup. (ocefpaf 7aad5e0)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.1.5
 ~~~~~
+- `zoom_toggler` option in Map (bibmartin fb2ef74)
 - Popups on lines. (themiurgo)
 - `fit_bounds` method. (themiurgo)
 - GeoJSON popup. (ocefpaf 7aad5e0)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -61,7 +61,7 @@ class Map(object):
     def __init__(self, location=None, width='100%', height='100%',
                  tiles='OpenStreetMap', API_key=None, max_zoom=18, min_zoom=1,
                  zoom_start=10, attr=None, min_lat=-90, max_lat=90,
-                 min_lon=-180, max_lon=180):
+                 min_lon=-180, max_lon=180, zoom_toggler=False):
         """Create a Map with Folium and Leaflet.js
 
         Generate a base map of given width and height with either default
@@ -98,6 +98,8 @@ class Map(object):
             Initial zoom level for the map.
         attr: string, default None
             Map tile attribution; only required if passing custom tile URL.
+        zoom_toggler: bool, default False
+            Add a button on the map to enable/disable scrolling zoom.
 
         Returns
         -------
@@ -221,6 +223,7 @@ class Map(object):
         self.added_layers = []
         self.template_vars.setdefault('wms_layers', [])
         self.template_vars.setdefault('tile_layers', [])
+        self.template_vars['zoom_toggler'] = zoom_toggler
 
     @iter_obj('simple')
     def add_tile_layer(self, tile_name=None, tile_url=None, active=False):

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -45,12 +45,27 @@
         left:0;
       }
 
+      #toggle_scroll {
+        position:absolute;
+        width:35px;
+        bottom:10px;
+        height:35px;
+        left:10px;
+        background-color:#fff;
+        text-align:center;
+        line-height:35px;
+        vertical-align: middle;
+      }
    </style>
 </head>
 
 <body>
 
    <div class="folium-map" id="{{ map_id }}" {{ size }}></div>
+
+   <img id="toggle_scroll" alt="scroll"
+      src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/1.5.2/png/512/arrow-move.png"
+      onclick="toggleScroll()"></img>
 
    <script>
 
@@ -106,6 +121,29 @@
                                        maxBounds: bounds,
                                        layers: [base_tile]
                                      });
+
+      map.scrollEnabled = true;
+
+      var toggleScroll = function() {
+        if (map.scrollEnabled) {
+            map.scrollEnabled = false;
+            //map.dragging.disable();
+            //map.touchZoom.disable();
+            //map.doubleClickZoom.disable();
+            map.scrollWheelZoom.disable();
+            //if (map.tap) map.tap.disable();
+            }
+        else {
+            map.scrollEnabled = true;
+            //map.dragging.enable();
+            //map.touchZoom.enable();
+            //map.doubleClickZoom.enable();
+            map.scrollWheelZoom.enable();
+            //if (map.tap) map.tap.enable();
+            }
+        };
+
+      toggleScroll();
 
       L.control.layers(baseLayer, layer_list).addTo(map);
 

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -45,6 +45,7 @@
         left:0;
       }
 
+    {% if zoom_toggler %}
       #toggle_scroll {
         position:absolute;
         width:35px;
@@ -56,6 +57,7 @@
         line-height:35px;
         vertical-align: middle;
       }
+    {% endif %}
    </style>
 </head>
 
@@ -63,9 +65,11 @@
 
    <div class="folium-map" id="{{ map_id }}" {{ size }}></div>
 
+    {% if zoom_toggler %}
    <img id="toggle_scroll" alt="scroll"
       src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/1.5.2/png/512/arrow-move.png"
       onclick="toggleScroll()"></img>
+    {% endif %}
 
    <script>
 
@@ -122,6 +126,7 @@
                                        layers: [base_tile]
                                      });
 
+    {% if zoom_toggler %}
       map.scrollEnabled = true;
 
       var toggleScroll = function() {
@@ -144,6 +149,7 @@
         };
 
       toggleScroll();
+    {% endif %}
 
       L.control.layers(baseLayer, layer_list).addTo(map);
 

--- a/tests/folium_tests.py
+++ b/tests/folium_tests.py
@@ -73,7 +73,8 @@ class testFolium(object):
                 'min_lat': -90,
                 'max_lat': 90,
                 'min_lon': -180,
-                'max_lon': 180}
+                'max_lon': 180,
+                'zoom_toggler' : False}
 
         assert self.map.template_vars == tmpl
 


### PR DESCRIPTION
When embedding a leaflet chart in a webpage (in a jupyter notebook, for example), you've got a quite heavy behavior when scrolling your web page : when the charts comes under the mouse cursor, then you zoom into your map instead of scrolling down the page.

I solve this in adding a small button in the bottom left corner, that toggle the scrolling behavior.

![capture du 2015-07-09 18 10 52](https://cloud.githubusercontent.com/assets/4586863/8600405/1a9d6984-2666-11e5-8c07-1e8b924b4c06.png)
