### PR TITLE
Require branca 0.3.0, raise error otherwise

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -23,6 +23,11 @@ from folium.map import (
 
 from folium.vector_layers import Circle, CircleMarker, PolyLine, Polygon, Rectangle  # noqa
 
+import branca
+if tuple(int(x) for x in branca.__version__.split('.')) < (0, 3, 0):
+    raise ImportError('branca version 0.3.0 or higher is required. '
+                      'Update branca with e.g. `pip install branca --upgrade`.')
+
 __version__ = get_versions()['version']
 del get_versions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-branca
+branca>=0.3.0
 jinja2
 numpy
 requests


### PR DESCRIPTION
Moving the templates to the class attributes breaks folium when using older branca versions which still have the templates in the init's. The failure is silently, so it may confuse users. So apart from listing the version in requirements.txt I also propose raising an exception when the branca version is older than 0.3.0.