### PR TITLE
Icon: warn for wrong color value

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -10,6 +10,8 @@ from __future__ import (absolute_import, division, print_function)
 import json
 from collections import OrderedDict
 
+import warnings
+
 from branca.element import CssLink, Element, Figure, Html, JavascriptLink, MacroElement  # noqa
 
 from folium.utilities import _validate_coordinates, camelize, get_bounds
@@ -193,11 +195,19 @@ class Icon(MacroElement):
                 {{this._parent.get_name()}}.setIcon({{this.get_name()}});
             {% endmacro %}
             """)
+    color_options = {'red', 'darkred',  'lightred', 'orange', 'beige',
+                     'green', 'darkgreen', 'lightgreen',
+                     'blue', 'darkblue', 'cadetblue', 'lightblue',
+                     'purple',  'darkpurple', 'pink',
+                     'white', 'gray', 'lightgray' 'black'}
 
     def __init__(self, color='blue', icon_color='white', icon='info-sign',
                  angle=0, prefix='glyphicon'):
         super(Icon, self).__init__()
         self._name = 'Icon'
+        if color not in self.color_options:
+            warnings.warn('color argument of Icon should be one of: {}.'
+                          .format(self.color_options), stacklevel=2)
         self.color = color
         self.icon = icon
         self.icon_color = icon_color

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -8,8 +8,10 @@ Folium map Tests
 
 from __future__ import (absolute_import, division, print_function)
 
+import pytest
+
 from folium import Map
-from folium.map import Popup
+from folium.map import Popup, Icon
 
 
 tmpl = u"""
@@ -87,3 +89,17 @@ def test_popup_show():
                html_name=list(popup.html._children.keys())[0],
                map_name=m.get_name())
     assert _normalize(rendered) == _normalize(expected)
+
+
+def test_icon_valid_marker_colors():
+    with pytest.warns(None) as record:
+        for color in Icon.color_options:
+            Icon(color=color)
+    assert len(record) == 0
+
+
+@pytest.mark.filterwarnings('ignore::UserWarning')
+def test_icon_invalid_marker_colors():
+    pytest.warns(UserWarning, Icon, color='lila')
+    pytest.warns(UserWarning, Icon, color=42)
+    pytest.warns(UserWarning, Icon, color=None)


### PR DESCRIPTION
The `Icon` class has two color arguments: one for the marker, one for the icon. The color for the icon can be a color name or any hex color. The color for the marker must be one of a set of values, otherwise the color will default to red.

This PR adds a check on the color argument a user provides. If it is not in the set of allowed colors, a warning is raised. 

I used a warning instead of an exception because even with a wrong color value the map will render normally and it will display without errors. The color will just not be as expected.