### PR TITLE
Bringing folium closer to Leaflet

### DIFF
--- a/examples/Features.ipynb
+++ b/examples/Features.ipynb
@@ -291,10 +291,10 @@
     "pp = features.Popup(\"hello\")\n",
     "ic = features.Icon(color='red')\n",
     "\n",
-    "f.add_children(m)\n",
-    "mk.add_children(ic)\n",
-    "mk.add_children(pp)\n",
-    "m.add_children(mk)\n",
+    "f.add_child(m)\n",
+    "mk.add_child(ic)\n",
+    "mk.add_child(pp)\n",
+    "m.add_child(mk)\n",
     "\n",
     "f"
    ]
@@ -438,9 +438,9 @@
     "mk = features.RegularPolygonMarker([0,0])\n",
     "mk2 = features.RegularPolygonMarker([0,45])\n",
     "\n",
-    "f.add_children(m)\n",
-    "m.add_children(mk)\n",
-    "m.add_children(mk2)\n",
+    "f.add_child(m)\n",
+    "m.add_child(mk)\n",
+    "m.add_child(mk2)\n",
     "\n",
     "f"
    ]
@@ -738,10 +738,10 @@
     "mk = features.Marker([0,0])\n",
     "p = features.Popup(\"Hello\")\n",
     "v = features.Vega(data, width=\"100%\", height=\"100%\")\n",
-    "f.add_children(m)\n",
-    "mk.add_children(p)\n",
-    "p.add_children(v)\n",
-    "m.add_children(mk)\n",
+    "f.add_child(m)\n",
+    "mk.add_child(p)\n",
+    "p.add_child(v)\n",
+    "m.add_child(mk)\n",
     "\n",
     "f"
    ]
@@ -993,7 +993,7 @@
     "\n",
     "f = features.Figure()\n",
     "v = features.Vega(data, height=40, width=600)\n",
-    "f.add_children(v)\n",
+    "f.add_child(v)\n",
     "\n",
     "f"
    ]
@@ -1455,10 +1455,10 @@
     "\n",
     "v2 = features.Vega(data, position='absolute', left=\"0%\", width=\"50%\", height=\"50%\", top='50%')\n",
     "\n",
-    "f.add_children(m)\n",
-    "f.add_children(m2)\n",
-    "f.add_children(v)\n",
-    "f.add_children(v2)\n",
+    "f.add_child(m)\n",
+    "f.add_child(m2)\n",
+    "f.add_child(v)\n",
+    "f.add_child(v2)\n",
     "\n",
     "f"
    ]
@@ -2329,7 +2329,7 @@
     "        ],\n",
     "    }\n",
     "m = features.Map([48.,5.], zoom_start=6)\n",
-    "m.add_children(features.GeoJson(data))\n",
+    "m.add_child(features.GeoJson(data))\n",
     "m"
    ]
   },
@@ -4076,10 +4076,10 @@
     "for i in range(N):\n",
     "    mk = features.Marker([data[i][0],data[i][1]])\n",
     "    p = features.Popup(str(data[i][2]))\n",
-    "    mk.add_children(p)\n",
-    "    mc.add_children(mk)\n",
+    "    mk.add_child(p)\n",
+    "    mc.add_child(mk)\n",
     "\n",
-    "m.add_children(mc)\n",
+    "m.add_child(mc)\n",
     "m"
    ]
   },
@@ -4251,8 +4251,8 @@
     "d1 = f.add_subplot(1,2,1)\n",
     "d2 = f.add_subplot(1,2,2)\n",
     "\n",
-    "d1.add_children(features.Map([0,0], tiles='stamenwatercolor', zoom_start=1))\n",
-    "d2.add_children(features.Map([46,3], tiles='mapquestopen', zoom_start=5))\n",
+    "d1.add_child(features.Map([0,0], tiles='stamenwatercolor', zoom_start=1))\n",
+    "d2.add_child(features.Map([46,3], tiles='mapquestopen', zoom_start=5))\n",
     "\n",
     "f"
    ]
@@ -6092,9 +6092,9 @@
     "m = features.Map([43,-100], zoom_start=4)\n",
     "g = features.GeoJson(geojson_data)\n",
     "\n",
-    "f.add_children(m)\n",
-    "m.add_children(g)\n",
-    "g.add_children(features.GeoJsonStyle([3.0, 7.0, 8.0, 9.0, 9.0], 'YlGn', sd, key_on='feature.id'))\n",
+    "f.add_child(m)\n",
+    "m.add_child(g)\n",
+    "g.add_child(features.GeoJsonStyle([3.0, 7.0, 8.0, 9.0, 9.0], 'YlGn', sd, key_on='feature.id'))\n",
     "\n",
     "f"
    ]

--- a/folium/features.py
+++ b/folium/features.py
@@ -14,7 +14,6 @@ from .utilities import (color_brewer, _parse_size, legend_scaler,
 from .element import Element, Figure, JavascriptLink, CssLink, MacroElement
 from .map import TileLayer, Icon
 
-
 class WmsTileLayer(TileLayer):
     def __init__(self, url, name=None,
                  format=None, layers=None, transparent=True,


### PR DESCRIPTION
A one-line change to put features in the main namespace and bring folium closer to Leaflet. No need to import folium.features.

```Python
import folium

mymap = folium.Map()
folium.Marker.add_to(my_map)
```