### PR TITLE
`show_in_browser()` method for folium.folium.Map

### DIFF
--- a/examples/OpenMapInBrowser.py
+++ b/examples/OpenMapInBrowser.py
@@ -1,0 +1,20 @@
+
+"""
+Uses plain python and opens the folium map in a browser window. No IPython, Jupyter or else is required.
+
+"""
+
+import numpy as np
+import folium
+from folium.plugins import HeatMap
+
+# create a dummy map
+data = (np.random.normal(size=(100, 3)) *
+        np.array([[1, 1, 1]]) +
+        np.array([[48, 5, 1]])).tolist()
+folium_map = folium.Map([48., 5.], tiles='stamentoner', zoom_start=6)
+HeatMap(data).add_to(folium_map)
+
+# open in in browser
+folium_map.show_in_browser()
+

--- a/folium/_server.py
+++ b/folium/_server.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+"""
+Simple HTTP server so we are able to show Maps in browser. Only works with python 3!.
+
+"""
+
+import sys
+if sys.version_info[0] < 3:
+    raise NotImplementedError('Only works with python 3!')
+
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from textwrap import dedent
+
+
+# Based on https://stackoverflow.com/a/38945907/3494126
+class TemporaryHTTPServer:
+    """
+    A simple, temporary http web server on the pure Python 3.
+
+    Parameters
+    ----------
+    host: str
+        Local address on which the page will be hosted, default is '127.0.0.1'
+    port: int
+        Corresponding port, default 7000
+    """
+    def __init__(self, host=None, port=None):
+        self.host = host or '127.0.0.1'
+        self.port = port or 7000
+
+        self.server_address = '{host}:{port}'.format(host=self.host, port=self.port)
+        self.full_server_address = 'http://' + self.server_address
+
+    def serve(self, html_data):
+        """
+        Serve html content in a suitable for us manner: allow to gracefully exit using ctrl+c and re-serve some other
+        content on the same host:port
+
+        """
+
+        # we need a request handler with a method `do_GET` which somehow is not provided in the baseline
+        class HTTPServerRequestHandler(BaseHTTPRequestHandler):
+            """
+            An handler of requests for the server, hosting HTML-pages.
+            """
+
+            def do_GET(self):
+                """Handle GET requests"""
+
+                # response from page
+                self.send_response(200)
+
+                # set up headers for pages
+                # content_type = 'text/{0}'.format(page_content_type)
+                self.send_header('Content-type', 'text/html')
+                self.end_headers()
+
+                # writing data on a page
+                self.wfile.write(bytes(html_data, encoding='utf'))
+
+                return
+
+        # create a temporary server
+        HTTPServer.allow_reuse_address = True
+        httpd = HTTPServer((self.host, self.port), HTTPServerRequestHandler)
+
+        # run the temporary http server with graceful exit option
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print('\n Closing the server.')
+            httpd.server_close()
+        except Exception:
+            raise
+
+    def open_html_in_browser(self, html_data=None):
+        """
+        Opens a browser window showing the html content
+
+        Parameters
+        ----------
+        html_data: str
+            Should be a valid html code
+
+        Examples
+        --------
+        
+        html_data = '''
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <title> Test Page </title>
+            </head>
+            <body>
+            <p> Seems to be working. Now give the function `open_html_in_browser` some content! </p>
+            </body>
+            </html>
+        '''
+
+        srvr = TemporaryHTTPServer()
+        srvr.open_html_in_browser(html_data)
+
+        """
+
+        # open the URL in a browser (if possible, in a new window)
+        webbrowser.open(self.full_server_address, new=2)
+
+        # print a user-friendly message
+        msg = '''
+            Your map is available at {link}. 
+            It should have been opened in your browser automatically.
+            Press ctrl+c to return.
+        '''.format(link=self.full_server_address)
+        print(dedent(msg))
+
+        # run server (this blocks the console!)
+        self.serve(html_data)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import tempfile
 import time
+import sys
 
 from branca.colormap import StepColormap
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
@@ -19,6 +20,7 @@ from folium.features import GeoJson, TopoJson
 from folium.map import FitBounds
 from folium.raster_layers import TileLayer
 from folium.utilities import _validate_location
+from folium._server import TemporaryHTTPServer
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -386,6 +388,25 @@ $(document).ready(objects_in_front);
             '</style>'), name='map_style')
 
         super(Map, self).render(**kwargs)
+
+    def show_in_browser(self, host='127.0.0.1', port=7000):
+        """
+        Displays the Map in the default web browser.
+
+        Parameters
+        ----------
+        host: str
+            Local address on which the Map will be hosted, default is '127.0.0.1'
+        port: int
+            Corresponding port, default 7000
+
+        """
+
+        if sys.version_info[0] < 3:
+            raise NotImplementedError('show_in_browser only works with python 3!')
+
+        srvr = TemporaryHTTPServer(host, port)
+        srvr.open_html_in_browser(self._repr_html_())
 
     def fit_bounds(self, bounds, padding_top_left=None,
                    padding_bottom_right=None, padding=None, max_zoom=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 altair
 cartopy
+descartes
 flake8
 flake8-builtins
 flake8-comprehensions
@@ -12,6 +13,7 @@ geopandas
 gpxpy
 ipykernel
 jupyter_client
+matplotlib
 mplleaflet
 nbconvert
 nbsphinx
@@ -20,7 +22,9 @@ pillow
 pycodestyle
 pytest
 selenium
+scipy
 sphinx
 twine
+owslib
 vega_datasets
 vincent


### PR DESCRIPTION
fixes #946

----

Adds `show_in_browser()` method for folium.folium.Map which should work even in a vanilla python, e.g. try:
```bash
python3 examples/OpenMapInBrowser.py
```

-----

I did not write any tests for the new functionality, as I am not quite sure how to test it. Suggestions welcome.
On the other hand, some tests were failing before I added any of my code, and some packages were missing in the `requirements-dev.txt`. I collected all the fixes here: #952 

-----

p.s. sorry for the branch name, this should work: 
```bash
git checkout 'show_in_browser()-method-for-folium.folium.Map'
```