### PR TITLE
Adding animation to Boat Marker plugin

### DIFF
--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 import json
 
-from branca.element import Figure, JavascriptLink
+from jinja2 import Template
 
+from branca.element import Figure, JavascriptLink
 from folium.map import Marker
 from folium.utilities import _validate_location
-
-from jinja2 import Template
 
 
 class BoatMarker(Marker):
@@ -34,8 +33,10 @@ class BoatMarker(Marker):
         Speed of the wind in knots.
 
     """
+
     def __init__(self, location, popup=None, icon=None,
-                 heading=0, wind_heading=None, wind_speed=0, **kwargs):
+                 heading=0, wind_heading=None, wind_speed=0, animate=True,
+                 **kwargs):
         super(BoatMarker, self).__init__(
             _validate_location(location),
             popup=popup,
@@ -46,15 +47,29 @@ class BoatMarker(Marker):
         self.wind_heading = wind_heading
         self.wind_speed = wind_speed
         self.kwargs = json.dumps(kwargs)
+        self.animate = 1 if animate else 0
 
         self._template = Template(u"""
             {% macro script(this, kwargs) %}
                 var {{this.get_name()}} = L.boatMarker(
                     [{{this.location[0]}},{{this.location[1]}}],
                     {{this.kwargs}}).addTo({{this._parent.get_name()}});
-                {{this.get_name()}}.setHeadingWind({{this.heading}}, {{this.wind_speed}}, {{this.wind_heading}});
+                var animate = {{this.animate}}
+                var boatMarker = {{this.get_name()}};
+                boatMarker.setHeadingWind({{this.heading}},
+                    {{this.wind_speed}}, {{this.wind_heading}});
+
+                if (animate === 1) {
+                    window.setInterval(function() {
+                        var destination = turf.destination(
+                            boatMarker.toGeoJSON(), 0.02, 60,"kilometers");
+
+                        boatMarker.setLatLng(
+                            destination.geometry.coordinates.reverse());
+                    }, 488);
+                }
             {% endmacro %}
-            """)  # noqa
+            """)
 
     def render(self, **kwargs):
         super(BoatMarker, self).render(**kwargs)
@@ -62,7 +77,10 @@ class BoatMarker(Marker):
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '
                                             'if it is not in a Figure.')
+        figure.header.add_child(
+            JavascriptLink('https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js'),  # noqa
+            name='turf')
 
         figure.header.add_child(
             JavascriptLink('https://unpkg.com/leaflet.boatmarker/leaflet.boatmarker.min.js'),  # noqa
-            name='markerclusterjs')
+            name='boatmarker')

--- a/tests/plugins/test_boat_marker.py
+++ b/tests/plugins/test_boat_marker.py
@@ -53,14 +53,29 @@ def test_boat_marker():
                 boatMarker.setHeadingWind({{this.heading}},
                     {{this.wind_speed}}, {{this.wind_heading}});
 
-                if (animate === 1) {
+                if (animate === 1 && {{this.speed}} > 0) {
+                    var updatesPerHour = function(s) {
+                        return parseInt(
+                            (60*60*1000)/s
+                        );
+                    }
+                    var updateInterval = updatesPerHour(
+                        {{this.update_frequency}});
+
                     window.setInterval(function() {
                         var destination = turf.destination(
-                            boatMarker.toGeoJSON(), 0.02, 60,"kilometers");
+                            boatMarker.toGeoJSON(),
+                            {{this.speed}} / updateInterval,
+                            {{this.heading}},
+                            "kilometers");
 
                         boatMarker.setLatLng(
                             destination.geometry.coordinates.reverse());
-                    }, 488);
+
+                        if (!{{this._parent.get_name()}}.getBounds().contains({{this.get_name()}}.getLatLng())) {
+                            {{this._parent.get_name()}}.panTo({{this.get_name()}}.getLatLng());
+                        }
+                    }, {{this.update_frequency}});
                 }
             {% endmacro %}
     """)  # noqa


### PR DESCRIPTION
Addresses https://github.com/python-visualization/folium/issues/718 by adding optional animation based on the [upstream plugin example](https://github.com/thomasbrueggemann/leaflet.boatmarker). Default animation can be disabled by passing `animate=False`

Also adds [Turf.js](https://github.com/Turfjs/turf/) JavascriptLink and updates name argument for boat marker import.

I hope it helps!!