### PR TITLE
iter_points list/tuple

### DIFF
--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -449,9 +449,9 @@ def iter_points(x):
     """Iterates over a list representing a feature, and returns a list of points,
     whatever the shape of the array (Point, MultiPolyline, etc).
     """
-    if isinstance(x, list):
+    if isinstance(x, (list, tuple)):
         if len(x):
-            if isinstance(x[0], list):
+            if isinstance(x[0], (list, tuple)):
                 out = []
                 for y in x:
                     out += iter_points(y)
@@ -461,4 +461,4 @@ def iter_points(x):
         else:
             return []
     else:
-        raise ValueError('List type expected. Got {!r}.'.format(x))
+        raise ValueError('List/tuple type expected. Got {!r}.'.format(x))


### PR DESCRIPTION
@Bibmartin I missed this when review PR #305.

Some GeoJSON, like those created with the `__geo__interface__`, will be `tuple`s instead of `list`s.