### PR TITLE
Update leaflet.draw version and repo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@
 - Added `TimeSliderChoropleth` plugin (halfdanrump #736)
 - Added `show` parameter to choose which overlays to show on opening (conengmo #772)
 - Added BeautifyIcon Plugin (arthuralvim and jeremybyu #819)
+- Updated links to Draw plugin (conengmo #868)
 
 API changes
 

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -11,10 +11,15 @@ class Draw(MacroElement):
     """
     Vector drawing and editing plugin for Leaflet.
 
+    Parameters
+    ----------
+    export : bool, default False
+        Add a small button that exports the drawn shapes as a geojson file.
+
     Examples
     --------
     >>> m = folium.Map()
-    >>> Draw().draw.add_to(m)
+    >>> Draw(export=True).add_to(m)
 
     For more info please check
     https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html
@@ -72,19 +77,19 @@ class Draw(MacroElement):
 
         export_style = """<style>
         #export {
-        position: absolute;
-        top: 5px;
-        right: 10px;
-        z-index: 999;
-        background: white;
-        color: black;
-        padding: 6px;
-        border-radius: 4px;
-        font-family: 'Helvetica Neue';
-        cursor: pointer;
-        font-size: 12px;
-        text-decoration: none;
-        top: 90px;
+            position: absolute;
+            top: 5px;
+            right: 10px;
+            z-index: 999;
+            background: white;
+            color: black;
+            padding: 6px;
+            border-radius: 4px;
+            font-family: 'Helvetica Neue';
+            cursor: pointer;
+            font-size: 12px;
+            text-decoration: none;
+            top: 90px;
         }
         </style>"""
         export_button = """<a href='#' id='export'>Export</a>"""

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -65,10 +65,10 @@ class Draw(MacroElement):
                                             'if it is not in a Figure.')
 
         figure.header.add_child(
-            JavascriptLink('https://cdn.rawgit.com/Leaflet/Leaflet.draw/v0.4.12/dist/leaflet.draw.js'))  # noqa
+            JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js'))  # noqa
 
         figure.header.add_child(
-            CssLink('https://cdn.rawgit.com/Leaflet/Leaflet.draw/v0.4.12/dist/leaflet.draw.css'))  # noqa
+            CssLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css'))  # noqa
 
         export_style = """<style>
         #export {


### PR DESCRIPTION
Closes #864. Update Leaflet.Draw plugin to most recent version and change repository from rawgit.com to cdnjs.cloudflare.com.