### PR TITLE
Untoggle overlays and additional base layers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@
 - Added `tooltip` support to `Marker`s (ocefpaf #724)
 - Added `tooltip` support to all vector layers (ocefpaf #722)
 - Added `TimeSliderChoropleth` plugin (halfdanrump #736)
+- Added `show` parameter to choose which overlays to show on opening (conengmo #772)
 
 API changes
 

--- a/folium/features.py
+++ b/folium/features.py
@@ -317,6 +317,8 @@ class GeoJson(Layer):
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls
+    hide: bool, default False
+        Whether the layer will be hidden by default, if it is an overlay.
     smooth_factor: float, default None
         How much to simplify the polyline on each zoom level. More means
         better performance and smoother look, and less means more accurate
@@ -341,10 +343,10 @@ class GeoJson(Layer):
 
     """
     def __init__(self, data, style_function=None, name=None,
-                 overlay=True, control=True, smooth_factor=None,
-                 highlight_function=None, tooltip=None):
+                 overlay=True, control=True, hide=False,
+                 smooth_factor=None, highlight_function=None, tooltip=None):
         super(GeoJson, self).__init__(name=name, overlay=overlay,
-                                      control=control)
+                                      control=control, hide=hide)
         self._name = 'GeoJson'
         self.tooltip = tooltip
         if isinstance(data, dict):

--- a/folium/features.py
+++ b/folium/features.py
@@ -313,12 +313,12 @@ class GeoJson(Layer):
         Function mapping a GeoJson Feature to a style dict for mouse events.
     name : string, default None
         The name of the Layer, as it will appear in LayerControls
-    overlay : bool, default False
+    overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls
-    hide: bool, default False
-        Whether the layer will be hidden by default, if it is an overlay.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     smooth_factor: float, default None
         How much to simplify the polyline on each zoom level. More means
         better performance and smoother look, and less means more accurate
@@ -343,10 +343,10 @@ class GeoJson(Layer):
 
     """
     def __init__(self, data, style_function=None, name=None,
-                 overlay=True, control=True, hide=False,
+                 overlay=True, control=True, show=True,
                  smooth_factor=None, highlight_function=None, tooltip=None):
         super(GeoJson, self).__init__(name=name, overlay=overlay,
-                                      control=control, hide=hide)
+                                      control=control, show=show)
         self._name = 'GeoJson'
         self.tooltip = tooltip
         if isinstance(data, dict):
@@ -473,7 +473,9 @@ class TopoJson(Layer):
     overlay : bool, default False
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
-        Whether the Layer will be included in LayerControls
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     smooth_factor: float, default None
         How much to simplify the polyline on each zoom level. More means
         better performance and smoother look, and less means more accurate
@@ -498,10 +500,10 @@ class TopoJson(Layer):
 
     """
     def __init__(self, data, object_path, style_function=None,
-                 name=None, overlay=True, control=True, smooth_factor=None,
-                 tooltip=None):
+                 name=None, overlay=True, control=True, show=True,
+                 smooth_factor=None, tooltip=None):
         super(TopoJson, self).__init__(name=name, overlay=overlay,
-                                       control=control)
+                                       control=control, show=show)
         self._name = 'TopoJson'
         self.tooltip = tooltip
         if 'read' in dir(data):

--- a/folium/map.py
+++ b/folium/map.py
@@ -33,15 +33,15 @@ class Layer(MacroElement):
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.
-    hide: bool, default False
-        Whether the layer will be hidden by default, if it is an overlay.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     """
-    def __init__(self, name=None, overlay=False, control=True, hide=False):
+    def __init__(self, name=None, overlay=False, control=True, show=True):
         super(Layer, self).__init__()
         self.layer_name = name if name is not None else self.get_name()
         self.overlay = overlay
         self.control = control
-        self.hide = hide
+        self.show = show
 
 
 class FeatureGroup(Layer):
@@ -61,11 +61,12 @@ class FeatureGroup(Layer):
         LayerControls) or a base layer (ticked with a radio button).
     control: bool, default True
         Whether the layer will be included in LayerControls.
-    hide: bool, default False
-        Whether the layer will be hidden by default, if it is an overlay.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     """
-    def __init__(self, name=None, overlay=True, control=True, hide=False):
-        super(FeatureGroup, self).__init__(overlay=overlay, control=control, name=name, hide=hide)  # noqa
+    def __init__(self, name=None, overlay=True, control=True, show=True):
+        super(FeatureGroup, self).__init__(name=name, overlay=overlay,
+                                           control=control, show=show)
         self._name = 'FeatureGroup'
 
         self.tile_name = name if name is not None else self.get_name()
@@ -138,7 +139,7 @@ class LayerControl(MacroElement):
         self.overlays_hidden = [
             val.get_name() for val in
             self._parent._children.values() if isinstance(val, Layer)
-            and val.overlay and val.control and val.hide]
+            and val.overlay and val.control and not val.show]
         super(LayerControl, self).render()
 
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -59,9 +59,13 @@ class FeatureGroup(Layer):
     overlay : bool, default True
         Whether your layer will be an overlay (ticked with a check box in
         LayerControls) or a base layer (ticked with a radio button).
+    control: bool, default True
+        Whether the layer will be included in LayerControls.
+    hide: bool, default False
+        Whether the layer will be hidden by default, if it is an overlay.
     """
-    def __init__(self, name=None, overlay=True, control=True):
-        super(FeatureGroup, self).__init__(overlay=overlay, control=control, name=name)  # noqa
+    def __init__(self, name=None, overlay=True, control=True, hide=False):
+        super(FeatureGroup, self).__init__(overlay=overlay, control=control, name=name, hide=hide)  # noqa
         self._name = 'FeatureGroup'
 
         self.tile_name = name if name is not None else self.get_name()

--- a/folium/map.py
+++ b/folium/map.py
@@ -106,7 +106,7 @@ class LayerControl(MacroElement):
         self.autoZIndex = str(autoZIndex).lower()
         self.base_layers = OrderedDict()
         self.overlays = OrderedDict()
-        self.overlays_untoggle = []
+        self.layers_untoggle = []
 
         self._template = Template("""
         {% macro script(this,kwargs) %}
@@ -121,7 +121,7 @@ class LayerControl(MacroElement):
                  collapsed: {{this.collapsed}},
                  autoZIndex: {{this.autoZIndex}}
                 }).addTo({{this._parent.get_name()}});
-            {% for val in this.overlays_untoggle %}
+            {% for val in this.layers_untoggle %}
                 {{ val }}.remove();{% endfor %}
         {% endmacro %}
         """)  # noqa
@@ -136,10 +136,12 @@ class LayerControl(MacroElement):
             [(val.layer_name, val.get_name()) for key, val in
              self._parent._children.items() if isinstance(val, Layer)
              and val.overlay and val.control])
-        self.overlays_untoggle = [
+        self.layers_untoggle = [
             val.get_name() for val in
             self._parent._children.values() if isinstance(val, Layer)
             and val.overlay and val.control and not val.show]
+        for additional_base_layer in list(self.base_layers.values())[1:]:
+            self.layers_untoggle.append(additional_base_layer)
         super(LayerControl, self).render()
 
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -106,7 +106,7 @@ class LayerControl(MacroElement):
         self.autoZIndex = str(autoZIndex).lower()
         self.base_layers = OrderedDict()
         self.overlays = OrderedDict()
-        self.overlays_hidden = []
+        self.overlays_untoggle = []
 
         self._template = Template("""
         {% macro script(this,kwargs) %}
@@ -121,7 +121,7 @@ class LayerControl(MacroElement):
                  collapsed: {{this.collapsed}},
                  autoZIndex: {{this.autoZIndex}}
                 }).addTo({{this._parent.get_name()}});
-            {% for val in this.overlays_hidden %}
+            {% for val in this.overlays_untoggle %}
                 {{ val }}.remove();{% endfor %}
         {% endmacro %}
         """)  # noqa
@@ -136,7 +136,7 @@ class LayerControl(MacroElement):
             [(val.layer_name, val.get_name()) for key, val in
              self._parent._children.items() if isinstance(val, Layer)
              and val.overlay and val.control])
-        self.overlays_hidden = [
+        self.overlays_untoggle = [
             val.get_name() for val in
             self._parent._children.values() if isinstance(val, Layer)
             and val.overlay and val.control and not val.show]

--- a/folium/map.py
+++ b/folium/map.py
@@ -135,7 +135,8 @@ class LayerControl(MacroElement):
             [(val.layer_name, val.get_name()) for key, val in
              self._parent._children.items() if isinstance(val, Layer)
              and val.overlay and val.control])
-        self.overlays_hidden = [val.get_name() for val in
+        self.overlays_hidden = [
+            val.get_name() for val in
             self._parent._children.values() if isinstance(val, Layer)
             and val.overlay and val.control and val.hide]
         super(LayerControl, self).render()

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -25,15 +25,24 @@ class FastMarkerCluster(MarkerCluster):
     data: list
         List of list of shape [[], []]. Data points should be of
         the form [[lat, lng]].
-
     callback: string, default None
         A string representation of a valid Javascript function
         that will be passed a lat, lon coordinate pair. See the
         FasterMarkerCluster for an example of a custom callback.
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls.
+    overlay : bool, default True
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     """
-    def __init__(self, data, callback=None):
-        super(FastMarkerCluster, self).__init__([])
+    def __init__(self, data, callback=None,
+                 name=None, overlay=True, control=True, show=True):
+        super(FastMarkerCluster, self).__init__(name=name, overlay=overlay,
+                                                control=control, show=show)
         self._name = 'FastMarkerCluster'
         self._data = _validate_coordinates(data)
 

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -79,7 +79,7 @@ class HeatMap(Layer):
         """)
 
     def render(self, **kwargs):
-        super(HeatMap, self).render()
+        super(HeatMap, self).render(**kwargs)
 
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -3,12 +3,12 @@
 from branca.element import CssLink, Element, Figure, JavascriptLink
 from branca.utilities import none_max, none_min
 
-from folium.raster_layers import TileLayer
+from folium.map import Layer
 
 from jinja2 import Template
 
 
-class HeatMapWithTime(TileLayer):
+class HeatMapWithTime(Layer):
     """
     Create a HeatMapWithTime layer
 
@@ -19,8 +19,8 @@ class HeatMapWithTime(TileLayer):
         steps in sequential order. (weight defaults to 1 if not specified for a point)
     index: Index giving the label (or timestamp) of the elements of data. Should have
         the same length as data, or is replaced by a simple count if not specified.
-    name: str
-        The name of the layer that will be created.
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls.
     radius: default 15.
         The radius used around points for the heatmap.
     min_opacity: default 0
@@ -46,22 +46,30 @@ class HeatMapWithTime(TileLayer):
         Step between different fps speeds on the speed slider.
     position: default 'bottomleft'
         Position string for the time slider. Format: 'bottom/top'+'left/right'.
+    overlay : bool, default True
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     """
-    def __init__(self, data, index=None, name=None, radius=15, min_opacity=0, max_opacity=0.6,
-                 scale_radius=False, use_local_extrema=False, auto_play=False, display_index=True,
-                 index_steps=1, min_speed=0.1, max_speed=10, speed_step=0.1, position='bottomleft'
-                 ):
-        super(TileLayer, self).__init__(name=name)
+    def __init__(self, data, index=None, name=None, radius=15, min_opacity=0,
+                 max_opacity=0.6, scale_radius=False, use_local_extrema=False,
+                 auto_play=False, display_index=True, index_steps=1,
+                 min_speed=0.1, max_speed=10, speed_step=0.1,
+                 position='bottomleft', overlay=True, control=True, show=True):
+        super(HeatMapWithTime, self).__init__(name=name, overlay=overlay,
+                                              control=control, show=show)
         self._name = 'HeatMap'
         self._control_name = self.get_name() + 'Control'
-        self.tile_name = name if name is not None else self.get_name()
 
         # Input data.
         self.data = data
-        self.index = index if index is not None else [str(i) for i in range(1, len(data)+1)]
+        self.index = index if index is not None else [str(i) for i in
+                                                      range(1, len(data)+1)]
         if len(self.data) != len(self.index):
-            raise ValueError('Input data and index are not of compatible lengths.')
+            raise ValueError('Input data and index are not of compatible lengths.')  # noqa
         self.times = list(range(1, len(data)+1))
 
         # Heatmap settings.

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -148,7 +148,7 @@ class HeatMapWithTime(Layer):
         """)
 
     def render(self, **kwargs):
-        super(TileLayer, self).render()
+        super(HeatMapWithTime, self).render(**kwargs)
 
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -17,10 +17,12 @@ class MarkerCluster(Layer):
     ----------
     name : string, default None
         The name of the Layer, as it will appear in LayerControls
-    overlay : bool, default False
+    overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
-        Whether the Layer will be included in LayerControls
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     icon_create_function : string, default None
         Override the default behaviour, making possible to customize
         markers colors and sizes.
@@ -43,8 +45,10 @@ class MarkerCluster(Layer):
 
     """
     def __init__(self, locations=None, popups=None, icons=None, name=None,
-                 overlay=True, control=True, icon_create_function=None):
-        super(MarkerCluster, self).__init__(name=name, overlay=overlay, control=control)  # noqa
+                 overlay=True, control=True, show=True,
+                 icon_create_function=None):
+        super(MarkerCluster, self).__init__(name=name, overlay=overlay,
+                                            control=control, show=show)
 
         if locations is not None:
             if popups is None:

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -22,15 +22,26 @@ class TimeSliderChoropleth(GeoJson):
     styledict: dict
         A dictionary where the keys are the geojson feature ids and the values are
         dicts of `{time: style_options_dict}`
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls.
+    overlay : bool, default False
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     """
-    def __init__(self, data, styledict, name=None, overlay=True, control=True, **kwargs):
-        super(TimeSliderChoropleth, self).__init__(data, name=name, overlay=overlay, control=control)
+    def __init__(self, data, styledict, name=None, overlay=True, control=True,
+                 show=True):
+        super(TimeSliderChoropleth, self).__init__(data, name=name,
+                                                   overlay=overlay,
+                                                   control=control, show=show)
         if not isinstance(styledict, dict):
-            raise ValueError('styledict must be a dictionary, got {!r}'.format(styledict))
+            raise ValueError('styledict must be a dictionary, got {!r}'.format(styledict))  # noqa
         for val in styledict.values():
             if not isinstance(val, dict):
-                raise ValueError('Each item in styledict must be a dictionary, got {!r}'.format(val))
+                raise ValueError('Each item in styledict must be a dictionary, got {!r}'.format(val))  # noqa
 
         # Make set of timestamps.
         timestamps = set()

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -35,6 +35,14 @@ class TimestampedWmsTileLayers(Layer):
         from the first available time. Format: ISO8601 Duration
         ex: 'P1M' -> 1/month, 'P1D' -> 1/day, 'PT1H' -> 1/hour, and 'PT1M' -> 1/minute
         Note: this seems to be overridden by the WMS Tile Layer GetCapabilities.
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls.
+    overlay : bool, default True
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     Examples
     --------
@@ -66,10 +74,12 @@ class TimestampedWmsTileLayers(Layer):
 
     """
     def __init__(self, data, transition_time=200, loop=False, auto_play=False,
-                 period='P1D', time_interval=False):
-        super(TimestampedWmsTileLayers, self).__init__(overlay=True,
-                                                       control=False,
-                                                       name='timestampedwms')
+                 period='P1D', time_interval=False, name=None,
+                 overlay=True, control=True, show=True):
+        super(TimestampedWmsTileLayers, self).__init__(name=name,
+                                                       overlay=overlay,
+                                                       control=control,
+                                                       show=show)
         self._name = 'TimestampedWmsTileLayers'
 
         self.transition_time = int(transition_time)

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -58,18 +58,20 @@ class TileLayer(Layer):
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.
+    hide: bool, default False
+        Whether the layer will be hidden by default, if it is an overlay.
     subdomains: list of strings, default ['abc']
         Subdomains of the tile service.
 
     """
     def __init__(self, tiles='OpenStreetMap', min_zoom=1, max_zoom=18,
                  attr=None, API_key=None, detect_retina=False,
-                 name=None, overlay=False,
-                 control=True, no_wrap=False, subdomains='abc'):
+                 name=None, overlay=False, control=True, hide=False,
+                 no_wrap=False, subdomains='abc'):
         self.tile_name = (name if name is not None else
                           ''.join(tiles.lower().strip().split()))
         super(TileLayer, self).__init__(name=self.tile_name, overlay=overlay,
-                                        control=control)
+                                        control=control, hide=hide)
         self._name = 'TileLayer'
         self._env = ENV
 

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -58,20 +58,20 @@ class TileLayer(Layer):
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.
-    hide: bool, default False
-        Whether the layer will be hidden by default, if it is an overlay.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     subdomains: list of strings, default ['abc']
         Subdomains of the tile service.
 
     """
     def __init__(self, tiles='OpenStreetMap', min_zoom=1, max_zoom=18,
                  attr=None, API_key=None, detect_retina=False,
-                 name=None, overlay=False, control=True, hide=False,
+                 name=None, overlay=False, control=True, show=True,
                  no_wrap=False, subdomains='abc'):
         self.tile_name = (name if name is not None else
                           ''.join(tiles.lower().strip().split()))
         super(TileLayer, self).__init__(name=self.tile_name, overlay=overlay,
-                                        control=control, hide=hide)
+                                        control=control, show=show)
         self._name = 'TileLayer'
         self._env = ENV
 
