### PR TITLE
Fix typo in style_function

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -673,7 +673,7 @@ class Map(LegacyMap):
         def style_function(x):
             return {
                 "weight": line_weight,
-                "opactiy": line_opacity,
+                "opacity": line_opacity,
                 "color": line_color,
                 "fillOpacity": fill_opacity,
                 "fillColor": color_scale_fun(x)


### PR DESCRIPTION
This typo renders the `line_opacity` attribute of `Map.choropleth` useless. The error is propagated to the generated JavaScript, where Leaflet ignores it.

This one line fix corrects the error. Consider the attached screenshots for a demonstration of the fix applied to US Unemployment example.

### Prior to Fix:
![us_states](https://cloud.githubusercontent.com/assets/4552310/17770285/0d3c0cac-653d-11e6-85d2-1c6c66f4680e.png)

### After Fix:
![us_states_fix](https://cloud.githubusercontent.com/assets/4552310/17770320/2bcc1d88-653d-11e6-9334-c2233c8c2715.png)
