### PR TITLE
Added ability to use remote geo_path

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,7 @@
 - Added `smooth_factor `option to `GeoJSON`, `TopoJSON` and `Choropleth` (JamesGardiner #428)
 - `Map` object now accepts Leaflet global switches (sgvandijk #424)
 - Added weight option to CircleMarker (palewire #581)
-- Added requests support to enable http(s) and ftp for geo_path parameter
+- Added requests support to enable http(s) and ftp for geo_path parameter (jreades #602)
 
 Bug Fixes
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@
 - Added `smooth_factor `option to `GeoJSON`, `TopoJSON` and `Choropleth` (JamesGardiner #428)
 - `Map` object now accepts Leaflet global switches (sgvandijk #424)
 - Added weight option to CircleMarker (palewire #581)
+- Added requests support to enable http(s) and ftp for geo_path parameter
 
 Bug Fixes
 

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -252,7 +252,6 @@ class Map(LegacyMap):
 
         # Create GeoJson object
         if geo_path:
-            print("Using new folium")
             if geo_path.lower().startswith(('http','ftp','https')): 
                 geo_data = requests.get(geo_path).json()
             else: 

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -252,7 +252,7 @@ class Map(LegacyMap):
 
         # Create GeoJson object
         if geo_path:
-            if geo_path.lower().startswith(('http:', 'ftp':, 'https:')):
+            if geo_path.lower().startswith(('http:', 'ftp:', 'https:')):
                 geo_data = requests.get(geo_path).json()
             else:
                 geo_data = open(geo_path)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -15,6 +15,7 @@ from branca.utilities import color_brewer
 from .map import LegacyMap, FitBounds
 from .features import GeoJson, TopoJson
 
+import requests
 
 class Map(LegacyMap):
     """Create a Map with Folium and Leaflet.js
@@ -251,7 +252,11 @@ class Map(LegacyMap):
 
         # Create GeoJson object
         if geo_path:
-            geo_data = open(geo_path)
+            print("Using new folium")
+            if geo_path.lower().startswith(('http','ftp','https')): 
+                geo_data = requests.get(geo_path).json()
+            else: 
+                geo_data = open(geo_path)
         elif geo_str:
             geo_data = geo_str
         else:

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -252,9 +252,9 @@ class Map(LegacyMap):
 
         # Create GeoJson object
         if geo_path:
-            if geo_path.lower().startswith(('http','ftp','https')): 
+            if geo_path.lower().startswith(('http', 'ftp', 'https')):
                 geo_data = requests.get(geo_path).json()
-            else: 
+            else:
                 geo_data = open(geo_path)
         elif geo_str:
             geo_data = geo_str

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -252,7 +252,7 @@ class Map(LegacyMap):
 
         # Create GeoJson object
         if geo_path:
-            if geo_path.lower().startswith(('http', 'ftp', 'https')):
+            if geo_path.lower().startswith(('http:', 'ftp':, 'https:')):
                 geo_data = requests.get(geo_path).json()
             else:
                 geo_data = open(geo_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2
 branca
 six
+requests

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -29,9 +29,9 @@ rootpath = os.path.abspath(os.path.dirname(__file__))
 
 # For testing remote requests
 remote_url = '/'.join([
-	'https://raw.githubusercontent.com',
-	'python-visualization/folium/master',
-	'examples/data/us-states.json'])
+    'https://raw.githubusercontent.com',
+    'python-visualization/folium/master',
+    'examples/data/us-states.json'])
 
 def setup_data():
     """Import economic data for testing."""

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -21,6 +21,8 @@ from jinja2 import Environment, PackageLoader
 from six import PY3
 import branca.element
 
+import requests
+
 import folium
 from folium.map import Popup, Marker, FitBounds, FeatureGroup
 from folium.features import TopoJson, RectangleMarker, PolygonMarker
@@ -448,3 +450,16 @@ class TestFolium(object):
         assert (mapd.global_switches.prefer_canvas is True and
                 mapd.global_switches.no_touch is True and
                 mapd.global_switches.disable_3d is True)
+
+    def test_json_request(self):
+        """Test requests for remote GeoJSON files."""
+        self.map = folium.Map(zoom_start=4)
+
+        # Adding remote GeoJSON as additional layer.
+        path = 'https://raw.githubusercontent.com/python-visualization/folium/master/examples/data/us-states.json'
+        self.map.choropleth(geo_path=path,
+                            smooth_factor=0.5)
+
+        self.map._parent.render()
+        bounds = self.map.get_bounds()
+        assert bounds == [[18.948267, -178.123152], [71.351633, 173.304726]], bounds

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -21,14 +21,17 @@ from jinja2 import Environment, PackageLoader
 from six import PY3
 import branca.element
 
-import requests
-
 import folium
 from folium.map import Popup, Marker, FitBounds, FeatureGroup
 from folium.features import TopoJson, RectangleMarker, PolygonMarker
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
+# For testing remote requests
+remote_url = '/'.join([
+	'https://raw.githubusercontent.com',
+	'python-visualization/folium/master',
+	'examples/data/us-states.json'])
 
 def setup_data():
     """Import economic data for testing."""
@@ -456,8 +459,7 @@ class TestFolium(object):
         self.map = folium.Map(zoom_start=4)
 
         # Adding remote GeoJSON as additional layer.
-        path = 'https://raw.githubusercontent.com/python-visualization/folium/master/examples/data/us-states.json'
-        self.map.choropleth(geo_path=path,
+        self.map.choropleth(geo_path=remote_url,
                             smooth_factor=0.5)
 
         self.map._parent.render()


### PR DESCRIPTION
Adds a dependency (requests) but enables ability to use http/https/ftp for loading geo_paths.

I'm _really_ rusty on unit tests (last did them in Java 1.2 or thereabouts) so I've not attempted to implement these. This is the first time I've done this, so please review carefully before accepting the PR.