### PR TITLE
Add subdomains option for TileLayer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.4.0
+~~~~~
+- Added support for subdomains options in TileLayer (damselem #623)
+
 0.3.0
 ~~~~~
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -152,7 +152,8 @@ class LegacyMap(MacroElement):
                  no_wrap=False, attr=None, min_lat=-90, max_lat=90,
                  min_lon=-180, max_lon=180, max_bounds=True,
                  detect_retina=False, crs='EPSG3857', control_scale=False,
-                 prefer_canvas=False, no_touch=False, disable_3d=False):
+                 prefer_canvas=False, no_touch=False, disable_3d=False,
+                 subdomains='abc'):
         super(LegacyMap, self).__init__()
         self._name = 'Map'
         self._env = ENV
@@ -192,7 +193,8 @@ class LegacyMap(MacroElement):
             self.add_tile_layer(
                 tiles=tiles, min_zoom=min_zoom, max_zoom=max_zoom,
                 continuous_world=continuous_world, no_wrap=no_wrap, attr=attr,
-                API_key=API_key, detect_retina=detect_retina
+                API_key=API_key, detect_retina=detect_retina,
+                subdomains=subdomains
             )
 
         self._template = Template(u"""
@@ -247,7 +249,8 @@ class LegacyMap(MacroElement):
     def add_tile_layer(self, tiles='OpenStreetMap', name=None,
                        API_key=None, max_zoom=18, min_zoom=1,
                        continuous_world=False, attr=None, active=False,
-                       detect_retina=False, no_wrap=False, **kwargs):
+                       detect_retina=False, no_wrap=False, subdomains='abc',
+                       **kwargs):
         """
         Add a tile layer to the map. See TileLayer for options.
 
@@ -257,6 +260,7 @@ class LegacyMap(MacroElement):
                                attr=attr, API_key=API_key,
                                detect_retina=detect_retina,
                                continuous_world=continuous_world,
+                               subdomains=subdomains,
                                no_wrap=no_wrap)
         self.add_child(tile_layer, name=tile_layer.tile_name)
 
@@ -374,11 +378,13 @@ class TileLayer(Layer):
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.
+    subdomains: string, default 'abc'
+        Subdomains of the tile service.
     """
     def __init__(self, tiles='OpenStreetMap', min_zoom=1, max_zoom=18,
                  attr=None, API_key=None, detect_retina=False,
                  continuous_world=False, name=None, overlay=False,
-                 control=True, no_wrap=False):
+                 control=True, no_wrap=False, subdomains='abc'):
         self.tile_name = (name if name is not None else
                           ''.join(tiles.lower().strip().split()))
         super(TileLayer, self).__init__(name=self.tile_name, overlay=overlay,
@@ -390,6 +396,7 @@ class TileLayer(Layer):
         self.max_zoom = max_zoom
         self.no_wrap = no_wrap
         self.continuous_world = continuous_world
+        self.subdomains = subdomains
 
         self.detect_retina = detect_retina
 
@@ -424,7 +431,8 @@ class TileLayer(Layer):
                     continuousWorld: {{this.continuous_world.__str__().lower()}},
                     noWrap: {{this.no_wrap.__str__().lower()}},
                     attribution: '{{this.attr}}',
-                    detectRetina: {{this.detect_retina.__str__().lower()}}
+                    detectRetina: {{this.detect_retina.__str__().lower()}},
+                    subdomains: '{{this.subdomains}}'
                     }
                 ).addTo({{this._parent.get_name()}});
 

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -79,7 +79,8 @@
                 continuousWorld: {{tile['continuous_world'].__str__().lower()}},
                 noWrap: {{tile['no_wrap'].__str__().lower()}},
                 attribution: '{{tile['attr']}}',
-                detectRetina: {{tile['detect_retina'].__str__().lower()}}
+                detectRetina: {{tile['detect_retina'].__str__().lower()}},
+                subdomains: '{{tile['subdomains']}}'
                 }
             ).addTo({{ map_id }});
     {% endfor %}

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -147,6 +147,28 @@ class TestFolium(object):
         bounds = map.get_bounds()
         assert bounds == [[None, None], [None, None]], bounds
 
+    def test_custom_tile_subdomains(self):
+        """Test custom tile subdomains."""
+
+        url = 'http://{s}.custom_tiles.org/{z}/{x}/{y}.png'
+        map = folium.Map(location=[45.52, -122.67], tiles=url,
+                         attr='attribution',
+                         subdomains='1234')
+
+        url_with_name = 'http://{s}.custom_tiles-subdomains.org/{z}/{x}/{y}.png'
+        tile_layer = folium.map.TileLayer(url,
+                                          name='subdomains2',
+                                          attr='attribution',
+                                          subdomains='5678')
+        map.add_child(tile_layer)
+        map.add_tile_layer(tiles=url_with_name, attr='attribution',
+                           subdomains='9012')
+
+        out = map._parent.render()
+        assert '1234' in out
+        assert '5678' in out
+        assert '9012' in out
+
     def test_feature_group(self):
         """Test FeatureGroup."""
 
@@ -320,7 +342,8 @@ class TestFolium(object):
              'min_zoom': 1,
              'detect_retina': False,
              'no_wrap': False,
-             'continuous_world': False
+             'continuous_world': False,
+             'subdomains': 'abc'
              }]
         tmpl = {'map_id': 'map_' + '0' * 32,
                 'lat': 45.5236, 'lon': -122.675,


### PR DESCRIPTION
Some tile services use a different set of subdomains. For reference: http://leafletjs.com/reference-1.0.3.html#tilelayer-subdomains