### PR TITLE
Prevent installing 0.9 on dropped Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
 matrix:
   fast_finish: true
   include:
-  - name: legacy-python
-    env: PY=2.7
   - name: default
     env: PY=3.7
   - name: notebooks-conding-standard
@@ -63,11 +61,6 @@ script:
     fi
 
   - if [[ $TRAVIS_JOB_NAME == 'default' ]]; then
-      pytest /tmp -vv --ignore=tests/notebooks/test_notebooks.py ;
-    fi
-
-  - if [[ $TRAVIS_JOB_NAME == 'legacy-python' ]]; then
-      conda install mock ;
       pytest /tmp -vv --ignore=tests/notebooks/test_notebooks.py ;
     fi
 

--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -47,20 +47,32 @@ from folium.map import (
 from folium.raster_layers import TileLayer, WmsTileLayer
 from folium.vector_layers import Circle, CircleMarker, PolyLine, Polygon, Rectangle
 
+__version__ = get_versions()['version']
+del get_versions
+
 if tuple(int(x) for x in branca.__version__.split('.')[:2]) < (0, 3):
     raise ImportError('branca version 0.3.0 or higher is required. '
                       'Update branca with e.g. `pip install branca --upgrade`.')
 
 if sys.version_info < (3, 0):
-    warnings.warn(
-        ('This version of folium is the last to support Python 2.'
-         ' Transition to Python 3 to be able to receive updates and fixes.'
-         ' Check out https://python3statement.org/ for more info.'),
-        UserWarning
-    )
-
-__version__ = get_versions()['version']
-del get_versions
+    raise ImportError(
+        """You are running folium {} on Python 2
+    
+    folium 0.9 and above are no longer compatible with Python 2, but somehow
+    you got this version anyway. Make sure you have pip >= 9.0 to avoid this
+    kind of issue, as well as setuptools >= 24.2:
+    
+     $ pip install pip setuptools --upgrade
+    
+    Your choices:
+    
+    - Upgrade to Python 3.
+    
+    - Install an older version of folium:
+    
+     $ pip install 'folium<9.0'
+    
+    """.format(__version__))  # noqa
 
 __all__ = [
     'Choropleth',

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,28 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
+import sys
 from setuptools import setup
 
 import versioneer
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
+
+if sys.version_info < (3, 5):
+    error = """
+    folium 0.9+ supports Python 3.5 and above.
+    When using Python 2.7, please install folium 0.8.*.
+
+    See folium `README.rst` file for more information:
+
+    https://github.com/python-visualization/folium/blob/master/README.rst
+
+    Python {py} detected.
+
+    Try upgrading pip and retry.
+    """.format(py='.'.join([str(v) for v in sys.version_info[:3]]))
+    print(error, file=sys.stderr)
+    sys.exit(1)
 
 
 def read(*parts):
@@ -60,8 +77,6 @@ setup(
     url='https://github.com/python-visualization/folium',
     keywords='data visualization',
     classifiers=[
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -73,6 +88,7 @@ setup(
     platforms="any",
     packages=packages,
     package_data=package_data,
+    python_requires='>=3.5',
     extras_require={"testing": ["pytest"]},
     install_requires=install_requires,
     zip_safe=False,


### PR DESCRIPTION
* Use pip's `python_requires` argument should work for users with fairly recent pip version.
* Otherwise raise an exception in `setup.py` when it is executed by an old Python version.
* As a final catch raise an exception on importing folium when the Python version is lower than 3.

This is from the guidelines from https://python3statement.org/practicalities/