@@ -143,7 +143,9 @@ class WmsTileLayer(Layer):
     overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
-        Whether the Layer will be included in LayerControls
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
     **kwargs : additional keyword arguments
         Passed through to the underlying tileLayer.wms object and can be used
         for setting extra tileLayer.wms parameters or as extra parameters in
@@ -153,8 +155,10 @@ class WmsTileLayer(Layer):
     http://leafletjs.com/reference-1.2.0.html#tilelayer-wms
 
     """
-    def __init__(self, url, name=None, attr='', overlay=True, control=True, **kwargs):  # noqa
-        super(WmsTileLayer, self).__init__(overlay=overlay, control=control, name=name)  # noqa
+    def __init__(self, url, name=None, attr='', overlay=True, control=True,
+                 show=True, **kwargs):
+        super(WmsTileLayer, self).__init__(overlay=overlay, control=control,
+                                           name=name, show=show)
         self.url = url
         # Options.
         options = _parse_wms(**kwargs)
@@ -207,15 +211,24 @@ class ImageOverlay(Layer):
         object.
     pixelated: bool, default True
         Sharp sharp/crips (True) or aliased corners (False).
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls
+    overlay : bool, default True
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     See http://leafletjs.com/reference-1.2.0.html#imageoverlay for more
     options.
 
     """
     def __init__(self, image, bounds, origin='upper', colormap=None,
-                 mercator_project=False, overlay=True, control=True,
-                 pixelated=True, name=None, **kwargs):
-        super(ImageOverlay, self).__init__(overlay=overlay, control=control, name=name)  # noqa
+                 mercator_project=False, pixelated=True,
+                 name=None, overlay=True, control=True, show=True, **kwargs):
+        super(ImageOverlay, self).__init__(name=name, overlay=overlay,
+                                           control=control, show=show)
 
         options = {
             'opacity': kwargs.pop('opacity', 1.),
@@ -291,11 +304,21 @@ class VideoOverlay(Layer):
         [lat_max, lon_max]]
     opacity: float, default Leaflet's default (1.0)
     attr: string, default Leaflet's default ('')
+    name : string, default None
+        The name of the Layer, as it will appear in LayerControls
+    overlay : bool, default True
+        Adds the layer as an optional overlay (True) or the base layer (False).
+    control : bool, default True
+        Whether the Layer will be included in LayerControls.
+    show: bool, default True
+        Whether the layer will be shown on opening (only for overlays).
 
     """
     def __init__(self, video_url, bounds, opacity=1., attr=None,
-                 autoplay=True, loop=True):
-        super(VideoOverlay, self).__init__()
+                 autoplay=True, loop=True,
+                 name=None, overlay=True, control=True, show=True):
+        super(VideoOverlay, self).__init__(name=name, overlay=overlay,
+                                           control=control, show=show)
         self._name = 'VideoOverlay'
 
         self.video_url = video_url


### PR DESCRIPTION
I worked on solving issue #606 and #571. I added functionality in the `LayerControl` class to untoggle overlays that have `hidden=True`. While I was there I simplified the checks in render(). If an item is an instance of `Layer` it will always have the `overlay` and `control` attributes.

I added the `hide` parameter to some classes to test it out, but not to all children of `Layer` yet.

What do you guys think, is this a good way to do this?