### PR TITLE
Make the next release the last Py2 version

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -53,10 +53,10 @@ if tuple(int(x) for x in branca.__version__.split('.')[:2]) < (0, 3):
 
 if sys.version_info < (3, 0):
     warnings.warn(
-        ('folium will stop working with Python 2.7 starting Jan. 1, 2019.'
-         ' Please transition to Python 3 before this time.'
+        ('This version of folium is the last to support Python 2.'
+         ' Transition to Python 3 to be able to receive updates and fixes.'
          ' Check out https://python3statement.org/ for more info.'),
-        PendingDeprecationWarning
+        UserWarning
     )
 
 __version__ = get_versions()['version']


### PR DESCRIPTION
Good news, the number of Py2 users of folium is dropping since January. Seems our pending deprecation warning has had effect. I got this graph from https://pypistats.org/packages/folium

![image](https://user-images.githubusercontent.com/33519926/54072325-a3e9df00-4279-11e9-9883-4ce222c5ffde.png)

Note that it's still at 25 %, not an insignificant amount.

I propose we make the next release the last to support Python 2. To make sure the message is heard I upgraded the warning to a `UserWarning`, which means it will show on all systems by default.

Then for the release after that we have to make sure users cannot install it on Python 2. More on how to achieve that here: https://python3statement.org/practicalities/