### PR TITLE
Use jquery.com CDN instead of Google

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -25,7 +25,7 @@ _default_js = [
     ('leaflet',
      'https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.js'),
     ('jquery',
-     'https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js'),
+     'https://code.jquery.com/jquery-1.12.4.min.js'),
     ('bootstrap',
      'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'),
     ('awesome_markers',

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -3,7 +3,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <script>L_PREFER_CANVAS=false; L_NO_TOUCH=false; L_DISABLE_3D=false;</script>
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.css"/>


### PR DESCRIPTION
Closes #1085. Use jQuery's own CDN instead of Googles so folium is more easy to use in China.