### PR TITLE
Fix colormap import error in python2

### DIFF
--- a/folium/colormap.py
+++ b/folium/colormap.py
@@ -6,6 +6,8 @@ Colormap
 Utility module for dealing with colormaps.
 
 """
+from __future__ import absolute_import
+
 import math
 from jinja2 import Template
 from folium.six import text_type, binary_type
@@ -365,7 +367,7 @@ class LinearColormap(ColorMap):
         if index is None:
             self.index = [vmin + (vmax-vmin)*i*1./(n-1) for i in range(n)]
         else:
-            self.index = list(index).copy()
+            self.index = [x for x in index]
         self.colors = [_parse_color(x) for x in colors]
 
     def rgba_floats_tuple(self, x):
@@ -525,7 +527,7 @@ class StepColormap(ColorMap):
         if index is None:
             self.index = [vmin + (vmax-vmin)*i*1./n for i in range(n+1)]
         else:
-            self.index = list(index).copy()
+            self.index = [x for x in index]
         self.colors = [_parse_color(x) for x in colors]
 
     def rgba_floats_tuple(self, x):


### PR DESCRIPTION
When trying to play with colormap in python2 ; I got bad surprises.

This is to fix this.

BTW ; this shows that we need tests for colormap. I'll add them in this PR soon.