### PR TITLE
Update TimeDimension.Control css-link on TimestampedGeoJson plugin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ Bug Fixes
 
 - Fix wrong default value for fmt argument of WmsTileLayer (conengmo #950)
 - Fix icon_create_function argument in MarkerCluster (conengmo #954)
-
+- Update stylesheet url in TimestampedGeoJson (frodebjerke #963)
 
 0.6.0
 ~~~~~

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -192,7 +192,7 @@ class TimestampedGeoJson(MacroElement):
             name='highlight.js_css')
 
         figure.header.add_child(
-            CssLink("http://apps.socib.es/Leaflet.TimeDimension/dist/leaflet.timedimension.control.min.css"),  # noqa
+            CssLink("https://cdn.rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css"),  # noqa
             name='leaflet.timedimension_css')
 
         figure.header.add_child(

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -105,7 +105,7 @@ def test_timestamped_geo_json():
     assert '<script src="https://rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>' in out
     assert '<script src="https://rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"></script>' in out  # noqa
     assert '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css"/>' in out  # noqa
-    assert '<link rel="stylesheet" href="http://apps.socib.es/Leaflet.TimeDimension/dist/leaflet.timedimension.control.min.css"/>' in out  # noqa
+    assert '<link rel="stylesheet" href="https://cdn.rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css"/>' in out  # noqa
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>' in out
 
     # Verify that the script is okay.


### PR DESCRIPTION
The styling of the TimeDimension Controller on the TimestampedGeoJson plugin was broken in my browser (chrome) due to the css-link being HTTP while running on an HTTPS site.

Used the content URL used in the [Leaflet.TimeDimension Readme](https://github.com/socib/Leaflet.TimeDimension#examples-and-basic-usage) instead.