### PR TITLE
Set min_zoom default to Leaflet value (0 i.o. 1)

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -101,8 +101,10 @@ class Map(MacroElement):
         pass a custom URL or pass `None` to create a map without tiles.
     API_key: str, default None
         API key for Cloudmade or Mapbox tiles.
+    min_zoom: int, default 0
+        Minimum allowed zoom level for the tile layer that is created.
     max_zoom: int, default 18
-        Maximum zoom depth for the map.
+        Maximum allowed zoom level for the tile layer that is created.
     zoom_start: int, default 10
         Initial zoom level for the map.
     attr: string, default None
@@ -163,7 +165,7 @@ class Map(MacroElement):
 
     def __init__(self, location=None, width='100%', height='100%',
                  left='0%', top='0%', position='relative',
-                 tiles='OpenStreetMap', API_key=None, max_zoom=18, min_zoom=1,
+                 tiles='OpenStreetMap', API_key=None, max_zoom=18, min_zoom=0,
                  zoom_start=10, world_copy_jump=False,
                  no_wrap=False, attr=None, min_lat=-90, max_lat=90,
                  min_lon=-180, max_lon=180, max_bounds=False,
@@ -178,9 +180,9 @@ class Map(MacroElement):
         self.png_enabled = png_enabled
 
         if not location:
-            # If location is not passed we center and ignore zoom.
+            # If location is not passed we center and zoom out.
             self.location = [0, 0]
-            self.zoom_start = min_zoom
+            self.zoom_start = 1
         else:
             self.location = _validate_location(location)
             self.zoom_start = zoom_start
@@ -309,7 +311,7 @@ class Map(MacroElement):
         return self._to_png()
 
     def add_tile_layer(self, tiles='OpenStreetMap', name=None,
-                       API_key=None, max_zoom=18, min_zoom=1,
+                       API_key=None, max_zoom=18, min_zoom=0,
                        attr=None, active=False,
                        detect_retina=False, no_wrap=False, subdomains='abc',
                        **kwargs):

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -40,10 +40,10 @@ class TileLayer(Layer):
 
         You can pass a custom tileset to Folium by passing a Leaflet-style
         URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``
-    min_zoom: int, default 1
-        Minimal zoom for which the layer will be displayed.
+    min_zoom: int, default 0
+        Minimum allowed zoom level for this tile layer.
     max_zoom: int, default 18
-        Maximal zoom for which the layer will be displayed.
+        Maximum allowed zoom level for this tile layer.
     attr: string, default None
         Map tile attribution; only required if passing custom tile URL.
     API_key: str, default None
@@ -62,7 +62,7 @@ class TileLayer(Layer):
         Subdomains of the tile service.
 
     """
-    def __init__(self, tiles='OpenStreetMap', min_zoom=1, max_zoom=18,
+    def __init__(self, tiles='OpenStreetMap', min_zoom=0, max_zoom=18,
                  attr=None, API_key=None, detect_retina=False,
                  name=None, overlay=False,
                  control=True, no_wrap=False, subdomains='abc'):

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -207,7 +207,7 @@ class TestFolium(object):
              'address': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
              'attr': attr,
              'max_zoom': 20,
-             'min_zoom': 1,
+             'min_zoom': 0,
              'detect_retina': False,
              'no_wrap': False,
              'subdomains': 'abc'


### PR DESCRIPTION
I noticed the default value for the min_zoom parameter is set to 1, while [in Leaflet it is 0](http://leafletjs.com/reference-1.2.0.html#tilelayer-minzoom). I couldn't find any documentation on this, so I assume it's a (tiny) mistake. 

I can imagine that users don't want the `zoom_start` to change from 1 to 0, so I set it to 1 instead of `min_zoom`. If `min_zoom` is higher than 1, Leaflet will automatically change the starting zoom level.