### PR TITLE
Fix image_overlay bug

### DIFF
--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -488,7 +488,8 @@ def write_png(data, origin='upper', colormap=None):
 
     # Normalize to uint8 if it isn't already.
     if array.dtype != 'uint8':
-        array *= 255/array.max(axis=(0, 1)).reshape((1, 1, 4)).astype('uint8')
+        array = array * 255./array.max(axis=(0, 1)).reshape((1, 1, 4))
+        array = array.astype('uint8')
 
     # Eventually flip the image.
     if origin == 'lower':


### PR DESCRIPTION
Fix another bug introduced by my awesome pep3'ing skills.

@BibMartin there is another bug with the `mercator_transform` that I could not figure out.  See cell [5]:

http://nbviewer.ipython.org/gist/ocefpaf/2c35a679f333c57ecd1d