### PR TITLE
Use Javascript template literals in DivIcon

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1092,7 +1092,7 @@ class DivIcon(MacroElement):
                     {% if this.icon_anchor %}iconAnchor: [{{this.icon_anchor[0]}},{{this.icon_anchor[1]}}],{% endif %}
                     {% if this.popup_anchor %}popupAnchor: [{{this.popup_anchor[0]}},{{this.popup_anchor[1]}}],{% endif %}
                     {% if this.className %}className: '{{this.className}}',{% endif %}
-                    {% if this.html %}html: '{{this.html}}',{% endif %}
+                    {% if this.html %}html: `{{this.html}}`,{% endif %}
                     });
                 {{this._parent.get_name()}}.setIcon({{this.get_name()}});
             {% endmacro %}


### PR DESCRIPTION
Using the code in `test_divicon()` actually doesn't result in a working map because of the newlines in the html. Using Javascript template literals in the `DivIcon` template solves this problem. We've already applied these with success in the `Popup` and `Tooltip` classes so I think it's good to also use them here.