### PR TITLE
Draggable markers

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -221,6 +221,8 @@ class Marker(MacroElement):
         Display a text when hovering over the object.
     icon: Icon plugin
         the Icon plugin to use to render the marker.
+    draggable: bool, default False
+        Set to True to be able to drag the marker around the map.
 
     Returns
     -------
@@ -239,17 +241,23 @@ class Marker(MacroElement):
         var {{this.get_name()}} = L.marker(
             [{{this.location[0]}}, {{this.location[1]}}],
             {
-                icon: new L.Icon.Default()
+                icon: new L.Icon.Default(),
+                {%- if this.draggable %}
+                draggable: true,
+                autoPan: true,
+                {%- endif %}
                 }
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """)
 
-    def __init__(self, location, popup=None, tooltip=None, icon=None):
+    def __init__(self, location, popup=None, tooltip=None, icon=None,
+                 draggable=False):
         super(Marker, self).__init__()
         self._name = 'Marker'
         self.tooltip = tooltip
         self.location = _validate_coordinates(location)
+        self.draggable = draggable
         if icon is not None:
             self.add_child(icon)
         if isinstance(popup, text_type) or isinstance(popup, binary_type):

--- a/folium/map.py
+++ b/folium/map.py
@@ -255,7 +255,6 @@ class Marker(MacroElement):
                  draggable=False):
         super(Marker, self).__init__()
         self._name = 'Marker'
-        self.tooltip = tooltip
         self.location = _validate_coordinates(location)
         self.draggable = draggable
         if icon is not None:

--- a/tests/plugins/test_marker_cluster.py
+++ b/tests/plugins/test_marker_cluster.py
@@ -49,7 +49,7 @@ def test_marker_cluster():
             var {{marker.get_name()}} = L.marker(
                 [{{marker.location[0]}},{{marker.location[1]}}],
                 {
-                    icon: new L.Icon.Default()
+                    icon: new L.Icon.Default(),
                     }
                 )
                 .addTo({{this.get_name()}});


### PR DESCRIPTION
This PR adds a new argument to the `Marker` class. By setting `draggable=True` you can drag the markers around the map. I don't know if anybody really needs this behavior, but I thought it was kind of nice :)

If we think this feature is not necessary, we could consider to alter `Marker` to accept `**kwargs` and pass those as options to the Leaflet object.