### PR TITLE
Update doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,5 @@ script:
     - if [[ $TEST_TARGET == 'notebooks' ]]; then
         for file in $(find . -type f -name "*.ipynb"); do jupyter nbconvert --template=tests/strip_markdown.tpl --stdout --to python $file | grep -v '^get_ipython' | flake8 - --ignore=W391,E226,E402 --max-line-length=100 --show-source ; done ;
         py.test -vv tests/notebooks/test_notebooks.py ;
-        doctr deploy --built-docs=examples/results --gh-pages-docs=gallery ;
+        doctr deploy --built-docs=examples/results gallery ;
       fi


### PR DESCRIPTION
The `--gh-pages-docs` flag is deprecated and the deploy directory is now a required argument.