### PR TITLE
Use pixelated image rendering for image overlays

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@
 - Added support for subdomains options in TileLayer (damselem #623)
 - Updated to leaflet 1.1.0 (ocefpaf #639)
 - Added `FastMarkerCluster` (James Gardiner #585 (proposed by @ruoyu0088))
+- Changed default css image-rendering style for image overlaus to pixelated
 
 Bug Fixes
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@
 - Added support for subdomains options in TileLayer (damselem #623)
 - Updated to leaflet 1.1.0 (ocefpaf #639)
 - Added `FastMarkerCluster` (James Gardiner #585 (proposed by @ruoyu0088))
-- Changed default css image-rendering style for image overlaus to pixelated
+- Changed default css image-rendering style for image overlays to pixelated
 
 Bug Fixes
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -231,6 +231,12 @@ class LegacyMap(MacroElement):
                 left: {{this.left[0]}}{{this.left[1]}};
                 top: {{this.top[0]}}{{this.top[1]}};
                 }
+                #{{this.get_name()}} .leaflet-image-layer {
+                    image-rendering: pixelated; /* chrome */
+                    image-rendering: -moz-crisp-edges; /* firefox */
+                    image-rendering: -o-crisp-edges; /* opera */
+                    -ms-interpolation-mode: nearest-neighbor; /* internet explorer */
+                }
             </style>
         {% endmacro %}
         {% macro html(this, kwargs) %}


### PR DESCRIPTION
As discusses previously. This changes the default css image-rendering style for image overlays to pixelated.

Tested on firefox and chrome