### PR TITLE
Add Python 3.7 to the PyPI trove classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Scientific/Engineering :: Visualization',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
These must have been some glitch in the last release to PyPI because these trove classifiers should appear in the leftmost column in https://pypi.org/project/folium/ instead at the very bottom of the README.md txt.