### PR TITLE
Fix Stamen Toner URL to use .png as stated at maps.stamen.com. Update…

### DIFF
--- a/folium/templates/tiles/stamentoner/attr.txt
+++ b/folium/templates/tiles/stamentoner/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.

--- a/folium/templates/tiles/stamentoner/tiles.txt
+++ b/folium/templates/tiles/stamentoner/tiles.txt
@@ -1,1 +1,1 @@
-https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.jpg
+https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png


### PR DESCRIPTION
… different attribution required specifically for Toner as also stated there.