### PR TITLE
Fix test for #568

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -37,8 +37,6 @@ _default_js = [
      'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'),
     ('awesome_markers',
      'https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js'),  # noqa
-    ('marker_cluster_src',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/leaflet.markercluster-src.js'),  # noqa
     ('marker_cluster',
      'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/leaflet.markercluster.js'),  # noqa
     ]


### PR DESCRIPTION
`leaflet.markercluster-src.js` is not needed and it was removed from the testing template in #568.
This PR removes in from the renderings map renderings as well.

Note to self: I want to eliminate `fol_template.html` entirely so future tests should not rely on that template. I believe that the code already does not.

Ping @birdage 