### PR TITLE
Make features accessible from root

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -3,4 +3,10 @@ from __future__ import absolute_import
 
 __version__ = '0.2.0.dev'
 
-from folium.folium import Map, initialize_notebook
+from folium.folium import Map, initialize_notebook, CircleMarker
+
+from folium.map import FeatureGroup, FitBounds,Icon, LayerControl, Marker, Popup, TileLayer
+
+from folium.features import (ClickForMarker, ColorScale, CustomIcon, DivIcon, GeoJson, GeoJsonStyle,
+    ImageOverlay, LatLngPopup, MarkerCluster, MultiPolyLine, PolyLine,
+    RegularPolygonMarker, TopoJson, Vega, WmsTileLayer)


### PR DESCRIPTION
This temporarily makes every feature accessible from the root namespace to solve #257 . We can later remove features that are less used if we prefer, or keep it like this.