### PR TITLE
add custom css link

### DIFF
--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <head>
    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+   <link rel="stylesheet" href="https://rawgit.com/andrewgiessel/leafletstuff/master/leaflet.css" />
    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 
    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>


### PR DESCRIPTION
This is related to https://github.com/Leaflet/Leaflet/issues/2282.

Basically, there is a directive in the 0.7.3 css that makes image overlays shift and disappear at high zoom levels.  It has been fixed upstream but is present in the stable release of leaflet.

The fix is simple:  https://github.com/Leaflet/Leaflet/issues/2282#issuecomment-30439260

Then we need to host our own version of the css and change the main folium template.  I've done this at https://rawgit.com/andrewgiessel/leafletstuff/master/leaflet.css.  Maybe we want to host this in the main folium repo, but it's a bit chicken/egg until it's in master.