### PR TITLE
TileLayer and WMSTileLayer are in __all__,

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -13,7 +13,7 @@ from folium.features import (
     LatLngPopup, RegularPolygonMarker, TopoJson, Vega, VegaLite,
 )
 
-# from folium.raster_layers imoort TileLayer, WmsTileLayer
+from folium.raster_layers imoort TileLayer, WmsTileLayer
 
 from folium.folium import Map
 

--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -13,7 +13,7 @@ from folium.features import (
     LatLngPopup, RegularPolygonMarker, TopoJson, Vega, VegaLite,
 )
 
-from folium.raster_layers imoort TileLayer, WmsTileLayer
+from folium.raster_layers import TileLayer, WmsTileLayer
 
 from folium.folium import Map
 


### PR DESCRIPTION
therefore they should be imported.

Or if this was the wrong fix then they should be removed from `__all__` (note: I haven't tested this at all it's just a driveby fix)