### PR TITLE
Add negative values to legend

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -992,7 +992,8 @@ class Map(object):
             # Create legend.
             name = legend_name or columns[1]
             leg_templ = self.env.get_template('d3_map_legend.js')
-            legend = leg_templ.render({'lin_max': int(domain[-1]*1.1),
+            legend = leg_templ.render({'lin_min': int(domain[0]*1.1),
+                                       'lin_max': int(domain[-1]*1.1),
                                        'tick_labels': tick_labels,
                                        'caption': name})
             self.template_vars.setdefault('map_legends', []).append(legend)

--- a/folium/templates/d3_map_legend.js
+++ b/folium/templates/d3_map_legend.js
@@ -5,7 +5,7 @@
     legend.addTo(map);
 
     var x = d3.scale.linear()
-    .domain([0, {{ lin_max }}])
+    .domain([{{ lin_min }}, {{ lin_max }}])
     .range([0, 400]);
 
     var xAxis = d3.svg.axis()


### PR DESCRIPTION
**This PR is not ready to merge!!**  (This Fixes #184)

If the user provides the tick-marks it will work, but the auto-scale is not.  Here is an example using specifying the legend tickmarks (`threshold_scale`).

```python
import json
import numpy as np
import pandas as pd

state_unemployment = 'data/US_Unemployment_Oct2012.csv'
df = pd.read_csv(state_unemployment)

with open('data/us-states.json') as f:
    states = json.load(f)

geometry, geo_id = [], []
for state in states['features']:
    geometry.append(state['geometry']['coordinates'])
    geo_id.append(state['id'])

states = pd.DataFrame(np.c_[geo_id, geometry], columns=['state', 'geometry'])

threshold_scale = np.linspace(df['Unemployment'].min(),
                              df['Unemployment'].max(),
                              6, dtype=int)
threshold_scale = threshold_scale.tolist()

mapa = folium.Map(location=[48, -102], zoom_start=3)
mapa.geo_json(geo_path='data/us-states.json', data=df,
              columns=['State', 'Unemployment'],
              key_on='feature.id',
              fill_color='YlGn', fill_opacity=0.7, line_opacity=0.2,
              legend_name='Unemployment Rate (%)',
              threshold_scale=threshold_scale)


mapa.create_map("map_manual.html")
```