### PR TITLE
Add support for leaflet div markers to folium

### DIFF
--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -135,6 +135,13 @@
       {{ add_mark }}
       {% endfor %}
 
+      {% for icon, mark, popup, add_mark in div_markers %}
+      {{ icon }}
+      {{ mark }}
+      {{ popup }}
+      {{ add_mark }}
+      {% endfor %}
+
       {% for mark, popup, add_mark in markers %}
       {{ mark }}
       {{ popup }}

--- a/folium/templates/static_div_icon.js
+++ b/folium/templates/static_div_icon.js
@@ -1,0 +1,2 @@
+var {{icon_name}} = L.divIcon({className: 'leaflet-div-icon',
+                              'iconSize': [{{size}},{{size}}]});

--- a/tests/folium_tests.py
+++ b/tests/folium_tests.py
@@ -169,6 +169,44 @@ class testFolium(object):
         nopopup = ''
         assert self.map.template_vars['custom_markers'][2][2] == nopopup
 
+    def test_div_markers(self):
+        '''Test div marker list addition'''
+
+        icon_templ = self.env.get_template('static_div_icon.js')
+        mark_templ = self.env.get_template('simple_marker.js')
+        popup_templ = self.env.get_template('simple_popup.js')
+
+        # Test with popups (expected use case)
+        self.map.div_markers(locations=[[37.421114, -122.128314], [37.391637, -122.085416], [37.388832, -122.087709]], popups=['1437494575531', '1437492135937', '1437493590434'])
+        icon_1 = icon_templ.render({'icon_name': 'div_marker_1_0_icon', 'size': 10})
+        mark_1 = mark_templ.render({'marker': 'div_marker_1_0', 'lat': 37.421114,
+                                    'lon': -122.128314,
+                                    'icon': "{'icon':div_marker_1_0_icon}"})
+        popup_1 = popup_templ.render({'pop_name': 'div_marker_1_0',
+                                      'pop_txt': '"1437494575531"',
+                                      'width': 300})
+        nt.assert_equals(self.map.mark_cnt['div_mark'], 1)
+        nt.assert_equals(self.map.template_vars['div_markers'][0][0], icon_1)
+        nt.assert_equals(self.map.template_vars['div_markers'][0][1], mark_1)
+        nt.assert_equals(self.map.template_vars['div_markers'][0][2], popup_1)
+
+        # Second set of markers with popups to test the numbering
+        self.map.div_markers(locations=[[37.421114, -122.128314], [37.391637, -122.085416], [37.388832, -122.087709]], popups=['1437494575531', '1437492135937', '1437493590434'])
+        icon_2 = icon_templ.render({'icon_name': 'div_marker_2_1_icon', 'size': 10})
+        mark_2 = mark_templ.render({'marker': 'div_marker_2_1', 'lat': 37.391637,
+                                    'lon': -122.085416,
+                                    'icon': "{'icon':div_marker_2_1_icon}"})
+        popup_2 = popup_templ.render({'pop_name': 'div_marker_2_1',
+                                      'pop_txt': '"1437492135937"',
+                                      'width': 300})
+        nt.assert_equals(self.map.mark_cnt['div_mark'], 2)
+        nt.assert_equals(self.map.template_vars['div_markers'][4][0], icon_2)
+        nt.assert_equals(self.map.template_vars['div_markers'][4][1], mark_2)
+        nt.assert_equals(self.map.template_vars['div_markers'][4][2], popup_2)
+
+        # Test no popup. If there are no popups, then we should get a runtimeerror.
+        nt.assert_raises(RuntimeError, self.map.div_markers, [[45.60, -122.8]])
+
     def test_circle_marker(self):
         """Test circle marker additions."""
 


### PR DESCRIPTION
This allows us to generate polylines that display intermediate points with popups. Updated the tests as well. Tests pass.
    
        bash-3.2$ PYTHONPATH=./tests ipython
        Python 2.7.10 |Anaconda 2.0.1 (x86_64)| (default, May 28 2015, 17:04:42)
        Type "copyright", "credits" or "license" for more information.
    
        IPython 2.1.0 -- An enhanced Interactive Python.
        Anaconda is brought to you by Continuum Analytics.
        Please check out: http://continuum.io/thanks and https://binstar.org
        ?         -> Introduction and overview of IPython's features.
        %quickref -> Quick reference.
        help      -> Python's own help system.
        object?   -> Details about 'object', use 'object??' for extra details.
    
        In [1]: import folium_tests
    
        In [2]: tester = folium_tests.testFolium()
    
        In [3]: tester.setup()
    
        In [4]: tester.test_div_markers()