### PR TITLE
Tooltip Template string switch from single quotes to template literal.

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -361,8 +361,8 @@ class Tooltip(MacroElement):
     _template = Template(u"""
         {% macro script(this, kwargs) %}
         {{ this._parent.get_name() }}.bindTooltip(
-            '<div{% if this.style %} style="{{ this.style }}"{% endif %}>'
-            + '{{ this.text }}' + '</div>',
+            `<div{% if this.style %} style="{{ this.style }}"{% endif %}>`
+            + `{{ this.text }}` + `</div>`,
             {{ this.options }}
         );
         {% endmacro %}


### PR DESCRIPTION
I noticed a bug in the template due to concatenating strings with single quotes which were interrupted with other possessive single quotes. Switching these to template literals should address the issue.
I noticed this with the following string concatenation example from a dataset:

 `'<div>'
            + 'City: Saint John's<br>Country: Antigua and Barbuda<br>Continent: North America' + '</div>'`