### PR TITLE
Ignore the failing PNG test on Python 2.7

### DIFF
--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -8,6 +8,7 @@ Folium _repr_*_ Tests
 
 from __future__ import (absolute_import, division, print_function)
 
+import sys
 import io
 
 import PIL.Image
@@ -50,6 +51,8 @@ def test__repr_png_is_bytes():
     assert isinstance(png, bytes)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 0),
+                    reason="Doesn't work on Python 2.7.")
 def test_valid_png():
     png = make_map(png_enabled=True)._repr_png_()
     img = PIL.Image.open(io.BytesIO(png))


### PR DESCRIPTION
Currently Travis fails all PR's because `test_valid_png()` fails in Python 2.7. Something with a temporary file being closed prematurely in the Selenium phantomjs driver.  I don't think it's worth trying to fix this since:

* it seems an issue in Selenium
* Python 2.7 should be deprecated
* phantomjs has already been deprecated

So I think the best solution is to ignore the test for now in Python 2.7.