### PR TITLE
introduce free scale for geo_json

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -986,7 +986,6 @@ class Map(object):
             if threshold_scale and len(threshold_scale) > 6:
                 raise ValueError
             domain = threshold_scale or utilities.split_six(series=series, freescale=freescale)
-            print(domain)
             if len(domain) > 253:
                 raise ValueError('The threshold scale must be length <= 253')
             if not utilities.color_brewer(fill_color):

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -828,7 +828,7 @@ class Map(object):
                  data=None, columns=None, key_on=None, threshold_scale=None,
                  fill_color='blue', fill_opacity=0.6, line_color='black',
                  line_weight=1, line_opacity=1, legend_name=None,
-                 topojson=None, reset=False):
+                 topojson=None, reset=False, freescale=False):
         """Apply a GeoJSON overlay to the map.
 
         Plot a GeoJSON overlay on the base map. There is no requirement
@@ -985,7 +985,8 @@ class Map(object):
             series = data[columns[1]]
             if threshold_scale and len(threshold_scale) > 6:
                 raise ValueError
-            domain = threshold_scale or utilities.split_six(series=series)
+            domain = threshold_scale or utilities.split_six(series=series, freescale=freescale)
+            print(domain)
             if len(domain) > 253:
                 raise ValueError('The threshold scale must be length <= 253')
             if not utilities.color_brewer(fill_color):
@@ -1004,9 +1005,20 @@ class Map(object):
             # Create legend.
             name = legend_name or columns[1]
             leg_templ = self.env.get_template('d3_map_legend.js')
-            legend = leg_templ.render({'lin_max': int(domain[-1]*1.1),
-                                       'tick_labels': tick_labels,
-                                       'caption': name})
+            if freescale==False:
+
+                legend = leg_templ.render({'lin_min': 0,
+                                           'lin_max': int(domain[-1]*1.1),
+                                           'tick_labels': tick_labels,
+                                           'caption': name})
+
+            else:
+
+                legend = leg_templ.render({'lin_min': domain[0],
+                                           'lin_max': domain[-1],
+                                           'tick_labels': tick_labels,
+                                           'caption': name})
+
             self.template_vars.setdefault('map_legends', []).append(legend)
 
             # Style with color brewer colors.

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -895,6 +895,9 @@ class Map(object):
             keyword argument will enable conversion to GeoJSON.
         reset: boolean, default False
             Remove all current geoJSON layers, start with new layer
+        freescale: if True use free format for the scale, where min and max values
+            are taken from the data. It also allow to plot values that do not have 0 
+            minimum and are, for example, float.
 
         Output
         ------

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -986,8 +986,9 @@ class Map(object):
 
             # D3 Color scale.
             series = data[columns[1]]
-            if threshold_scale and len(threshold_scale) > 6:
-                raise ValueError
+            if freescale == False:
+                if threshold_scale and len(threshold_scale) > 6:
+                    raise ValueError
             domain = threshold_scale or utilities.split_six(series=series, freescale=freescale)
             if len(domain) > 253:
                 raise ValueError('The threshold scale must be length <= 253')

--- a/folium/templates/d3_map_legend.js
+++ b/folium/templates/d3_map_legend.js
@@ -5,7 +5,7 @@
     legend.addTo(map);
 
     var x = d3.scale.linear()
-    .domain([0, {{ lin_max }}])
+    .domain([{{ lin_min }}, {{ lin_max }}])
     .range([0, 400]);
 
     var xAxis = d3.svg.axis()

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -286,6 +286,8 @@ def split_six(series=None, freescale=False):
     Parameters
     ----------
     series: Pandas series, default None
+    freescale: If True use simple method to find quantiles from the data
+        in the series.
 
     Returns
     -------

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -277,7 +277,7 @@ def transform_data(data):
     return json_data
 
 
-def split_six(series=None):
+def split_six(series=None, freescale=False):
     """
     Given a Pandas Series, get a domain of values from zero to the 90% quantile
     rounded to the nearest order-of-magnitude integer. For example, 2100 is
@@ -309,7 +309,11 @@ def split_six(series=None):
     quants = [0, 50, 75, 85, 90]
     # Some weirdness in series quantiles a la 0.13.
     arr = series.values
-    return [base(np.percentile(arr, x)) for x in quants]
+    if freescale==False:
+        return [base(np.percentile(arr, x)) for x in quants]
+    else:
+        quants = [0, 25, 50, 75, 85, 90]
+        return [np.percentile(arr, x) for x in quants]
 
 
 def write_png(array):


### PR DESCRIPTION
This PR introduce `freescale` option to the `geo_json` function. It's allow to plot values that do not have 0 minimum and are, for example, float. It do not change default functionality (AFAIU from @ocefpaf a lot of people rely on it for creating choropleth maps), but gives opportunity to people like me to use real values for the plots :)

![small map](https://www.dropbox.com/s/kj6zm8od3rh3u16/freescale1.png?raw=1)