### PR TITLE
Added HERE tiles template

### DIFF
--- a/folium/templates/tiles/here/attr.txt
+++ b/folium/templates/tiles/here/attr.txt
@@ -1,0 +1,1 @@
+Map tiles by <a href="https://www.here.com/">HERE Technologies</a>.

--- a/folium/templates/tiles/here/tiles.txt
+++ b/folium/templates/tiles/here/tiles.txt
@@ -1,0 +1,1 @@
+https://{s}.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?app_id={{ APP_ID }}&app_code={{ APP_CODE }}


### PR DESCRIPTION
This contains only the `attr.txt` and `tiles.txt` files. Not sure if something else is needed (apart from README, etc). In addition to the credentials (`APP_CODE` and `APP_ID`) many more items can be varied in the HERE tiles URL, but I'm not sure if the current design suggests to use multiple folders and names, like in the current `stamenterrain` and `stamentoner` folders, or if additional attributes could/should be rather passed to the `folium.Map()` constructor. (Sure, the user can use the his own tiles URL, anyway.)