### PR TITLE
Add a `time` named argument to `to_png`

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -271,12 +271,12 @@ class Map(MacroElement):
         """Export the HTML to byte representation of a PNG image.
 
         Uses Phantom JS to render the HTML and record a PNG. You may need to 
-        adjust the `delay` time keyword argument if maps render without data or tiles. 
+        adjust the `delay` time keyword argument if maps render without data or tiles.
 
         Examples
         --------
         >>> map._to_png()
-        >>> map._to_png(time=10)  # Wait 10 seconds between render and snapshot. 
+        >>> map._to_png(time=10)  # Wait 10 seconds between render and snapshot.
         """
 
         if self._png_image is None:

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -270,7 +270,7 @@ class Map(MacroElement):
     def _to_png(self, delay=3):
         """Export the HTML to byte representation of a PNG image.
 
-        Uses Phantom JS to render the HTML and record a PNG. You may need to 
+        Uses Phantom JS to render the HTML and record a PNG. You may need to
         adjust the `delay` time keyword argument if maps render without data or tiles.
 
         Examples

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -267,19 +267,18 @@ class Map(MacroElement):
             out = self._parent._repr_html_(**kwargs)
         return out
 
-    def _to_png(self, time=3):
+    def _to_png(self, delay=3):
         """Export the HTML to byte representation of a PNG image.
-        
+
         Uses Phantom JS to render the HTML and record a PNG. You may need to 
-        adjust the time keyword argument if maps render without data or tiles. 
+        adjust the `delay` time keyword argument if maps render without data or tiles. 
+
         Examples
         --------
-        
-        map._to_png()
-        
-        map._to_png(time=10) # Wait 10 seconds between render and snapshot. 
-        
+        >>> map._to_png()
+        >>> map._to_png(time=10)  # Wait 10 seconds between render and snapshot. 
         """
+
         if self._png_image is None:
             import selenium.webdriver
 
@@ -295,7 +294,7 @@ class Map(MacroElement):
                 driver.execute_script("document.body.style.width = '100%';")  # noqa
                 # We should probably monitor if some element is present,
                 # but this is OK for now.
-                time.sleep(time)
+                time.sleep(delay)
                 png = driver.get_screenshot_as_png()
                 driver.quit()
                 self._png_image = png

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -267,8 +267,19 @@ class Map(MacroElement):
             out = self._parent._repr_html_(**kwargs)
         return out
 
-    def _to_png(self):
-        """Export the HTML to byte representation of a PNG image."""
+    def _to_png(self, time=3):
+        """Export the HTML to byte representation of a PNG image.
+        
+        Uses Phantom JS to render the HTML and record a PNG. You may need to 
+        adjust the time keyword argument if maps render without data or tiles. 
+        Examples
+        --------
+        
+        map._to_png()
+        
+        map._to_png(time=10) # Wait 10 seconds between render and snapshot. 
+        
+        """
         if self._png_image is None:
             import selenium.webdriver
 
@@ -284,7 +295,7 @@ class Map(MacroElement):
                 driver.execute_script("document.body.style.width = '100%';")  # noqa
                 # We should probably monitor if some element is present,
                 # but this is OK for now.
-                time.sleep(3)
+                time.sleep(time)
                 png = driver.get_screenshot_as_png()
                 driver.quit()
                 self._png_image = png


### PR DESCRIPTION
Since it might take longer than 3 seconds to render the map, this adds a time named arg that allows you to delay the screenshot.