### PR TITLE
#382: TopoJson.get_bounds() returns [lon,lat] instead of [lat,lon]

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -507,12 +507,12 @@ class TopoJson(Layer):
                 ymax = none_max(y, ymax)
         return [
             [
-                self.data['transform']['translate'][0] + self.data['transform']['scale'][0] * xmin,  # noqa
                 self.data['transform']['translate'][1] + self.data['transform']['scale'][1] * ymin,  # noqa
+                self.data['transform']['translate'][0] + self.data['transform']['scale'][0] * xmin  # noqa
             ],
             [
-                self.data['transform']['translate'][0] + self.data['transform']['scale'][0] * xmax,  # noqa
                 self.data['transform']['translate'][1] + self.data['transform']['scale'][1] * ymax,  # noqa
+                self.data['transform']['translate'][0] + self.data['transform']['scale'][0] * xmax  # noqa
             ]
 
         ]

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -453,7 +453,7 @@ class TestFolium(object):
                           [71.285909, -66.979601]], bounds
 
     def test_topo_json(self):
-        """Test geojson method."""
+        """Test topojson method."""
 
         self.map = folium.Map([43, -100], zoom_start=4)
 
@@ -470,8 +470,8 @@ class TestFolium(object):
         assert ''.join(topojson_str.split())[:-1] in ''.join(out.split())
 
         bounds = self.map.get_bounds()
-        assert bounds == [[-124.56617536999985, 41.99187135900012],
-                          [-116.46422312599977, 46.28768217800006]], bounds
+        assert bounds == [[41.99187135900012, -124.56617536999985],
+                          [46.28768217800006, -116.46422312599977]], bounds
 
     def test_map_build(self):
         """Test map build."""


### PR DESCRIPTION
Fixes #382