### PR TITLE
Fix WMS only layer bug

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -18,7 +18,7 @@ from .map import TileLayer, Icon
 class WmsTileLayer(TileLayer):
     def __init__(self, url, name=None,
                  format=None, layers=None, transparent=True,
-                 attr=None):
+                 attr=None, overlay=True):
         """
         TODO docstring here
 
@@ -29,6 +29,7 @@ class WmsTileLayer(TileLayer):
         self.url = url
         self.format = format
         self.layers = layers
+        self.overlay = overlay
         self.transparent = transparent
         self.attr = attr
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -289,11 +289,11 @@ class LayerControl(MacroElement):
         self.base_layers = OrderedDict(
             [(val.tile_name, val.get_name()) for key, val in
              self._parent._children.items() if
-             isinstance(val, TileLayer) and not val.overlay])
+             isinstance(val, TileLayer) and not hasattr(val, 'overlay')])
         self.overlays = OrderedDict(
             [(val.tile_name, val.get_name()) for key, val in
              self._parent._children.items() if
-             isinstance(val, TileLayer) and val.overlay])
+             isinstance(val, TileLayer) and hasattr(val, 'overlay')])
 
         super(LayerControl, self).render()
 


### PR DESCRIPTION
I guess that the `overlay` property is not always present.

@BibMartin tiny one to relax after the #266 rebase :stuck_out_tongue_winking_eye: 

PS: The `LayerControl` seems to be swamping `base_layers` and `overlays`.  I will take a look into that.