### PR TITLE
Link to stable and newest docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ or
 Documentation
 -------------
 
+http://python-visualization.github.io/folium/docs-v0.5.0/
+
+The documentation for the development version can be found here:
 http://python-visualization.github.io/folium/docs-master/
 
 Note that the documentation on Read the Docs is for the deprecated version


### PR DESCRIPTION
Again for #788. @AlJohri mentioned the readme only links to the docs of the development version. So I added a link to the docs of the latest release (0.5.0).