### PR TITLE
Add zoom_control option to `Map()`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@
 - Ingest any object that __geo_interface__ (ocefpaf #880)
 - Added `FeatureGroupSubGroup` plugin (shtrom #875)
 - Added `duration` option to `TimestampedGeoJson` (andy23512 #894)
+- Added `zoom_control` to `Map` to toggle zoom controls as per enhancement (#795) (okomarov #899)
 
 API changes
 

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -145,6 +145,8 @@ class Map(MacroElement):
         Forces Leaflet to not use hardware-accelerated CSS 3D
         transforms for positioning (which may cause glitches in some
         rare environments) even if they're supported.
+    zoom_control : bool, default True
+        Display zoom controls on the map.
 
     Returns
     -------
@@ -197,7 +199,8 @@ class Map(MacroElement):
         maxBounds: bounds,
         layers: [],
         worldCopyJump: {{this.world_copy_jump.__str__().lower()}},
-        crs: L.CRS.{{this.crs}}
+        crs: L.CRS.{{this.crs}},
+        zoomControl: {{this.zoom_control.__str__().lower()}}
         });
 {% if this.control_scale %}L.control.scale().addTo({{this.get_name()}});{% endif %}
     
@@ -222,7 +225,7 @@ $(document).ready(objects_in_front);
                  min_lon=-180, max_lon=180, max_bounds=False,
                  detect_retina=False, crs='EPSG3857', control_scale=False,
                  prefer_canvas=False, no_touch=False, disable_3d=False,
-                 subdomains='abc', png_enabled=False):
+                 subdomains='abc', png_enabled=False, zoom_control=True):
         super(Map, self).__init__()
         self._name = 'Map'
         self._env = ENV
@@ -257,6 +260,7 @@ $(document).ready(objects_in_front);
 
         self.crs = crs
         self.control_scale = control_scale
+        self.zoom_control = zoom_control
 
         self.global_switches = GlobalSwitches(
             prefer_canvas,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -200,7 +200,7 @@ class Map(MacroElement):
         layers: [],
         worldCopyJump: {{this.world_copy_jump.__str__().lower()}},
         crs: L.CRS.{{this.crs}},
-        zoomControl: {{this.zoom_control.__str__().lower()}}
+        zoomControl: {{this.zoom_control.__str__().lower()}},
         });
 {% if this.control_scale %}L.control.scale().addTo({{this.get_name()}});{% endif %}
     

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -39,7 +39,8 @@
       maxBounds: bounds,
       layers: [],
       worldCopyJump: {{ world_copy_jump.__str__().lower() }},
-      crs: L.CRS.{{crs}}
+      crs: L.CRS.{{crs}},
+      zoomControl: {{ zoom_control.__str__().lower() }},
       });
 
   {% for tile in tile_layers -%}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ flake8-quotes
 geographiclib
 geopandas
 gpxpy
+h5py
 ipykernel
 jupyter_client
 mplleaflet

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ flake8-quotes
 geographiclib
 geopandas
 gpxpy
-h5py
 ipykernel
 jupyter_client
 mplleaflet

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -226,7 +226,8 @@ class TestFolium(object):
                 'max_lon': 180,
                 'tile_layers': tile_layers,
                 'crs': 'EPSG3857',
-                'world_copy_jump': False
+                'world_copy_jump': False,
+                'zoom_control': True
                 }
         HTML = html_templ.render(tmpl, plugins={})
         expected = [line.strip() for line in HTML.splitlines() if line.strip()]


### PR DESCRIPTION
Enhancement #795: add a `zoom_control` option to the map creation (default: `True`)

Use case: create a .gif from 30+ snapshots of the map. The zoom controls do not serve any purpose and clutter the view. 

If averse to adding kwargs to the `Map()`  constructor, I could create a set method for ex-post toggle of the zoom controls. 