### PR TITLE
Fix python3 issue in Map._repr_html_()

### DIFF
--- a/folium/element.py
+++ b/folium/element.py
@@ -267,7 +267,7 @@ class Figure(Element):
 
         iframe = '<iframe src="{html}" width="{width}px" height="{height}px"></iframe>'\
             .format(\
-                    html = b"data:text/html;base64,"+base64.b64encode(html.encode('utf8')),
+                    html = "data:text/html;base64,"+base64.b64encode(html.encode('utf8')).decode('utf8'),
                     #html = self.HTML.replace('"','&quot;'),
                     width = int(60.*width),
                     height= int(60.*height),


### PR DESCRIPTION
A tiny PR to fix a bug I had not seen when working with python 3 :

When you do

    foo = b'foo'
    "{}".format(foo)

you get `"b'foo'"` instead of `"foo"`. So you have to decode explicitely from bytes to str