### PR TITLE
Fix highlight_function breaking popup in GeoJson

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -365,6 +365,7 @@ class GeoJson(Layer):
                         mouseover: function(e) {
                             e.target.setStyle(e.target.feature.properties.highlight);},
                         click: function(e) {
+                            layer.openPopup();
                             {{this._parent.get_name()}}.fitBounds(e.target.getBounds());}
                         });
                 };


### PR DESCRIPTION
Current behavior:
`GeoJson(highlight_function=None).add_child(folium.Popup('some popup'))` => click on shape, popup opens
`GeoJson(highlight_function=lambda x: {'weight': 5}).add_child(folium.Popup('some popup'))` => hover on shape, line weight changes (as expected); click on shape, no popup

Highlight function overrides the on click behavior - this PR adds it back. Not sure if this is the best way to do it though...