### PR TITLE
Fix ReferenceError with FastMarkerCluster in layer control

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,7 @@ Bug Fixes
 - Fixed numpy array bug (#749) in _flatten
 - Unify `get_bounds` routine to avoid wrong responses
 - If Path option `fill_color` is present it will override `fill=False`
+- Fix disappearing layer control when using FastMarkerCluster (conengmo #866)
 
 0.5.0
 ~~~~~

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -41,10 +41,10 @@ class FastMarkerCluster(MarkerCluster):
     """
     _template = Template(u"""
             {% macro script(this, kwargs) %}
-            
+
             var {{ this.get_name() }} = (function(){
                 {{this._callback}}
-                
+
                 var data = {{ this._data }};
                 var cluster = L.markerClusterGroup();
 
@@ -53,7 +53,7 @@ class FastMarkerCluster(MarkerCluster):
                     var marker = callback(row);
                     marker.addTo(cluster);
                 }
-                
+
                 cluster.addTo({{ this._parent.get_name() }});
                 return cluster;
             })();

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -41,11 +41,11 @@ class FastMarkerCluster(MarkerCluster):
     """
     _template = Template(u"""
             {% macro script(this, kwargs) %}
-            {{this._callback}}
-
-            (function(){
-                var data = {{this._data}};
-                var map = {{this._parent.get_name()}};
+            
+            var {{ this.get_name() }} = (function(){
+                {{this._callback}}
+                
+                var data = {{ this._data }};
                 var cluster = L.markerClusterGroup();
 
                 for (var i = 0; i < data.length; i++) {
@@ -53,8 +53,9 @@ class FastMarkerCluster(MarkerCluster):
                     var marker = callback(row);
                     marker.addTo(cluster);
                 }
-
-                cluster.addTo(map);
+                
+                cluster.addTo({{ this._parent.get_name() }});
+                return cluster;
             })();
             {% endmacro %}""")
 
@@ -66,15 +67,12 @@ class FastMarkerCluster(MarkerCluster):
         self._data = _validate_coordinates(data)
 
         if callback is None:
-            self._callback = ('var callback;\n' +
-                              'callback = function (row) {\n' +
-                              '\tvar icon, marker;\n' +
-                              '\t// Returns a L.marker object\n' +
-                              '\ticon = L.AwesomeMarkers.icon();\n' +
-                              '\tmarker = L.marker(new L.LatLng(row[0], ' +
-                              'row[1]));\n' +
-                              '\tmarker.setIcon(icon);\n' +
-                              '\treturn marker;\n' +
-                              '};')
+            self._callback = """
+                var callback = function (row) {
+                    var icon = L.AwesomeMarkers.icon();
+                    var marker = L.marker(new L.LatLng(row[0], row[1]));
+                    marker.setIcon(icon);
+                    return marker;
+                };"""
         else:
             self._callback = 'var callback = {};'.format(callback)


### PR DESCRIPTION
FastMarkerCluster was not set as a variable. So when adding it to layer control, it resulted in a ReferenceError. This PR sets it as a variable. This closes #863.

Furthermore, the callback function is included in the main function, so there is no conflict with other functions that may be called 'callback'.

I also simplified things a bit.