### PR TITLE
Fix icon_create_function in MarkerCluster

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@
 Bug Fixes
 
 - Fix wrong default value for fmt argument of WmsTileLayer (conengmo #950)
+- Fix icon_create_function argument in MarkerCluster (conengmo #954)
 
 
 0.6.0

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -52,7 +52,7 @@ class MarkerCluster(Layer):
             {% macro script(this, kwargs) %}
             var {{this.get_name()}} = L.markerClusterGroup({{ this.options }});
             {%- if this.icon_create_function is not none %}
-            {{ this.get_name() }}.options.iconCreateFunction = 
+            {{ this.get_name() }}.options.iconCreateFunction =
                 {{ this.icon_create_function.strip() }};
             {%- endif %}
             {{this._parent.get_name()}}.addLayer({{this.get_name()}});

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -51,6 +51,10 @@ class MarkerCluster(Layer):
     _template = Template(u"""
             {% macro script(this, kwargs) %}
             var {{this.get_name()}} = L.markerClusterGroup({{ this.options }});
+            {%- if this.icon_create_function is not none %}
+            {{ this.get_name() }}.options.iconCreateFunction = 
+                {{ this.icon_create_function.strip() }};
+            {%- endif %}
             {{this._parent.get_name()}}.addLayer({{this.get_name()}});
             {% endmacro %}
             """)
@@ -73,9 +77,10 @@ class MarkerCluster(Layer):
                 self.add_child(Marker(location, popup=p, icon=i))
 
         options = {} if options is None else options
-        if icon_create_function is not None:
-            options['iconCreateFunction'] = icon_create_function.strip()
         self.options = json.dumps(options, sort_keys=True, indent=2)
+        if icon_create_function is not None:
+            assert isinstance(icon_create_function, str)
+        self.icon_create_function = icon_create_function
 
     @staticmethod
     def _validate(obj, cls):


### PR DESCRIPTION
Closes #945.

- Insert the custom Javascript function `icon_create_function` directly to the template.
- Assert it has the correct type (str).
- Strip whitespaces around the Jinja2 blocks.