### PR TITLE
Fix wrong default value for fmt argument in WmsTileLayer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,11 @@
 
 - Update leaflet to 1.3.4 (ocefpaf #939)
 - More options (tms, opacity, kwargs) in TileLayer (mpickering #948)
+- Add MousePosition plugin (btozer #916)
+
+Bug Fixes
+
+- Fix wrong default value for fmt argument of WmsTileLayer (conengmo #950)
 
 
 0.6.0

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -176,7 +176,7 @@ class WmsTileLayer(Layer):
         """)  # noqa
 
     def __init__(self, url, name=None, layers='', styles='',
-                 fmt='image/jpg', transparent=False, version='1.1.1',
+                 fmt='image/jpeg', transparent=False, version='1.1.1',
                  attr='', overlay=True, control=True, show=True, **kwargs):
         super(WmsTileLayer, self).__init__(overlay=overlay, control=control,
                                            name=name, show=show)


### PR DESCRIPTION
Closes #938.

The default value of the `fmt` argument in `WmsTileLayer` was changed by accident to `image/jpg` instead of `image/jpeg`. This PR restored it.