### PR TITLE
HeatMap should pass "name" to super

### DIFF
--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -41,7 +41,7 @@ class HeatMap(TileLayer):
         gradient : dict, default None
             Color gradient config. e.g. {0.4: 'blue', 0.65: 'lime', 1: 'red'}
         """
-        super(TileLayer, self).__init__()
+        super(TileLayer, self).__init__(name=name)
         self._name = 'HeatMap'
         self.tile_name = name if name is not None else self.get_name()
 


### PR DESCRIPTION
HeatMap wasn't passing the name argument, so the label for a heatmap in the LayerControl was defaulting to a uuid-based name.

Also, I "fixed" some dependency issues I ran into so that I could build & test folium:
* `No matching distribution found for krb5 (from -r requirements-dev.txt (line 6))`
* `ImportError: No module named 'branca'`