### PR TITLE
Assert TimestampedGeoJson has Map as parent

### DIFF
--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -6,6 +6,7 @@ import json
 
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
+from folium.folium import Map
 from folium.utilities import iter_points, none_max, none_min
 
 from jinja2 import Template
@@ -166,6 +167,9 @@ class TimestampedGeoJson(MacroElement):
         self.options = json.dumps(options, sort_keys=True, indent=2)
 
     def render(self, **kwargs):
+        assert isinstance(self._parent, Map), (
+            'TimestampedGeoJson can only be added to a Map object.'
+        )
         super(TimestampedGeoJson, self).render()
 
         figure = self.get_root()


### PR DESCRIPTION
Closes #1038.

The docstring of TimestampedGeoJson states:

> Creates a TimestampedGeoJson plugin from timestamped GeoJSONs to append into a map with Map.add_child.

To prevent further confusion or questions about this I added a simple assert statement in the render method.