### PR TITLE
Add class definition

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -712,18 +712,19 @@ class Circle(Marker):
         The fill opacity of the marker, between 0. and 1.
     popup: string or folium.Popup, default None
         Input text or visualization for object.
+    class_name: string, default is an empty string
+        Class name to associate with the circle, known as ClassName in the leaflet spec
 
     """
     def __init__(self, location, radius=500, color='black',
-                 fill_color='black', fill_opacity=0.6, popup=None, class_name=None):
+                 fill_color='black', fill_opacity=0.6, popup=None, class_name=''):
         super(Circle, self).__init__(location, popup=popup)
         self._name = 'Circle'
         self.radius = radius
         self.color = color
         self.fill_color = fill_color
-        self.fill_opacity = fill_opacity
-        if class_name is not None:
-            self.class_name = class_name
+        self.fill_opacity = fill_opacity        
+        self.class_name = class_name
 
         self._template = Template(u"""
             {% macro script(this, kwargs) %}

--- a/folium/features.py
+++ b/folium/features.py
@@ -732,7 +732,7 @@ class Circle(Marker):
                 [{{this.location[0]}},{{this.location[1]}}],
                 {{ this.radius }},
                 {
-                    className: '{{this.class_name}}'
+                    className: '{{this.class_name}}',
                     color: '{{ this.color }}',
                     fillColor: '{{ this.fill_color }}',
                     fillOpacity: {{ this.fill_opacity }}

--- a/folium/features.py
+++ b/folium/features.py
@@ -723,7 +723,7 @@ class Circle(Marker):
         self.fill_color = fill_color
         self.fill_opacity = fill_opacity
         if class_name is not None:
-            self.class_name = class
+            self.class_name = class_name
 
         self._template = Template(u"""
             {% macro script(this, kwargs) %}

--- a/folium/features.py
+++ b/folium/features.py
@@ -715,13 +715,15 @@ class Circle(Marker):
 
     """
     def __init__(self, location, radius=500, color='black',
-                 fill_color='black', fill_opacity=0.6, popup=None):
+                 fill_color='black', fill_opacity=0.6, popup=None, class_name=None):
         super(Circle, self).__init__(location, popup=popup)
         self._name = 'Circle'
         self.radius = radius
         self.color = color
         self.fill_color = fill_color
         self.fill_opacity = fill_opacity
+        if class_name is not None:
+            self.class_name = class
 
         self._template = Template(u"""
             {% macro script(this, kwargs) %}
@@ -730,6 +732,7 @@ class Circle(Marker):
                 [{{this.location[0]}},{{this.location[1]}}],
                 {{ this.radius }},
                 {
+                    className: '{{this.class_name}}'
                     color: '{{ this.color }}',
                     fillColor: '{{ this.fill_color }}',
                     fillOpacity: {{ this.fill_opacity }}


### PR DESCRIPTION
@ocefpaf what do you think about adding a class definition to the markers. ive put an example of the proposed changes below for just the `circle`. Wed have to figure where to put the css, maybe `folium/templates/user_defined.css`? i can squash the multiple changes if we want to go down this path.

i.e we have a circle marker but we want to leverage css styling a bit more, this would aid in the following issue https://github.com/python-visualization/folium/issues/524

> leaflet js example
> 
> ``` js
>     L.circle([51.509, -0.11], 1500, {
>         className:" sample-circle",
>         color: 'red',
>         fillColor: '#f03',
>         fillOpacity: 0.5
>     }).addTo(mymap).bindPopup("I am a circle.");
> ```
> 
> css style
> 
> ``` css
> .sample-circle:hover{
>     stroke: blue;
> }
> ```
> 
> normal circle
> ![screen shot 2016-10-30 at 8 15 13 pm](https://cloud.githubusercontent.com/assets/547228/19841215/d965a174-9edd-11e6-83c5-89eede1f0e17.png)
> 
> on hover
> ![screen shot 2016-10-30 at 8 15 16 pm](https://cloud.githubusercontent.com/assets/547228/19841216/d9662522-9edd-11e6-9ce0-ed644c08e38b.png)
