### PR TITLE
Put explicit links to nbviewer/v0.2.0

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,7 +3,7 @@ Examples
 
 You shall take a look at folium's example gallery_.
 
-.. _gallery: http://nbviewer.jupyter.org/github/python-visualization/folium/tree/master/examples/
+.. _gallery: http://nbviewer.jupyter.org/github/python-visualization/folium/tree/v0.2.0/examples/
 
 If this is not enough, you may find fancier examples here_.
 

--- a/examples/Quickstart.ipynb
+++ b/examples/Quickstart.ipynb
@@ -482,7 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information about popups, please visit [Popups.ipynb](http://nbviewer.jupyter.org/github/python-visualization/folium/blob/master/examples/Popups.ipynb)"
+    "For more information about popups, please visit [Popups.ipynb](http://nbviewer.jupyter.org/github/python-visualization/folium/blob/v0.2.0/examples/Popups.ipynb)"
    ]
   },
   {
@@ -687,7 +687,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more choropleth example, please visit [GeoJSON and choropleth.ipynb](http://nbviewer.jupyter.org/github/python-visualization/folium/blob/master/examples/GeoJSON and choropleth.ipynb)"
+    "For more choropleth example, please visit [GeoJSON and choropleth.ipynb](http://nbviewer.jupyter.org/github/python-visualization/folium/blob/v0.2.0/examples/GeoJSON and choropleth.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
When linking from readthedocs to nbviewer, we arrive on the master version of notebooks (with branca in the code).
This changes the docs **for branch v0.2.0 only** for targetting the proper notebooks in nbviewer.

@ocefpaf Shall we open an issue to automate these chages at each version change ?
