### PR TITLE
Bugfix in template/tiles/openstreetmap/attr.txt

### DIFF
--- a/folium/templates/tiles/openstreetmap/attr.txt
+++ b/folium/templates/tiles/openstreetmap/attr.txt
@@ -1,2 +1,1 @@
-Data by <a href="http://openstreetmap.org">OpenStreetMap</a>,
-under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.
+Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -514,7 +514,7 @@ class TestFolium(object):
             {'id': 'tile_layer_'+'0'*32,
              'address': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
              'attr': ('Data by <a href="http://openstreetmap.org">OpenStreetMap'
-                      '</a>,\nunder '
+                      '</a>,under '
                       '<a href="http://www.openstreetmap.org/copyright">ODbL'
                       '</a>.'),
              'max_zoom': 20,


### PR DESCRIPTION
I did a mistake in #310 : attribution cannot be split over 2 lines: it breaks everything in the Javascript (at least with Opera).

@ocefpaf Can you merge this one first, please ?