### PR TITLE
Change default date_options to 24 hour clock in TimestampedGeoJson

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@
 - Added `FeatureGroupSubGroup` plugin (shtrom #875)
 - Added `duration` option to `TimestampedGeoJson` (andy23512 #894)
 - Added `zoom_control` to `Map` to toggle zoom controls as per enhancement (#795) (okomarov #899)
+- Change default `date_options` to `YYYY-MM-DD HH:mm:ss` to make it more
+  ISO8601 compatible (andy23512 #914)
 
 API changes
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,8 +19,7 @@
 - Added `FeatureGroupSubGroup` plugin (shtrom #875)
 - Added `duration` option to `TimestampedGeoJson` (andy23512 #894)
 - Added `zoom_control` to `Map` to toggle zoom controls as per enhancement (#795) (okomarov #899)
-- Change default `date_options` in TimestampedGeoJson to `YYYY-MM-DD HH:mm:ss` to make it more
-  ISO8601 compatible (andy23512 #914)
+- Change default `date_options` in TimestampedGeoJson (andy23512 #914)
 
 API changes
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,7 +19,7 @@
 - Added `FeatureGroupSubGroup` plugin (shtrom #875)
 - Added `duration` option to `TimestampedGeoJson` (andy23512 #894)
 - Added `zoom_control` to `Map` to toggle zoom controls as per enhancement (#795) (okomarov #899)
-- Change default `date_options` to `YYYY-MM-DD HH:mm:ss` to make it more
+- Change default `date_options` in TimestampedGeoJson to `YYYY-MM-DD HH:mm:ss` to make it more
   ISO8601 compatible (andy23512 #914)
 
 API changes

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -130,7 +130,7 @@ class TimestampedGeoJson(MacroElement):
 
     def __init__(self, data, transition_time=200, loop=True, auto_play=True,
                  add_last_point=True, period='P1D', min_speed=0.1, max_speed=10,
-                 loop_button=False, date_options='YYYY/MM/DD hh:mm:ss',
+                 loop_button=False, date_options='YYYY/MM/DD HH:mm:ss',
                  time_slider_drag_update=False, duration=None):
         super(TimestampedGeoJson, self).__init__()
         self._name = 'TimestampedGeoJson'

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -130,7 +130,7 @@ class TimestampedGeoJson(MacroElement):
 
     def __init__(self, data, transition_time=200, loop=True, auto_play=True,
                  add_last_point=True, period='P1D', min_speed=0.1, max_speed=10,
-                 loop_button=False, date_options='YYYY/MM/DD HH:mm:ss',
+                 loop_button=False, date_options='YYYY-MM-DD HH:mm:ss',
                  time_slider_drag_update=False, duration=None):
         super(TimestampedGeoJson, self).__init__()
         self._name = 'TimestampedGeoJson'


### PR DESCRIPTION
According to the document of moment.js https://momentjs.com/docs/#/displaying/format/ , `hh` shows hours in 01 to 12, while `HH` shows hours in 00 to 23.
The original code use `hh` to display hour, and it causes the time `14:00` shown as `02:00`. It's a pretty weird and misleading default option.
I think displaying 24-hour clock with `HH` is a better choice.
Any suggestion or anything else I need to do?