### PR TITLE
Enable Travis' container-based infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 env:
     - CONDA="python=2.7"
     - CONDA="python=3.3"


### PR DESCRIPTION
Since you're using conda, there's pretty much no reason to use `sudo`. This should start and build a little faster.