### PR TITLE
Allow non-standard params on WmsTileLayer

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -53,7 +53,7 @@ class WmsTileLayer(Layer):
     """
     def __init__(self, url, name=None, layers=None, styles=None, format=None,
                  transparent=True, version='1.1.1', attr=None, overlay=True,
-                 control=True):
+                 control=True, **kwargs):
         super(WmsTileLayer, self).__init__(overlay=overlay, control=control, name=name)  # noqa
         self.url = url
         self.attribution = attr if attr is not None else ''
@@ -63,6 +63,9 @@ class WmsTileLayer(Layer):
         self.format = format if format else 'image/jpeg'
         self.transparent = transparent
         self.version = version
+        self.extra_params = []
+        for name, value in kwargs.items():
+            self.extra_params.append((name, value))
         # FIXME: Should be map CRS!
         # self.crs = crs if crs else 'null
         self._template = Template(u"""
@@ -74,8 +77,9 @@ class WmsTileLayer(Layer):
                     styles: '{{ this.styles }}',
                     format: '{{ this.format }}',
                     transparent: {{ this.transparent.__str__().lower() }},
-                    version: '{{ this.version }}',
-                    {% if this.attribution %} attribution: '{{this.attribution}}'{% endif %}
+                    version: '{{ this.version }}'
+                    {% if this.attribution %}, attribution: '{{this.attribution}}'{% endif %}
+                    {% for param in this.extra_params %}, {{param.0}}: '{{param.1}}'{% endfor %}
                     }
                 ).addTo({{this._parent.get_name()}});
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -133,3 +133,21 @@ def test_color_line():
         opacity=1)
     m.add_child(color_line)
     m._repr_html_()
+
+
+# WmsTileLayer. Non-standard params
+def test_non_standard_params_wms_service():
+    m = Map([40, -100], zoom_start=4)
+    url = 'http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi'
+    w = features.WmsTileLayer(url,
+                              name='test',
+                              format='image/png',
+                              layers='nexrad-n0r-900913',
+                              attr=u"Weather data © 2012 IEM Nexrad",
+                              colorscalerange='auto',
+                              transparent=True)
+    w.add_to(m)
+    m._repr_html_()
+
+    bounds = m.get_bounds()
+    assert bounds == [[None, None], [None, None]], bounds


### PR DESCRIPTION
I've tried to add a WMS layer with some non-standard params, but it failed because `WmsTileLayer` got an unexpected keyword argument.

I propose to pass any other kwarg as an option of the WMS layer that is created by folium.
