### PR TITLE
Removing `.cdn` from rawgit URLs

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -51,7 +51,7 @@ _default_css = [
     ("marker_cluster_css",
      "https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css"),  # noqa
     ("awesome_rotate_css",
-     "https://cdn.rawgit.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css"),  # noqa
+     "https://rawgit.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css"),  # noqa
     ]
 
 

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -143,11 +143,11 @@ class TimestampedGeoJson(MacroElement):
             name='jqueryui1.10.2')
 
         figure.header.add_child(
-            JavascriptLink("https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"),  # noqa
+            JavascriptLink("https://rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"),  # noqa
             name='iso8601')
 
         figure.header.add_child(
-            JavascriptLink("https://cdn.rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"),  # noqa
+            JavascriptLink("https://rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"),  # noqa
             name='leaflet.timedimension')
 
         figure.header.add_child(

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -16,7 +16,7 @@
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"/>
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css"/>
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css"/>
-   <link rel="stylesheet" href="https://cdn.rawgit.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css"/>
+   <link rel="stylesheet" href="https://rawgit.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css"/>
 
    <style>
 

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -96,10 +96,10 @@ def test_timestamped_geo_json():
     assert ('<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/'
             '1.10.2/jquery-ui.min.js"></script>'
             ) in out
-    assert ('<script src="https://cdn.rawgit.com/nezasa/'
+    assert ('<script src="https://rawgit.com/nezasa/'
             'iso8601-js-period/master/iso8601.min.js"></script>'
             ) in out
-    assert ('<script src="https://cdn.rawgit.com/socib/Leaflet.'
+    assert ('<script src="https://rawgit.com/socib/Leaflet.'
             'TimeDimension/master/dist/leaflet.timedimension.min.js">'
             '</script>'
             ) in out


### PR DESCRIPTION
This avoids future bugs caused by #440.