### PR TITLE
Relaxing location data type restriction.

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -231,7 +231,7 @@ $(document).ready(objects_in_front);
         self._png_image = None
         self.png_enabled = png_enabled
 
-        if not location:
+        if location is None:
             # If location is not passed we center and zoom out.
             self.location = [0, 0]
             self.zoom_start = 1

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -12,6 +12,10 @@ from contextlib import contextmanager
 import copy
 import uuid
 import collections
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
 
 import numpy as np
 
@@ -23,9 +27,14 @@ _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard('')
 
 
+def _is_sized_iterable(arg):
+    """Validates the arg is Sized & Iterable"""
+    return isinstance(arg, abc.Sized) & isinstance(arg, abc.Iterable)
+
+
 def _validate_location(location):
     """Validates and formats location values before setting."""
-    if not isinstance(location, collections.abc.Collection):
+    if not _is_sized_iterable(location):
         raise TypeError('Expected a collection object for location, got '
                         '{!r}'.format(location))
     if len(location) != 2:
@@ -58,7 +67,7 @@ def _iter_tolist(x):
 
 def _flatten(container):
     for i in container:
-        if isinstance(i, collections.abc.Collection):
+        if _is_sized_iterable(i):
             for j in _flatten(i):
                 yield j
         else:

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -25,16 +25,16 @@ _VALID_URLS.discard('')
 
 def _validate_location(location):
     """Validates and formats location values before setting."""
-    if _isnan(location):
-        raise ValueError('Location values cannot contain NaNs, '
-                         'got {!r}'.format(location))
-    if isinstance(type(location), collections.abc.Iterable):
-        raise TypeError('Expected Iterable object for location, got '
+    if not isinstance(location, collections.abc.Collection):
+        raise TypeError('Expected a collection object for location, got '
                         '{!r}'.format(location))
-
     if len(location) != 2:
         raise ValueError('Expected two values for location [lat, lon], '
                          'got {}'.format(len(location)))
+    if _isnan(location):
+        raise ValueError('Location values cannot contain NaNs, '
+                         'got {!r}'.format(location))
+
     location = _iter_tolist(location)
     return location
 
@@ -58,7 +58,7 @@ def _iter_tolist(x):
 
 def _flatten(container):
     for i in container:
-        if isinstance(i, (list, tuple, np.ndarray)):
+        if isinstance(i, collections.abc.Collection):
             for j in _flatten(i):
                 yield j
         else:

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -28,8 +28,8 @@ def _validate_location(location):
     if _isnan(location):
         raise ValueError('Location values cannot contain NaNs, '
                          'got {!r}'.format(location))
-    if type(location) not in [list, tuple]:
-        raise TypeError('Expected tuple/list for location, got '
+    if isinstance(type(location), collections.abc.Iterable):
+        raise TypeError('Expected Iterable object for location, got '
                         '{!r}'.format(location))
 
     if len(location) != 2:

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -19,6 +19,7 @@ from folium.features import GeoJson, Choropleth
 import jinja2
 from jinja2 import Environment, PackageLoader
 
+import numpy as np
 import pandas as pd
 
 import pytest
@@ -60,6 +61,17 @@ def test_get_templates():
 
     env = branca.utilities.get_templates()
     assert isinstance(env, jinja2.environment.Environment)
+
+
+def test_location_args():
+    """Test some data types for a location arg."""
+    location = np.array([45.5236, -122.6750])
+    m = folium.Map(location)
+    assert m.location == [45.5236, -122.6750]
+
+    df = pd.DataFrame({"location": [45.5236, -122.6750]})
+    m = folium.Map(df["location"])
+    assert m.location == [45.5236, -122.6750]
 
 
 class TestFolium(object):
@@ -108,9 +120,9 @@ class TestFolium(object):
                     'name': 'TileLayer',
                     'id': '00000000000000000000000000000000',
                     'children': {}
-                    }
                 }
             }
+        }
 
     def test_cloudmade(self):
         """Test cloudmade tiles and the API key."""
@@ -197,7 +209,8 @@ class TestFolium(object):
 
         # Standard map.
         self.setup()
-        rendered = [line.strip() for line in self.m._parent.render().splitlines() if line.strip()]
+        rendered = [line.strip()
+                    for line in self.m._parent.render().splitlines() if line.strip()]
 
         html_templ = self.env.get_template('fol_template.html')
         attr = 'http://openstreetmap.org'
@@ -332,7 +345,7 @@ class TestFolium(object):
                                               'padding': (3, 3), },
                                              sort_keys=True),
             'this': fitbounds,
-            })
+        })
 
         assert ''.join(fit_bounds_rendered.split()) in ''.join(out.split())
 

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -120,9 +120,9 @@ class TestFolium(object):
                     'name': 'TileLayer',
                     'id': '00000000000000000000000000000000',
                     'children': {}
+                    }
                 }
             }
-        }
 
     def test_cloudmade(self):
         """Test cloudmade tiles and the API key."""
@@ -209,8 +209,7 @@ class TestFolium(object):
 
         # Standard map.
         self.setup()
-        rendered = [line.strip()
-                    for line in self.m._parent.render().splitlines() if line.strip()]
+        rendered = [line.strip() for line in self.m._parent.render().splitlines() if line.strip()]
 
         html_templ = self.env.get_template('fol_template.html')
         attr = 'http://openstreetmap.org'
@@ -345,7 +344,7 @@ class TestFolium(object):
                                               'padding': (3, 3), },
                                              sort_keys=True),
             'this': fitbounds,
-        })
+            })
 
         assert ''.join(fit_bounds_rendered.split()) in ''.join(out.split())
 


### PR DESCRIPTION
Currently, `folium.Map(location)` requires location data to be an instance of _list_ or _tuple_. I felt it to be inconvenient since neither numpy's array nor pandas' DataFrame cannot be used  as a _location_ argument directly. In this PR, I'm trying to relax the restriction so that any iterable object with `len(location)==2` can be accepted.