### PR TITLE
Switch to non-minified leaflet.awesome-markers

### DIFF
--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -5,7 +5,7 @@
    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-   <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster-src.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
 


### PR DESCRIPTION
Fixes #505

The minified version of leaflet.awesome-markers has a problem with
correctly passing the extraClasses option to the <i> tags 'class'
attribute, causing the fa-rotate-* classes not to be applied correctly.

As a workaround, switch to using the non-minified version of
leaflet.awesome-markers that works correctly.