### PR TITLE
Add possibility to have unembedded GeoJSON.

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -228,10 +228,10 @@ class GeoJson(MacroElement):
         """
         super(GeoJson, self).__init__()
         self._name = 'GeoJson'
-        if 'read' in dir(data):
+        if hasattr(data,'read'):
             self.embed = True
             self.data = json.load(data)
-        elif type(data) is dict:
+        elif isinstance(data,dict):
             self.embed = True
             self.data = data
         elif isinstance(data, text_type) or isinstance(data, binary_type):


### PR DESCRIPTION
Addresses #285.
Instead of having an `embed` option as @ocefpaf suggested, the user shall pass `data=open(filename)` if he wants to have the file embedded, and `data=filename` otherwise.

Note that the `style_function` cannot be applyed in the latter case, because the file won't be openned.
