### PR TITLE
Replace undocumented strftime usage in TimesliderChoropleth example.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,7 @@ Bug Fixes
 - Fix disappearing layer control when using FastMarkerCluster (conengmo #866)
 - Host heatmap.js to circumvent adblockers (conengmo #886)
 - Fix permission error in Map._to_png() due to tempfile (conengmo #887)
+- Replace strftime use in TimesliderChoropleth example (conengmo #919)
 
 0.5.0
 ~~~~~

--- a/examples/TimeSliderChoropleth.ipynb
+++ b/examples/TimeSliderChoropleth.ipynb
@@ -258,7 +258,7 @@
     "assert n_sample < n_periods\n",
     "\n",
     "datetime_index = pd.date_range('2016-1-1', periods=n_periods, freq='M')\n",
-    "dt_index_epochs = datetime_index.astype(np.int64) // 10**9\n",
+    "dt_index_epochs = datetime_index.astype(int) // 10**9\n",
     "dt_index = dt_index_epochs.astype('U10')\n",
     "\n",
     "dt_index"

--- a/examples/TimeSliderChoropleth.ipynb
+++ b/examples/TimeSliderChoropleth.ipynb
@@ -257,9 +257,9 @@
     "\n",
     "assert n_sample < n_periods\n",
     "\n",
-    "dt_index = pd.date_range(\n",
-    "    '2016-1-1', periods=n_periods, freq='M'\n",
-    ").strftime('%s')\n",
+    "datetime_index = pd.date_range('2016-1-1', periods=n_periods, freq='M')\n",
+    "dt_index_epochs = datetime_index.astype(np.int64) // 10**9\n",
+    "dt_index = dt_index_epochs.astype('U10')\n",
     "\n",
     "dt_index"
    ]

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -8,6 +8,7 @@ Folium _repr_*_ Tests
 
 from __future__ import (absolute_import, division, print_function)
 
+import sys
 import io
 
 import PIL.Image
@@ -50,6 +51,8 @@ def test__repr_png_is_bytes():
     assert isinstance(png, bytes)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 0),
+                    reason="Doesn't work on Python 2.7.")
 def test_valid_png():
     png = make_map(png_enabled=True)._repr_png_()
     img = PIL.Image.open(io.BytesIO(png))


### PR DESCRIPTION
The use of `.strftime('%s')` on datetime objects is [undocumented and system dependent](https://stackoverflow.com/questions/11743019/convert-python-datetime-to-epoch-with-strftime). This can lead to unexpected behavior. So [as an alternative](https://stackoverflow.com/questions/15203623/convert-pandas-datetimeindex-to-unix-time) we can convert the Pandas DateTimeIndex object to epoch timestamps and then to strings, which leads to the same result.

Closes #855.