### PR TITLE
Add branca imports in __init__

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -2,11 +2,14 @@
 
 from __future__ import absolute_import
 
-from folium.folium import Map, initialize_notebook, CircleMarker
+from branca.element import (CssLink, Div, Element, Figure, Html, IFrame,
+                            JavascriptLink, Link, MacroElement)
+from branca.colormap import (ColorMap, LinearColormap, StepColormap)
 
+
+from folium.folium import Map, initialize_notebook, CircleMarker
 from folium.map import (FeatureGroup, FitBounds, Icon, LayerControl, Marker,
                         Popup, TileLayer)
-
 from folium.features import (ClickForMarker, CustomIcon, DivIcon,
                              GeoJson, LatLngPopup,
                              MarkerCluster, MultiPolyLine, PolyLine, Vega,
@@ -14,7 +17,19 @@ from folium.features import (ClickForMarker, CustomIcon, DivIcon,
 
 __version__ = '0.3.0.dev'
 
-__all__ = ['Map',
+__all__ = ['CssLink',
+           'Div',
+           'Element',
+           'Figure',
+           'Html',
+           'IFrame',
+           'JavascriptLink',
+           'Link',
+           'MacroElement',
+           'ColorMap',
+           'LinearColormap',
+           'StepColormap',
+           'Map',
            'initialize_notebook',
            'CircleMarker',
            'FeatureGroup',

--- a/pep8_test.sh
+++ b/pep8_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find . -type f -name "*.py" ! -name 'conf.py' | xargs flake8 --max-line-length=100


### PR DESCRIPTION
For most users (me at least), it's simpler if we can use folium without explicitely importing branca.
For that, this PR imports most useful branca objects in folium's `__init__` so that one can (for instance) use `folium.Figure` instead of `branca.element.Figure`