### PR TITLE
Use Jinja2 `tojson` filter

### DIFF
--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -2,8 +2,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import Figure, JavascriptLink
 
 from folium import Marker
@@ -34,14 +32,13 @@ class AntPath(Marker):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                {{this.get_name()}} = L.polyline.antPath(
-                  {{this.location}},
-                  {{ this.options }}
-                )
-                .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)  # noqa
+        {% macro script(this, kwargs) %}
+            {{ this.get_name() }} = L.polyline.antPath(
+              {{ this.location|tojson }},
+              {{ this.options|tojson }}
+        ).addTo({{this._parent.get_name()}});
+        {% endmacro %}
+        """)
 
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super(AntPath, self).__init__(
@@ -52,8 +49,8 @@ class AntPath(Marker):
 
         self._name = 'AntPath'
         # Polyline + AntPath defaults.
-        options = path_options(line=True, **kwargs)
-        options.update({
+        self.options = path_options(line=True, **kwargs)
+        self.options.update({
             'paused': kwargs.pop('paused', False),
             'reverse': kwargs.pop('reverse', False),
             'hardwareAcceleration': kwargs.pop('hardware_acceleration', False),
@@ -64,7 +61,6 @@ class AntPath(Marker):
             'color': kwargs.pop('color', '#0000FF'),
             'pulseColor': kwargs.pop('pulse_color', '#FFFFFF'),
         })
-        self.options = json.dumps(options, sort_keys=True, indent=2)
 
     def render(self, **kwargs):
         super(AntPath, self).render()

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -2,13 +2,11 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
-from jinja2 import Template
+from folium.utilities import parse_options
 
-from six import iteritems
+from jinja2 import Template
 
 
 class BeautifyIcon(MacroElement):
@@ -48,37 +46,37 @@ class BeautifyIcon(MacroElement):
     >>> BeautifyIcon(icon='arrow-down', icon_shape='marker').add_to(marker)
 
     """
+    _template = Template(u"""
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = new L.BeautifyIcon.icon(
+                {{ this.options|tojson }}
+            )
+            {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
+        {% endmacro %}
+        """)
     ICON_SHAPE_TYPES = ['circle', 'circle-dot', 'doughnut', 'rectangle-dot',
                         'marker', None]
 
-    def __init__(self, icon=None, icon_shape=None, border_width=3, border_color='#000', text_color='#000',
+    def __init__(self, icon=None, icon_shape=None, border_width=3,
+                 border_color='#000', text_color='#000',
                  background_color='#FFF', inner_icon_style='', spin=False,
-                 number=None):
+                 number=None, **kwargs):
         super(BeautifyIcon, self).__init__()
         self._name = 'BeautifyIcon'
 
-        options = {
-            'icon': icon,
-            'iconShape': icon_shape,
-            'borderWidth': border_width,
-            'borderColor': border_color,
-            'textColor': text_color,
-            'backgroundColor': background_color,
-            'innerIconStyle': inner_icon_style,
-            'spin': spin,
-            'isAlphaNumericIcon': number is not None,
-            'text': number
-        }
-        # Must remove key/values where the value is None/undefined
-        options = {k: v for k, v in iteritems(options) if v is not None}
-        self.options = json.dumps(options, sort_keys=True, indent=2)
-
-        self._template = Template(u"""
-            {% macro script(this, kwargs) %}
-                var {{this.get_name()}} = new L.BeautifyIcon.icon({{ this.options }})
-                {{this._parent.get_name()}}.setIcon({{this.get_name()}});
-            {% endmacro %}
-            """)
+        self.options = parse_options(
+            icon=icon,
+            icon_shape=icon_shape,
+            border_width=border_width,
+            border_color=border_color,
+            text_color=text_color,
+            background_color=background_color,
+            inner_icon_style=inner_icon_style,
+            spin=spin,
+            isAlphaNumericIcon=number is not None,
+            text=number,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         super(BeautifyIcon, self).render(**kwargs)

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -2,50 +2,50 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import Figure, JavascriptLink
 
 from folium.map import Marker
-from folium.utilities import _validate_location
+from folium.utilities import _validate_location, parse_options
 
 from jinja2 import Template
 
 
 class BoatMarker(Marker):
-    """
-    Creates a BoatMarker plugin to append into a map with
-    Map.add_plugin.
+    """Add a Marker in the shape of a boat.
 
     Parameters
     ----------
     location: tuple of length 2, default None
         The latitude and longitude of the marker.
         If None, then the middle of the map is used.
-
     heading: int, default 0
         Heading of the boat to an angle value between 0 and 360 degrees
-
     wind_heading: int, default None
         Heading of the wind to an angle value between 0 and 360 degrees
         If None, then no wind is represented.
-
     wind_speed: int, default 0
         Speed of the wind in knots.
 
+    https://github.com/thomasbrueggemann/leaflet.boatmarker
+
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                var {{this.get_name()}} = L.boatMarker(
-                    [{{this.location[0]}},{{this.location[1]}}],
-                    {{this.kwargs}}).addTo({{this._parent.get_name()}});
-                {% if this.wind_heading is not none -%}
-                {{this.get_name()}}.setHeadingWind({{this.heading}}, {{this.wind_speed}}, {{this.wind_heading}});
-                {% else -%}
-                {{this.get_name()}}.setHeading({{this.heading}});
-                {% endif -%}
-            {% endmacro %}
-            """)  # noqa
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.boatMarker(
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+            {% if this.wind_heading is not none -%}
+            {{ this.get_name() }}.setHeadingWind(
+                {{ this.heading }},
+                {{ this.wind_speed }},
+                {{ this.wind_heading }}
+            );
+            {% else -%}
+            {{this.get_name()}}.setHeading({{this.heading}});
+            {% endif -%}
+        {% endmacro %}
+        """)
 
     def __init__(self, location, popup=None, icon=None,
                  heading=0, wind_heading=None, wind_speed=0, **kwargs):
@@ -58,7 +58,7 @@ class BoatMarker(Marker):
         self.heading = heading
         self.wind_heading = wind_heading
         self.wind_speed = wind_speed
-        self.kwargs = json.dumps(kwargs)
+        self.options = parse_options(**kwargs)
 
     def render(self, **kwargs):
         super(BoatMarker, self).render(**kwargs)

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
 from __future__ import (absolute_import, division, print_function)
-
-import json
 
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
 
@@ -20,15 +17,16 @@ class Draw(MacroElement):
         Add a small button that exports the drawn shapes as a geojson file.
     filename : string, default 'data.geojson'
         Name of geojson file
-    position : string, default 'topleft'
-        Position of control. It can be one of 'topleft', 'toprigth', 'bottomleft', 'bottomright'
+    position : {'topleft', 'toprigth', 'bottomleft', 'bottomright'}
+        Position of control.
         See https://leafletjs.com/reference-1.4.0.html#control
     draw_options : dict, optional
-        The options used to configure the draw toolbar
-        See http://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions
+        The options used to configure the draw toolbar. See
+        http://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions
     edit_options : dict, optional
-        The options used to configure the edit toolbar
-        See https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#editpolyoptions
+        The options used to configure the edit toolbar. See
+        https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#editpolyoptions
+
     Examples
     --------
     >>> m = folium.Map()
@@ -45,41 +43,46 @@ class Draw(MacroElement):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
+        {% macro script(this, kwargs) %}
             var options = {
-              position: "{{this.position}}",
-              draw: {{this.draw_options}},
-              edit: {{this.edit_options}}
+              position: {{ this.position|tojson }},
+              draw: {{ this.draw_options }},
+              edit: {{ this.edit_options }},
             }
             // FeatureGroup is to store editable layers.
-            var drawnItems = new L.featureGroup().addTo({{this._parent.get_name()}});
-            options.edit.featureGroup = drawnItems
-            var {{this.get_name()}} = new L.Control.Draw(options).addTo({{this._parent.get_name()}})
-            {{this._parent.get_name()}}.on(L.Draw.Event.CREATED, function (event) {
-              var layer = event.layer,
-                  type = event.layerType,
-                  coords;
-              var coords = JSON.stringify(layer.toGeoJSON());
-              layer.on('click', function() {
-                alert(coords);
-                console.log(coords);
+            var drawnItems = new L.featureGroup().addTo(
+                {{ this._parent.get_name() }}
+            );
+            options.edit.featureGroup = drawnItems;
+            var {{ this.get_name() }} = new L.Control.Draw(
+                options
+            ).addTo( {{this._parent.get_name()}} );
+            {{ this._parent.get_name() }}.on(L.Draw.Event.CREATED, function(e) {
+                var layer = e.layer,
+                    type = e.layerType;
+                var coords = JSON.stringify(layer.toGeoJSON());
+                layer.on('click', function() {
+                    alert(coords);
+                    console.log(coords);
                 });
-               drawnItems.addLayer(layer);
+                drawnItems.addLayer(layer);
              });
-            {{this._parent.get_name()}}.on('draw:created', function(e) {
+            {{ this._parent.get_name() }}.on('draw:created', function(e) {
                 drawnItems.addLayer(e.layer);
             });
             document.getElementById('export').onclick = function(e) {
-              var data = drawnItems.toGeoJSON();
-              var convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(data));
-              document.getElementById('export').setAttribute('href', 'data:' + convertedData);
-              document.getElementById('export').setAttribute(
-                'download',
-                "{{this.filename}}"
-              );
+                var data = drawnItems.toGeoJSON();
+                var convertedData = 'text/json;charset=utf-8,'
+                    + encodeURIComponent(JSON.stringify(data));
+                document.getElementById('export').setAttribute(
+                    'href', 'data:' + convertedData
+                );
+                document.getElementById('export').setAttribute(
+                    'download', {{ this.filename|tojson }}"
+                );
             }
-            {% endmacro %}
-            """)
+        {% endmacro %}
+        """)
 
     def __init__(self, export=False, filename='data.geojson',
                  position='topleft', draw_options=None, edit_options=None):
@@ -88,8 +91,8 @@ class Draw(MacroElement):
         self.export = export
         self.filename = filename
         self.position = position
-        self.draw_options = json.dumps(draw_options or {})
-        self.edit_options = json.dumps(edit_options or {})
+        self.draw_options = draw_options or {}
+        self.edit_options = edit_options or {}
 
     def render(self, **kwargs):
         super(Draw, self).render(**kwargs)
@@ -103,23 +106,25 @@ class Draw(MacroElement):
         figure.header.add_child(
             CssLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css'))  # noqa
 
-        export_style = """<style>
-        #export {
-            position: absolute;
-            top: 5px;
-            right: 10px;
-            z-index: 999;
-            background: white;
-            color: black;
-            padding: 6px;
-            border-radius: 4px;
-            font-family: 'Helvetica Neue';
-            cursor: pointer;
-            font-size: 12px;
-            text-decoration: none;
-            top: 90px;
-        }
-        </style>"""
+        export_style = """
+            <style>
+                #export {
+                    position: absolute;
+                    top: 5px;
+                    right: 10px;
+                    z-index: 999;
+                    background: white;
+                    color: black;
+                    padding: 6px;
+                    border-radius: 4px;
+                    font-family: 'Helvetica Neue';
+                    cursor: pointer;
+                    font-size: 12px;
+                    text-decoration: none;
+                    top: 90px;
+                }
+            </style>
+        """
         export_button = """<a href='#' id='export'>Export</a>"""
         if self.export:
             figure.header.add_child(Element(export_style), name='export')

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -16,6 +16,8 @@ class DualMap(MacroElement):
 
     Parameters
     ----------
+    location: tuple or list, optional
+        Latitude and longitude of center point of the maps.
     layout : {'horizontal', 'vertical'}
         Select how the two maps should be positioned. Either horizontal (left
         and right) or vertical (top and bottom).
@@ -37,8 +39,8 @@ class DualMap(MacroElement):
 
     _template = Template("""
         {% macro script(this, kwargs) %}
-        {{ this.m1.get_name() }}.sync({{ this.m2.get_name() }});
-        {{ this.m2.get_name() }}.sync({{ this.m1.get_name() }});
+            {{ this.m1.get_name() }}.sync({{ this.m2.get_name() }});
+            {{ this.m2.get_name() }}.sync({{ this.m1.get_name() }});
         {% endmacro %}
     """)
 

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -37,19 +37,18 @@ class FastMarkerCluster(MarkerCluster):
         Whether the Layer will be included in LayerControls.
     show: bool, default True
         Whether the layer will be shown on opening (only for overlays).
-    options : dict, default None
-        A dictionary with options for Leaflet.markercluster. See
+    **kwargs
+        Additional arguments are passed to Leaflet.markercluster. See
         https://github.com/Leaflet/Leaflet.markercluster for options.
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-
+        {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = (function(){
-                {{this._callback}}
+                {{ this._callback }}
 
-                var data = {{ this._data }};
-                var cluster = L.markerClusterGroup({{ this.options }});
+                var data = {{ this._data|tojson }};
+                var cluster = L.markerClusterGroup({{ this.options|tojson }});
 
                 for (var i = 0; i < data.length; i++) {
                     var row = data[i];
@@ -60,13 +59,15 @@ class FastMarkerCluster(MarkerCluster):
                 cluster.addTo({{ this._parent.get_name() }});
                 return cluster;
             })();
-            {% endmacro %}""")
+        {% endmacro %}""")
 
     def __init__(self, data, callback=None, options=None,
-                 name=None, overlay=True, control=True, show=True):
+                 name=None, overlay=True, control=True, show=True, **kwargs):
+        if options is not None:
+            kwargs.update(options)  # options argument is legacy
         super(FastMarkerCluster, self).__init__(name=name, overlay=overlay,
                                                 control=control, show=show,
-                                                options=options)
+                                                **kwargs)
         self._name = 'FastMarkerCluster'
         self._data = _validate_coordinates(data)
 

--- a/folium/plugins/feature_group_sub_group.py
+++ b/folium/plugins/feature_group_sub_group.py
@@ -21,7 +21,6 @@ class FeatureGroupSubGroup(Layer):
     ----------
     group : Layer
         The MarkerCluster or FeatureGroup containing this subgroup.
-
     name : string, default None
         The name of the Layer, as it will appear in LayerControls
     overlay : bool, default True
@@ -59,11 +58,13 @@ class FeatureGroupSubGroup(Layer):
     >>> folium.LayerControl().add_to(m)
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-            var {{this.get_name()}} = L.featureGroup.subGroup({{this._group.get_name()}});
-            {{this.get_name()}}.addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.featureGroup.subGroup(
+                {{ this._group.get_name() }}
+            );
+            {{ this.get_name() }}.addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
     def __init__(self, group, name=None, overlay=True, control=True, show=True):
         super(FeatureGroupSubGroup, self).__init__(name=name, overlay=overlay,

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division, print_function)
 
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
+from folium.utilities import parse_options
+
 from jinja2 import Template
 
 
@@ -14,44 +16,41 @@ class Fullscreen(MacroElement):
     Parameters
     ----------
     position : str
-          change the position of the button can be:
-          'topleft', 'topright', 'bottomright' or 'bottomleft'
-          default: 'topleft'
+        change the position of the button can be:
+        'topleft', 'topright', 'bottomright' or 'bottomleft'
+        default: 'topleft'
     title : str
-          change the title of the button,
-          default: 'Full Screen'
+        change the title of the button,
+        default: 'Full Screen'
     title_cancel : str
-          change the title of the button when fullscreen is on,
-          default: 'Exit Full Screen'
-    force_separate_button : boolean
-          force seperate button to detach from zoom buttons,
-          default: False
+        change the title of the button when fullscreen is on,
+        default: 'Exit Full Screen'
+    force_separate_button : bool, default False
+        force seperate button to detach from zoom buttons,
+
     See https://github.com/brunob/leaflet.fullscreen for more information.
 
     """
     _template = Template("""
         {% macro script(this, kwargs) %}
-            L.control.fullscreen({
-                position: '{{this.position}}',
-                title: '{{this.title}}',
-                titleCancel: '{{this.title_cancel}}',
-                forceSeparateButton: {{this.force_separate_button}},
-                }).addTo({{this._parent.get_name()}});
-            {{this._parent.get_name()}}.on('enterFullscreen', function(){
-                console.log('entered fullscreen');
-            });
-
+            L.control.fullscreen(
+                {{ this.options|tojson }}
+            ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """)  # noqa
 
     def __init__(self, position='topleft', title='Full Screen',
-                 title_cancel='Exit Full Screen', force_separate_button=False):
+                 title_cancel='Exit Full Screen', force_separate_button=False,
+                 **kwargs):
         super(Fullscreen, self).__init__()
         self._name = 'Fullscreen'
-        self.position = position
-        self.title = title
-        self.title_cancel = title_cancel
-        self.force_separate_button = str(force_separate_button).lower()
+        self.options = parse_options(
+            position=position,
+            title=title,
+            title_cancel=title_cancel,
+            force_separate_button=force_separate_button,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         super(Fullscreen, self).render()

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -2,12 +2,16 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import Figure, JavascriptLink
 
 from folium.map import Layer
-from folium.utilities import _isnan, _iter_tolist, none_max, none_min
+from folium.utilities import (
+    _isnan,
+    _iter_tolist,
+    none_max,
+    none_min,
+    parse_options,
+)
 
 from jinja2 import Template
 
@@ -45,23 +49,16 @@ class HeatMap(Layer):
     """
     _template = Template(u"""
         {% macro script(this, kwargs) %}
-            var {{this.get_name()}} = L.heatLayer(
-                {{this.data}},
-                {
-                    minOpacity: {{this.min_opacity}},
-                    maxZoom: {{this.max_zoom}},
-                    max: {{this.max_val}},
-                    radius: {{this.radius}},
-                    blur: {{this.blur}},
-                    gradient: {{this.gradient}}
-                    })
-                .addTo({{this._parent.get_name()}});
+            var {{ this.get_name() }} = L.heatLayer(
+                {{ this.data|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """)
 
     def __init__(self, data, name=None, min_opacity=0.5, max_zoom=18,
                  max_val=1.0, radius=25, blur=15, gradient=None,
-                 overlay=True, control=True, show=True):
+                 overlay=True, control=True, show=True, **kwargs):
         super(HeatMap, self).__init__(name=name, overlay=overlay,
                                       control=control, show=show)
         data = _iter_tolist(data)
@@ -70,13 +67,15 @@ class HeatMap(Layer):
                              'got:\n{!r}'.format(data))
         self._name = 'HeatMap'
         self.data = [[x for x in line] for line in data]
-        self.min_opacity = min_opacity
-        self.max_zoom = max_zoom
-        self.max_val = max_val
-        self.radius = radius
-        self.blur = blur
-        self.gradient = (json.dumps(gradient, sort_keys=True) if
-                         gradient is not None else 'null')
+        self.options = parse_options(
+            min_opacity=min_opacity,
+            max_zoom=max_zoom,
+            max=max_val,
+            radius=radius,
+            blur=blur,
+            gradient=gradient,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         super(HeatMap, self).render(**kwargs)

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -2,35 +2,32 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+
+from folium.utilities import parse_options
 
 from jinja2 import Template
 
 
 class MeasureControl(MacroElement):
-    """
-    Adds a measurem widget on the map.
+    """ Add a measurement widget on the map.
 
     Parameters
     ----------
-    position: location of the widget
-        default is 'topright'.
-
-    primary_length_unit and secondary_length_unit: length units
-         defaults are 'meters' and 'miles' respectively.
-
-    primary_area_unit and secondary_area_unit: ara units
-        defaults are 'sqmeters' and 'acres' respectively.
+    position: str, default 'topright'
+        Location of the widget.
+    primary_length_unit: str, default 'meters'
+    secondary_length_unit: str, default 'miles'
+    primary_area_unit: str, default 'sqmeters'
+    secondary_area_unit: str, default 'acres'
 
     See https://github.com/ljagis/leaflet-measure for more information.
 
     """
     _template = Template("""
         {% macro script(this, kwargs) %}
-            var {{this.get_name()}} = new L.Control.Measure(
-            {{ this.options }});
+            var {{ this.get_name() }} = new L.Control.Measure(
+                {{ this.options|tojson }});
             {{this._parent.get_name()}}.addControl({{this.get_name()}});
 
         {% endmacro %}
@@ -38,19 +35,19 @@ class MeasureControl(MacroElement):
 
     def __init__(self, position='topright', primary_length_unit='meters',
                  secondary_length_unit='miles', primary_area_unit='sqmeters',
-                 secondary_area_unit='acres'):
-        """Coordinate, linear, and area measure control"""
+                 secondary_area_unit='acres', **kwargs):
+
         super(MeasureControl, self).__init__()
         self._name = 'MeasureControl'
 
-        options = {
-            'position': position,
-            'primaryLengthUnit': primary_length_unit,
-            'secondaryLengthUnit': secondary_length_unit,
-            'primaryAreaUnit': primary_area_unit,
-            'secondaryAreaUnit': secondary_area_unit,
-        }
-        self.options = json.dumps(options)
+        self.options = parse_options(
+            position=position,
+            primary_length_unit=primary_length_unit,
+            secondary_length_unit=secondary_length_unit,
+            primary_area_unit=primary_area_unit,
+            secondary_area_unit=secondary_area_unit,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         super(MeasureControl, self).render()

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -2,11 +2,10 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.raster_layers import TileLayer
+from folium.utilities import parse_options
 
 from jinja2 import Template
 
@@ -66,15 +65,15 @@ class MiniMap(MacroElement):
 
     _template = Template("""
         {% macro script(this, kwargs) %}
-
-        var {{ this.tile_layer.get_name() }} = L.tileLayer(
-        '{{ this.tile_layer.tiles }}',
-        {{ this.tile_layer.options }} );
-
-        var {{ this.get_name() }} = new L.Control.MiniMap( {{this.tile_layer.get_name()}},
-         {{ this.options }});
-        {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
-
+            var {{ this.tile_layer.get_name() }} = L.tileLayer(
+                {{ this.tile_layer.tiles|tojson }},
+                {{ this.tile_layer.options|tojson }}
+            );
+            var {{ this.get_name() }} = new L.Control.MiniMap(
+                {{ this.tile_layer.get_name() }},
+                {{ this.options|tojson }}
+            );
+            {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
         {% endmacro %}
     """)  # noqa
 
@@ -83,7 +82,7 @@ class MiniMap(MacroElement):
                  zoom_level_offset=-5, zoom_level_fixed=None,
                  center_fixed=False, zoom_animation=False,
                  toggle_display=False, auto_toggle_display=False,
-                 minimized=False):
+                 minimized=False, **kwargs):
 
         super(MiniMap, self).__init__()
         self._name = 'MiniMap'
@@ -95,21 +94,21 @@ class MiniMap(MacroElement):
         else:
             self.tile_layer = TileLayer(tile_layer)
 
-        options = {
-            'position': position,
-            'width': width,
-            'height': height,
-            'collapsedWidth': collapsed_width,
-            'collapsedHeight': collapsed_height,
-            'zoomLevelOffset': zoom_level_offset,
-            'zoomLevelFixed': zoom_level_fixed,
-            'centerFixed': center_fixed,
-            'zoomAnimation': zoom_animation,
-            'toggleDisplay': toggle_display,
-            'autoToggleDisplay': auto_toggle_display,
-            'minimized': minimized,
-        }
-        self.options = json.dumps(options, sort_keys=True, indent=2)
+        self.options = parse_options(
+            position=position,
+            width=width,
+            height=height,
+            collapsed_width=collapsed_width,
+            collapsed_height=collapsed_height,
+            zoom_level_offset=zoom_level_offset,
+            zoom_level_fixed=zoom_level_fixed,
+            center_fixed=center_fixed,
+            zoom_animation=zoom_animation,
+            toggle_display=toggle_display,
+            auto_toggle_display=auto_toggle_display,
+            minimized=minimized,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         figure = self.get_root()

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -2,9 +2,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+
+from folium.utilities import parse_options
 
 from jinja2 import Template
 
@@ -45,32 +45,33 @@ class MousePosition(MacroElement):
     """
     _template = Template("""
         {% macro script(this, kwargs) %}
-
-        var {{ this.get_name() }} = new L.Control.MousePosition(
-            {{ this.options }});
-        {{ this.get_name() }}.options["latFormatter"] = {{ this.lat_formatter }};
-        {{ this.get_name() }}.options["lngFormatter"] = {{ this.lng_formatter }};
-        {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
-
+            var {{ this.get_name() }} = new L.Control.MousePosition(
+                {{ this.options|tojson }}
+            );
+            {{ this.get_name() }}.options["latFormatter"] =
+                {{ this.lat_formatter }};
+            {{ this.get_name() }}.options["lngFormatter"] =
+                {{ this.lng_formatter }};
+            {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
         {% endmacro %}
-    """)  # noqa
+    """)
 
     def __init__(self, position='bottomright', separator=' : ',
                  empty_string='Unavailable', lng_first=False, num_digits=5,
-                 prefix='', lat_formatter=None, lng_formatter=None):
+                 prefix='', lat_formatter=None, lng_formatter=None, **kwargs):
 
         super(MousePosition, self).__init__()
         self._name = 'MousePosition'
 
-        options = {
-            'position': position,
-            'separator': separator,
-            'emptyString': empty_string,
-            'lngFirst': lng_first,
-            'numDigits': num_digits,
-            'prefix': prefix,
-        }
-        self.options = json.dumps(options, sort_keys=True, indent=2)
+        self.options = parse_options(
+            position=position,
+            separator=separator,
+            empty_string=empty_string,
+            lng_first=lng_first,
+            num_digits=num_digits,
+            prefix=prefix,
+            **kwargs
+        )
         self.lat_formatter = lat_formatter or 'undefined'
         self.lng_formatter = lng_formatter or 'undefined'
 

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import (absolute_import, division, print_function)
-import json
 
 from branca.element import Figure, JavascriptLink, MacroElement
 
 from folium.folium import Map
-from folium.utilities import get_obj_in_upper_tree
+from folium.utilities import get_obj_in_upper_tree, parse_options
 
 from jinja2 import Template
 
@@ -38,27 +37,28 @@ class StripePattern(MacroElement):
 
     _template = Template(u"""
         {% macro script(this, kwargs) %}
-        var {{ this.get_name() }} = new L.StripePattern(
-            {{ this.options }}
-        );
-        {{ this.get_name() }}.addTo({{ this.parent_map.get_name() }});
+            var {{ this.get_name() }} = new L.StripePattern(
+                {{ this.options|tojson }}
+            );
+            {{ this.get_name() }}.addTo({{ this.parent_map.get_name() }});
         {% endmacro %}
     """)
 
     def __init__(self, angle=.5, weight=4, space_weight=4,
                  color="#000000", space_color="#ffffff",
-                 opacity=0.75, space_opacity=0.0):
+                 opacity=0.75, space_opacity=0.0, **kwargs):
         super(StripePattern, self).__init__()
         self._name = 'StripePattern'
-        self.options = json.dumps({
-            'angle': angle,
-            'weight': weight,
-            'spaceWeight': space_weight,
-            'color': color,
-            'spaceColor': space_color,
-            'opacity': opacity,
-            'spaceOpacity': space_opacity
-        })
+        self.options = parse_options(
+            angle=angle,
+            weight=weight,
+            space_weight=space_weight,
+            color=color,
+            space_color=space_color,
+            opacity=opacity,
+            space_opacity=space_opacity,
+            **kwargs
+        )
         self.parent_map = None
 
     def render(self, **kwargs):
@@ -104,14 +104,14 @@ class CirclePattern(MacroElement):
 
     _template = Template(u"""
         {% macro script(this, kwargs) %}
-        var shape = new L.PatternCircle(
-            {{ this.options_pattern_circle }}
-        );
-        var {{this.get_name()}} = new L.Pattern(
-            {{ this.options_pattern }}
-        );
-        {{ this.get_name() }}.addShape(shape);
-        {{ this.get_name() }}.addTo({{ this.parent_map }});
+            var {{ this.get_name() }}_shape = new L.PatternCircle(
+                {{ this.options_pattern_circle|tojson }}
+            );
+            var {{ this.get_name() }} = new L.Pattern(
+                {{ this.options_pattern|tojson }}
+            );
+            {{ this.get_name() }}.addShape({{ this.get_name() }}_shape);
+            {{ this.get_name() }}.addTo({{ this.parent_map }});
         {% endmacro %}
     """)
 
@@ -120,21 +120,21 @@ class CirclePattern(MacroElement):
                  opacity=0.75, fill_opacity=0.5):
         super(CirclePattern, self).__init__()
         self._name = 'CirclePattern'
-        self.options_pattern_circle = json.dumps({
-            'x': radius + 2 * weight,
-            'y': radius + 2 * weight,
-            'weight': weight,
-            'radius': radius,
-            'color': color,
-            'fillColor': fill_color,
-            'opacity': opacity,
-            'fillOpacity': fill_opacity,
-            'fill': True,
-        })
-        self.options_pattern = json.dumps({
-            'width': width,
-            'height': height,
-        })
+        self.options_pattern_circle = parse_options(
+            x=radius + 2 * weight,
+            y=radius + 2 * weight,
+            weight=weight,
+            radius=radius,
+            color=color,
+            fill_color=fill_color,
+            opacity=opacity,
+            fill_opacity=fill_opacity,
+            fill=True,
+        )
+        self.options_pattern = parse_options(
+            width=width,
+            height=height,
+        )
         self.parent_map = None
 
     def render(self, **kwargs):

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 from branca.element import Figure, JavascriptLink
 
 from folium.features import MacroElement
+from folium.utilities import parse_options
 
 from jinja2 import Template
 
@@ -17,25 +18,18 @@ class PolyLineTextPath(MacroElement):
     ----------
     polyline: folium.features.PolyLine object
         The folium.features.PolyLine object to attach the text to.
-
     text: string
         The string to be attached to the polyline.
-
     repeat: bool, default False
         Specifies if the text should be repeated along the polyline.
-
     center: bool, default False
         Centers the text according to the polyline's bounding box
-
     below: bool, default False
         Show text below the path
-
     offset: int, default 0
         Set an offset to position text relative to the polyline.
-
     orientation: int, default 0
         Rotate text to a specified angle.
-
     attributes: dict
         Object containing the attributes applied to the text tag.
         Check valid attributes here:
@@ -46,30 +40,29 @@ class PolyLineTextPath(MacroElement):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                {{this.polyline.get_name()}}.setText("{{this.text}}", {
-                    repeat: {{'true' if this.repeat else 'false'}},
-                    center: {{'true' if this.center else 'false'}},
-                    below: {{'true' if this.below else 'false'}},
-                    offset: {{this.offset}},
-                    orientation: {{this.orientation}},
-                    attributes: {{this.attributes}}
-                });
-            {% endmacro %}
-            """)  # noqa
+        {% macro script(this, kwargs) %}
+            {{ this.polyline.get_name() }}.setText(
+                {{ this.text|tojson }},
+                {{ this.options|tojson }}
+            );
+        {% endmacro %}
+        """)
 
     def __init__(self, polyline, text, repeat=False, center=False, below=False,
-                 offset=0, orientation=0, attributes=None):
+                 offset=0, orientation=0, attributes=None, **kwargs):
         super(PolyLineTextPath, self).__init__()
         self._name = 'PolyLineTextPath'
         self.polyline = polyline
         self.text = text
-        self.repeat = bool(repeat)
-        self.center = bool(center)
-        self.below = bool(below)
-        self.orientation = orientation
-        self.offset = offset
-        self.attributes = attributes
+        self.options = parse_options(
+            repeat=repeat,
+            center=center,
+            below=below,
+            offset=offset,
+            orientation=orientation,
+            attributes=attributes,
+            **kwargs
+        )
 
     def render(self, **kwargs):
         super(PolyLineTextPath, self).render(**kwargs)

--- a/folium/plugins/scroll_zoom_toggler.py
+++ b/folium/plugins/scroll_zoom_toggler.py
@@ -10,47 +10,46 @@ from jinja2 import Template
 class ScrollZoomToggler(MacroElement):
     """Creates a button for enabling/disabling scroll on the Map."""
     _template = Template("""
-            {% macro header(this,kwargs) %}
-                <style>
-                    #{{this.get_name()}} {
-                        position:absolute;
-                        width:35px;
-                        bottom:10px;
-                        height:35px;
-                        left:10px;
-                        background-color:#fff;
-                        text-align:center;
-                        line-height:35px;
-                        vertical-align: middle;
-                        }
-                </style>
-            {% endmacro %}
+        {% macro header(this,kwargs) %}
+            <style>
+                #{{ this.get_name() }} {
+                    position:absolute;
+                    width:35px;
+                    bottom:10px;
+                    height:35px;
+                    left:10px;
+                    background-color:#fff;
+                    text-align:center;
+                    line-height:35px;
+                    vertical-align: middle;
+                    }
+            </style>
+        {% endmacro %}
 
-            {% macro html(this,kwargs) %}
-            <img id="{{this.get_name()}}" alt="scroll"
+        {% macro html(this,kwargs) %}
+            <img id="{{ this.get_name() }}"
+                 alt="scroll"
                  src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/png/512/arrow-move.png"
                  style="z-index: 999999"
-                 onclick="{{this._parent.get_name()}}.toggleScroll()">
+                 onclick="{{ this._parent.get_name() }}.toggleScroll()">
             </img>
-            {% endmacro %}
+        {% endmacro %}
 
-            {% macro script(this,kwargs) %}
-                    {{this._parent.get_name()}}.scrollEnabled = true;
+        {% macro script(this,kwargs) %}
+            {{ this._parent.get_name() }}.scrollEnabled = true;
 
-                    {{this._parent.get_name()}}.toggleScroll = function() {
-                        if (this.scrollEnabled) {
-                            this.scrollEnabled = false;
-                            this.scrollWheelZoom.disable();
-                            }
-                        else {
-                            this.scrollEnabled = true;
-                            this.scrollWheelZoom.enable();
-                            }
-                        };
-
-                    {{this._parent.get_name()}}.toggleScroll();
-            {% endmacro %}
-            """)
+            {{ this._parent.get_name() }}.toggleScroll = function() {
+                if (this.scrollEnabled) {
+                    this.scrollEnabled = false;
+                    this.scrollWheelZoom.disable();
+                } else {
+                    this.scrollEnabled = true;
+                    this.scrollWheelZoom.enable();
+                }
+            };
+            {{ this._parent.get_name() }}.toggleScroll();
+        {% endmacro %}
+        """)
 
     def __init__(self):
         super(ScrollZoomToggler, self).__init__()

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -2,19 +2,14 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
-from ..utilities import camelize
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from jinja2 import Template
 
 from folium import Map
-
 from folium.features import FeatureGroup, GeoJson, TopoJson
-
 from folium.plugins import MarkerCluster
+from folium.utilities import parse_options
 
 
 class Search(MacroElement):
@@ -32,7 +27,7 @@ class Search(MacroElement):
         By default zooms to Polygon/Line bounds and points
         on their natural extent.
     geom_type: str, default 'Point'
-        Feature geometry type. "Point","Line" or "Polygon"
+        Feature geometry type. "Point", "Line" or "Polygon"
     position: str, default 'topleft'
         Change the position of the search bar, can be:
         'topleft', 'topright', 'bottomright' or 'bottomleft',
@@ -76,7 +71,7 @@ class Search(MacroElement):
                         return feature.properties.style
                     })
                     {% if this.options %}
-                    e.layer.setStyle({{ this.options }});
+                    e.layer.setStyle({{ this.options|tojson }});
                     {% endif %}
                     if(e.layer._popup)
                         e.layer.openPopup();
@@ -107,13 +102,10 @@ class Search(MacroElement):
         self.position = position
         self.placeholder = placeholder
         self.collapsed = collapsed
-        self.options = None
-        if len(kwargs.items()) > 0:
-            self.options = json.dumps({camelize(key): value
-                                       for key, value in kwargs.items()})
+        self.options = parse_options(**kwargs)
 
     def test_params(self, keys):
-        if keys is not None:
+        if keys is not None and self.search_label is not None:
             assert self.search_label in keys, "The label '{}' was not " \
                                               "available in {}" \
                                               "".format(self.search_label, keys)

--- a/folium/plugins/terminator.py
+++ b/folium/plugins/terminator.py
@@ -14,10 +14,10 @@ class Terminator(MacroElement):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                L.terminator().addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            L.terminator().addTo({{this._parent.get_name()}});
+        {% endmacro %}
+        """)
 
     def __init__(self):
         super(Terminator, self).__init__()

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -2,8 +2,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import Figure, JavascriptLink
 
 from folium.features import GeoJson
@@ -34,104 +32,105 @@ class TimeSliderChoropleth(Layer):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
+        {% macro script(this, kwargs) %}
 
-                var timestamps = {{ this.timestamps }};
-                var styledict = {{ this.styledict }};
-                var current_timestamp = timestamps[0];
+            var timestamps = {{ this.timestamps|tojson }};
+            var styledict = {{ this.styledict|tojson }};
+            var current_timestamp = timestamps[0];
 
-                // insert time slider
-                d3.select("body").insert("p", ":first-child").append("input")
-                    .attr("type", "range")
-                    .attr("width", "100px")
-                    .attr("min", 0)
-                    .attr("max", timestamps.length - 1)
-                    .attr("value", 0)
-                    .attr("id", "slider")
-                    .attr("step", "1")
-                    .style('align', 'center');
+            // insert time slider
+            d3.select("body").insert("p", ":first-child").append("input")
+                .attr("type", "range")
+                .attr("width", "100px")
+                .attr("min", 0)
+                .attr("max", timestamps.length - 1)
+                .attr("value", 0)
+                .attr("id", "slider")
+                .attr("step", "1")
+                .style('align', 'center');
 
-                // insert time slider output BEFORE time slider (text on top of slider)
-                d3.select("body").insert("p", ":first-child").append("output")
-                    .attr("width", "100")
-                    .attr("id", "slider-value")
-                    .style('font-size', '18px')
-                    .style('text-align', 'center')
-                    .style('font-weight', '500%');
+            // insert time slider output BEFORE time slider (text on top of slider)
+            d3.select("body").insert("p", ":first-child").append("output")
+                .attr("width", "100")
+                .attr("id", "slider-value")
+                .style('font-size', '18px')
+                .style('text-align', 'center')
+                .style('font-weight', '500%');
 
-                var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
-                d3.select("output#slider-value").text(datestring);
+            var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
+            d3.select("output#slider-value").text(datestring);
 
-                fill_map = function(){
-                    for (var feature_id in styledict){
-                        let style = styledict[feature_id]//[current_timestamp];
-                        var fillColor = 'white';
-                        var opacity = 0;
-                        if (current_timestamp in style){
-                            fillColor = style[current_timestamp]['color'];
-                            opacity = style[current_timestamp]['opacity'];
-                            d3.selectAll('#feature-'+feature_id
-                            ).attr('fill', fillColor)
-                            .style('fill-opacity', opacity);
-                        }
+            fill_map = function(){
+                for (var feature_id in styledict){
+                    let style = styledict[feature_id]//[current_timestamp];
+                    var fillColor = 'white';
+                    var opacity = 0;
+                    if (current_timestamp in style){
+                        fillColor = style[current_timestamp]['color'];
+                        opacity = style[current_timestamp]['opacity'];
+                        d3.selectAll('#feature-'+feature_id
+                        ).attr('fill', fillColor)
+                        .style('fill-opacity', opacity);
                     }
                 }
+            }
 
-                d3.select("#slider").on("input", function() {
-                    current_timestamp = timestamps[this.value];
-                var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
-                d3.select("output#slider-value").text(datestring);
-                fill_map();
-                });
+            d3.select("#slider").on("input", function() {
+                current_timestamp = timestamps[this.value];
+            var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
+            d3.select("output#slider-value").text(datestring);
+            fill_map();
+            });
 
-                {% if this.highlight %}
-                    {{this.get_name()}}_onEachFeature = function onEachFeature(feature, layer) {
-                        layer.on({
-                            mouseout: function(e) {
-                            if (current_timestamp in styledict[e.target.feature.id]){
-                                var opacity = styledict[e.target.feature.id][current_timestamp]['opacity'];
-                                d3.selectAll('#feature-'+e.target.feature.id).style('fill-opacity', opacity);
-                            }
-                        },
-                            mouseover: function(e) {
-                            if (current_timestamp in styledict[e.target.feature.id]){
-                                d3.selectAll('#feature-'+e.target.feature.id).style('fill-opacity', 1);
-                            }
-                        },
-                            click: function(e) {
-                                {{this._parent.get_name()}}.fitBounds(e.target.getBounds());
+            {% if this.highlight %}
+                {{this.get_name()}}_onEachFeature = function onEachFeature(feature, layer) {
+                    layer.on({
+                        mouseout: function(e) {
+                        if (current_timestamp in styledict[e.target.feature.id]){
+                            var opacity = styledict[e.target.feature.id][current_timestamp]['opacity'];
+                            d3.selectAll('#feature-'+e.target.feature.id).style('fill-opacity', opacity);
                         }
-                        });
-                    };
-
-                {% endif %}
-
-                var {{this.get_name()}} = L.geoJson(
-                        {{this.data}}
-                    ).addTo({{this._parent.get_name()}}
-                );
-
-            {{this.get_name()}}.setStyle(function(feature) {feature.properties.style;});
-
-                {{ this.get_name() }}.eachLayer(function (layer) {
-                    layer._path.id = 'feature-' + layer.feature.id;
+                    },
+                        mouseover: function(e) {
+                        if (current_timestamp in styledict[e.target.feature.id]){
+                            d3.selectAll('#feature-'+e.target.feature.id).style('fill-opacity', 1);
+                        }
+                    },
+                        click: function(e) {
+                            {{this._parent.get_name()}}.fitBounds(e.target.getBounds());
+                    }
                     });
+                };
 
-                d3.selectAll('path')
-                .attr('stroke', 'white')
-                .attr('stroke-width', 0.8)
-                .attr('stroke-dasharray', '5,5')
-                .attr('fill-opacity', 0);
-                fill_map();
+            {% endif %}
 
-            {% endmacro %}
-            """)
+            var {{ this.get_name() }} = L.geoJson(
+                    {{ this.data|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+
+            {{ this.get_name() }}.setStyle(function(feature) {
+                feature.properties.style;
+            });
+
+            {{ this.get_name() }}.eachLayer(function (layer) {
+                layer._path.id = 'feature-' + layer.feature.id;
+            });
+
+            d3.selectAll('path')
+            .attr('stroke', 'white')
+            .attr('stroke-width', 0.8)
+            .attr('stroke-dasharray', '5,5')
+            .attr('fill-opacity', 0);
+            fill_map();
+
+        {% endmacro %}
+        """)
 
     def __init__(self, data, styledict, name=None, overlay=True, control=True,
                  show=True):
         super(TimeSliderChoropleth, self).__init__(name=name, overlay=overlay,
                                                    control=control, show=show)
-        self.data = json.dumps(GeoJson.process_data(GeoJson({}), data))
+        self.data = GeoJson.process_data(GeoJson({}), data)
 
         if not isinstance(styledict, dict):
             raise ValueError('styledict must be a dictionary, got {!r}'.format(styledict))  # noqa
@@ -145,8 +144,8 @@ class TimeSliderChoropleth(Layer):
             timestamps.update(set(feature.keys()))
         timestamps = sorted(list(timestamps))
 
-        self.timestamps = json.dumps(timestamps)
-        self.styledict = json.dumps(styledict, sort_keys=True, indent=2)
+        self.timestamps = timestamps
+        self.styledict = styledict
 
     def render(self, **kwargs):
         super(TimeSliderChoropleth, self).render(**kwargs)

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -7,12 +7,10 @@ Wraps leaflet TileLayer, WmsTileLayer (TileLayer.WMS), ImageOverlay, and VideoOv
 
 from __future__ import (absolute_import, division, print_function)
 
-import json
-
 from branca.element import Element, Figure
 
 from folium.map import Layer
-from folium.utilities import image_to_url, mercator_transform
+from folium.utilities import image_to_url, mercator_transform, parse_options
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -75,12 +73,13 @@ class TileLayer(Layer):
         object.
     """
     _template = Template(u"""
-{% macro script(this, kwargs) -%}
-    var {{this.get_name()}} = L.tileLayer(
-        '{{this.tiles}}',
-        {{ this.options }}).addTo({{this._parent.get_name()}});
-{%- endmacro %}
-""")  # noqa
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.tileLayer(
+                {{ this.tiles|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
     def __init__(self, tiles='OpenStreetMap', min_zoom=0, max_zoom=18,
                  max_native_zoom=None, attr=None, API_key=None,
@@ -95,18 +94,18 @@ class TileLayer(Layer):
         self._name = 'TileLayer'
         self._env = ENV
 
-        options = {'minZoom': min_zoom,
-                   'maxZoom': max_zoom,
-                   'maxNativeZoom': max_native_zoom or max_zoom,
-                   'noWrap': no_wrap,
-                   'attribution': attr,
-                   'subdomains': subdomains,
-                   'detectRetina': detect_retina,
-                   'tms': tms,
-                   'opacity': opacity}
-        options.update(kwargs)
-        self.options = json.dumps(options, sort_keys=True, indent=8)
-
+        self.options = parse_options(
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            max_native_zoom=max_native_zoom or max_zoom,
+            no_wrap=no_wrap,
+            attribution=attr,
+            subdomains=subdomains,
+            detect_retina=detect_retina,
+            tms=tms,
+            opacity=opacity,
+            **kwargs
+        )
         tiles_flat = ''.join(tiles.lower().strip().split())
         if tiles_flat in ('cloudmade', 'mapbox') and not API_key:
             raise ValueError('You must pass an API key if using Cloudmade'
@@ -136,22 +135,21 @@ class WmsTileLayer(Layer):
     ----------
     url : str
         The url of the WMS server.
-    name : string, default None
-        The name of the Layer, as it will appear in LayerControls
-    layers : str, default ''
-        The names of the layers to be displayed.
-    styles : str, default ''
+    layers : str
+        Comma-separated list of WMS layers to show.
+    styles : str, optional
         Comma-separated list of WMS styles.
     fmt : str, default 'image/jpeg'
-        The format of the service output.
-        Ex: 'image/png'
+        The format of the service output. Ex: 'image/png'
     transparent: bool, default False
         Whether the layer shall allow transparency.
     version : str, default '1.1.1'
         Version of the WMS service to use.
-    attr : str, default None
+    attr : str, default ''
         The attribution of the service.
         Will be displayed in the bottom right corner.
+    name : string, optional
+        The name of the Layer, as it will appear in LayerControls
     overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
@@ -167,28 +165,28 @@ class WmsTileLayer(Layer):
     """
     _template = Template(u"""
         {% macro script(this, kwargs) %}
-            var {{this.get_name()}} = L.tileLayer.wms(
-                '{{ this.url }}',
-                {{ this.options }}
-                ).addTo({{this._parent.get_name()}});
-
+            var {{ this.get_name() }} = L.tileLayer.wms(
+                {{ this.url|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """)  # noqa
 
-    def __init__(self, url, name=None, layers='', styles='',
-                 fmt='image/jpeg', transparent=False, version='1.1.1',
-                 attr='', overlay=True, control=True, show=True, **kwargs):
-        super(WmsTileLayer, self).__init__(overlay=overlay, control=control,
-                                           name=name, show=show)
+    def __init__(self, url, layers, styles='', fmt='image/jpeg',
+                 transparent=False, version='1.1.1', attr='',
+                 name=None, overlay=True, control=True, show=True, **kwargs):
+        super(WmsTileLayer, self).__init__(name=name, overlay=overlay,
+                                           control=control, show=show)
         self.url = url
-        options = {'layers': layers,
-                   'styles': styles,
-                   'format': fmt,
-                   'transparent': transparent,
-                   'version': version,
-                   'attribution': attr}
-        options.update(kwargs)
-        self.options = json.dumps(options, sort_keys=True, indent=2)
+        kwargs['format'] = fmt
+        self.options = parse_options(
+            layers=layers,
+            styles=styles,
+            transparent=transparent,
+            version=version,
+            attribution=attr,
+            **kwargs
+        )
 
 
 class ImageOverlay(Layer):
@@ -204,8 +202,8 @@ class ImageOverlay(Layer):
         * If file, it's content will be converted as embedded in the output file.
         * If array-like, it will be converted to PNG base64 string and embedded in the output.
     bounds: list
-        Image bounds on the map in the form [[lat_min, lon_min],
-        [lat_max, lon_max]]
+        Image bounds on the map in the form
+         [[lat_min, lon_min], [lat_max, lon_max]]
     opacity: float, default Leaflet's default (1.0)
     alt: string, default Leaflet's default ('')
     origin: ['upper' | 'lower'], optional, default 'upper'
@@ -219,10 +217,8 @@ class ImageOverlay(Layer):
         Hint: you can use colormaps from `matplotlib.cm`.
     mercator_project: bool, default False.
         Used only for array-like image.  Transforms the data to
-        project (longitude, latitude) coordinates to the
-        Mercator projection.
-        Beware that this will only work if `image` is an array-like
-        object.
+        project (longitude, latitude) coordinates to the Mercator projection.
+        Beware that this will only work if `image` is an array-like object.
     pixelated: bool, default True
         Sharp sharp/crips (True) or aliased corners (False).
     name : string, default None
@@ -239,44 +235,32 @@ class ImageOverlay(Layer):
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                var {{this.get_name()}} = L.imageOverlay(
-                    '{{ this.url }}',
-                    {{ this.bounds }},
-                    {{ this.options }}
-                    ).addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.imageOverlay(
+                {{ this.url|tojson }},
+                {{ this.bounds|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
     def __init__(self, image, bounds, origin='upper', colormap=None,
                  mercator_project=False, pixelated=True,
                  name=None, overlay=True, control=True, show=True, **kwargs):
         super(ImageOverlay, self).__init__(name=name, overlay=overlay,
                                            control=control, show=show)
-
-        options = {
-            'opacity': kwargs.pop('opacity', 1.),
-            'alt': kwargs.pop('alt', ''),
-            'interactive': kwargs.pop('interactive', False),
-            'crossOrigin': kwargs.pop('cross_origin', False),
-            'errorOverlayUrl': kwargs.pop('error_overlay_url', ''),
-            'zIndex': kwargs.pop('zindex', 1),
-            'className': kwargs.pop('class_name', ''),
-        }
         self._name = 'ImageOverlay'
+        self.bounds = bounds
+        self.options = parse_options(**kwargs)
         self.pixelated = pixelated
-
         if mercator_project:
             image = mercator_transform(
                 image,
-                [bounds[0][0],
-                 bounds[1][0]],
-                origin=origin)
+                [bounds[0][0], bounds[1][0]],
+                origin=origin
+            )
 
         self.url = image_to_url(image, origin=origin, colormap=colormap)
-
-        self.bounds = json.loads(json.dumps(bounds))
-        self.options = json.dumps(options, sort_keys=True, indent=2)
 
     def render(self, **kwargs):
         super(ImageOverlay, self).render()
@@ -284,18 +268,20 @@ class ImageOverlay(Layer):
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '
                                             'if it is not in a Figure.')
-        pixelated = """<style>
-        .leaflet-image-layer {
-        image-rendering: -webkit-optimize-contrast; /* old android/safari*/
-        image-rendering: crisp-edges; /* safari */
-        image-rendering: pixelated; /* chrome */
-        image-rendering: -moz-crisp-edges; /* firefox */
-        image-rendering: -o-crisp-edges; /* opera */
-        -ms-interpolation-mode: nearest-neighbor; /* ie */
-        }
-        </style>"""
-
         if self.pixelated:
+            pixelated = """
+                <style>
+                    .leaflet-image-layer {
+                        /* old android/safari*/
+                        image-rendering: -webkit-optimize-contrast;
+                        image-rendering: crisp-edges; /* safari */
+                        image-rendering: pixelated; /* chrome */
+                        image-rendering: -moz-crisp-edges; /* firefox */
+                        image-rendering: -o-crisp-edges; /* opera */
+                        -ms-interpolation-mode: nearest-neighbor; /* ie */
+                    }
+                </style>
+            """
             figure.header.add_child(Element(pixelated), name='leaflet-image-layer')  # noqa
 
     def _get_self_bounds(self):
@@ -313,12 +299,13 @@ class VideoOverlay(Layer):
 
     Parameters
     ----------
-    video_url: URL of the video
+    video_url: str
+        URL of the video
     bounds: list
-        Video bounds on the map in the form [[lat_min, lon_min],
-        [lat_max, lon_max]]
-    opacity: float, default Leaflet's default (1.0)
-    attr: string, default Leaflet's default ('')
+        Video bounds on the map in the form
+         [[lat_min, lon_min], [lat_max, lon_max]]
+    autoplay: bool, default True
+    loop: bool, default True
     name : string, default None
         The name of the Layer, as it will appear in LayerControls
     overlay : bool, default True
@@ -327,35 +314,34 @@ class VideoOverlay(Layer):
         Whether the Layer will be included in LayerControls.
     show: bool, default True
         Whether the layer will be shown on opening (only for overlays).
+    **kwargs:
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#videooverlay
 
     """
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                var {{this.get_name()}} = L.videoOverlay(
-                    '{{ this.video_url }}',
-                    {{ this.bounds }},
-                    {{ this.options }}
-                    ).addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.videoOverlay(
+                {{ this.video_url|tojson }},
+                {{ this.bounds|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
-    def __init__(self, video_url, bounds, opacity=1., attr=None,
-                 autoplay=True, loop=True,
-                 name=None, overlay=True, control=True, show=True):
+    def __init__(self, video_url, bounds, autoplay=True, loop=True,
+                 name=None, overlay=True, control=True, show=True, **kwargs):
         super(VideoOverlay, self).__init__(name=name, overlay=overlay,
                                            control=control, show=show)
         self._name = 'VideoOverlay'
-
         self.video_url = video_url
 
-        self.bounds = json.loads(json.dumps(bounds))
-        options = {
-            'opacity': opacity,
-            'attribution': attr,
-            'loop': loop,
-            'autoplay': autoplay,
-        }
-        self.options = json.dumps(options)
+        self.bounds = bounds
+        self.options = parse_options(
+            autoplay=autoplay,
+            loop=loop,
+            **kwargs
+        )
 
     def _get_self_bounds(self):
         """

--- a/folium/templates/fol_template.html
+++ b/folium/templates/fol_template.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <script>L_PREFER_CANVAS=false; L_NO_TOUCH=false; L_DISABLE_3D=false;</script>
+    <script>
+        L_PREFER_CANVAS = false;
+        L_NO_TOUCH = false;
+        L_DISABLE_3D = false;
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
@@ -17,47 +21,52 @@
 
     <meta name="viewport" content="width=device-width,
         initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <style>#{{ map_id }} {
-        position: relative;
-        {{ width }}
-        {{ height }}
-        left: 0.0%;
-        top: 0.0%;
-      }
+    <style>
+        #{{ map_id }} {
+            position: relative;
+            {{ width }}
+            {{ height }}
+            left: 0.0%;
+            top: 0.0%;
+        }
     </style>
 </head>
 <body>
   <div class="folium-map" id="{{ map_id }}" ></div>
 </body>
 <script>
-  var southWest = L.latLng({{ min_lat }}, {{ min_lon }});
-  var northEast = L.latLng({{ max_lat }}, {{ max_lon }});
-  var bounds = L.latLngBounds(southWest, northEast);
+    var bounds = L.latLngBounds(
+        [{{ min_lat }}, {{ min_lon }}],
+        [{{ max_lat }}, {{ max_lon }}]
+    );
 
-  var {{ map_id }} = L.map(
-      '{{ map_id }}', {
-      center: [{{ lat }}, {{ lon }}],
-      zoom: {{ zoom_level }},
-      maxBounds: bounds,
-      layers: [],
-      worldCopyJump: {{ world_copy_jump.__str__().lower() }},
-      crs: L.CRS.{{crs}},
-      zoomControl: {{ zoom_control.__str__().lower() }},
-      });
-
-  {% for tile in tile_layers -%}
-   var {{tile['id']}} = L.tileLayer(
-       '{{tile['address']}}',
+    var {{ map_id }} = L.map(
+        "{{ map_id }}",
         {
-        "attribution": "{{tile['attr']}}",
-        "detectRetina": {{tile['detect_retina'].__str__().lower()}},
-        "maxNativeZoom": {{tile['max_zoom']}},
-        "maxZoom": {{tile['max_zoom']}},
-        "minZoom": {{tile['min_zoom']}},
-        "noWrap": {{tile['no_wrap'].__str__().lower()}},
-        "opacity": {{tile['opacity']}},
-        "subdomains": "{{tile['subdomains']}}",
-        "tms": {{tile['tms'].__str__().lower()}}
-}).addTo({{ map_id }});
+            center: [{{ lat }}, {{ lon }}],
+            zoom: {{ zoom_level }},
+            maxBounds: bounds,
+            layers: [],
+            worldCopyJump: {{ world_copy_jump.__str__().lower() }},
+            crs: L.CRS.{{crs}},
+            zoomControl: {{ zoom_control.__str__().lower() }},
+        }
+    );
+
+    {% for tile in tile_layers -%}
+    var {{ tile['id'] }} = L.tileLayer(
+        "{{ tile['address'] }}",
+        {
+            "attribution": "{{tile['attr']}}",
+            "detectRetina": {{tile['detect_retina'].__str__().lower()}},
+            "maxNativeZoom": {{tile['max_zoom']}},
+            "maxZoom": {{tile['max_zoom']}},
+            "minZoom": {{tile['min_zoom']}},
+            "noWrap": {{tile['no_wrap'].__str__().lower()}},
+            "opacity": {{tile['opacity']}},
+            "subdomains": "{{tile['subdomains']}}",
+            "tms": {{ tile['tms'].__str__().lower() }}
+        }
+    ).addTo({{ map_id }});
   {%- endfor %}
 </script>

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -62,7 +62,7 @@ def _iter_tolist(x):
     if hasattr(x, '__iter__'):
         return list(map(_iter_tolist, x))
     else:
-        return x
+        return float(x)
 
 
 def _flatten(container):

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -407,12 +407,16 @@ def compare_rendered(obj1, obj2):
     two folium map objects are the equal or not.
 
     """
-    return _normalize(obj1) == _normalize(obj2)
+    return normalize(obj1) == normalize(obj2)
 
 
-def _normalize(rendered):
-    """Return the input string as a list of stripped lines."""
-    return [line.strip() for line in rendered.splitlines() if line.strip()]
+def normalize(rendered):
+    """Return the input string without non-functional spaces or newlines."""
+    out = ''.join([line.strip()
+                   for line in rendered.splitlines()
+                   if line.strip()])
+    out = out.replace(', ', ',')
+    return out
 
 
 @contextmanager
@@ -452,3 +456,10 @@ def get_obj_in_upper_tree(element, cls):
     if not isinstance(parent, cls):
         return get_obj_in_upper_tree(parent, cls)
     return parent
+
+
+def parse_options(**kwargs):
+    """Return a dict with lower-camelcase keys and non-None values.."""
+    return {camelize(key): value
+            for key, value in kwargs.items()
+            if value is not None}

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -7,10 +7,6 @@ Wraps leaflet Polyline, Polygon, Rectangle, Circlem and CircleMarker
 
 from __future__ import absolute_import, division, print_function
 
-import json
-
-from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement  # noqa
-
 from folium.map import Marker
 
 from jinja2 import Template
@@ -102,14 +98,8 @@ def path_options(line=False, radius=False, **kwargs):
     return default
 
 
-def _parse_options(line=False, radius=False, **kwargs):
-    options = path_options(line=line, radius=radius, **kwargs)
-    return json.dumps(options, sort_keys=True, indent=2)
-
-
 class PolyLine(Marker):
-    """
-    Class for drawing polyline overlays on a map.
+    """Draw polyline overlays on a map.
 
     See :func:`folium.vector_layers.path_options` for the `Path` options.
 
@@ -127,34 +117,30 @@ class PolyLine(Marker):
         and less means more accurate representation.
     no_clip: Bool, default False
         Disable polyline clipping.
-
-
-    See https://leafletjs.com/reference-1.4.0.html#polyline
+    **kwargs
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#polyline
 
     """
 
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-                var {{this.get_name()}} = L.polyline(
-                    {{this.location}},
-                    {{ this.options }}
-                    )
-                    .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)  # noqa
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.polyline(
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{this._parent.get_name()}});
+        {% endmacro %}
+        """)
 
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super(PolyLine, self).__init__(location=locations, popup=popup,
                                        tooltip=tooltip)
         self._name = 'PolyLine'
-        self.options = _parse_options(line=True, **kwargs)
+        self.options = path_options(line=True, **kwargs)
 
 
 class Polygon(Marker):
-    """
-    Class for drawing polygon overlays on a map.
-
-    Extends :func:`folium.vector_layers.PolyLine`.
+    """Draw polygon overlays on a map.
 
     See :func:`folium.vector_layers.path_options` for the `Path` options.
 
@@ -166,34 +152,29 @@ class Polygon(Marker):
         Input text or visualization for object displayed when clicking.
     tooltip: str or folium.Tooltip, default None
         Display a text when hovering over the object.
-
-
-    See https://leafletjs.com/reference-1.4.0.html#polygon
+    **kwargs
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#polygon
 
     """
 
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-
-            var {{this.get_name()}} = L.polygon(
-                {{this.location}},
-                {{ this.options }}
-                )
-                .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.polygon(
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{this._parent.get_name()}});
+        {% endmacro %}
+        """)
 
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super(Polygon, self).__init__(locations, popup=popup, tooltip=tooltip)
         self._name = 'Polygon'
-        self.options = _parse_options(line=True, **kwargs)
+        self.options = path_options(line=True, **kwargs)
 
 
 class Rectangle(Marker):
-    """
-    Class for drawing rectangle overlays on a map.
-
-    Extends :func:`folium.vector_layers.Polygon`.
+    """Draw rectangle overlays on a map.
 
     See :func:`folium.vector_layers.path_options` for the `Path` options.
 
@@ -205,38 +186,34 @@ class Rectangle(Marker):
         Input text or visualization for object displayed when clicking.
     tooltip: str or folium.Tooltip, default None
         Display a text when hovering over the object.
-
-
-    See https://leafletjs.com/reference-1.4.0.html#rectangle
+    **kwargs
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#rectangle
 
     """
 
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-
+        {% macro script(this, kwargs) %}
             var {{this.get_name()}} = L.rectangle(
-                {{this.location}},
-                {{ this.options }}
-                )
-                .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{this._parent.get_name()}});
+        {% endmacro %}
+        """)
 
     def __init__(self, bounds, popup=None, tooltip=None, **kwargs):
         super(Rectangle, self).__init__(location=bounds, popup=popup,
                                         tooltip=tooltip)
         self._name = 'rectangle'
-        self.options = _parse_options(line=True, **kwargs)
+        self.options = path_options(line=True, **kwargs)
 
 
 class Circle(Marker):
     """
     Class for drawing circle overlays on a map.
 
-    It's an approximation and starts to diverge from a real circle closer to poles
-    (due to projection distortion).
-
-    Extends :func:`folium.vector_layers.CircleMarker`.
+    It's an approximation and starts to diverge from a real circle closer to
+    the poles (due to projection distortion).
 
     See :func:`folium.vector_layers.path_options` for the `Path` options.
 
@@ -250,28 +227,26 @@ class Circle(Marker):
         Display a text when hovering over the object.
     radius: float
         Radius of the circle, in meters.
-
-
-    See https://leafletjs.com/reference-1.4.0.html#circle
+    **kwargs
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#circle
 
     """
 
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-
-            var {{this.get_name()}} = L.circle(
-                [{{this.location[0]}}, {{this.location[1]}}],
-                {{ this.options }}
-                )
-                .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.circle(
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
     def __init__(self, location, radius, popup=None, tooltip=None, **kwargs):
         super(Circle, self).__init__(location=location, popup=popup,
                                      tooltip=tooltip)
         self._name = 'circle'
-        self.options = _parse_options(line=False, radius=radius, **kwargs)
+        self.options = path_options(line=False, radius=radius, **kwargs)
 
 
 class CircleMarker(Marker):
@@ -290,24 +265,23 @@ class CircleMarker(Marker):
         Display a text when hovering over the object.
     radius: float, default 10
         Radius of the circle marker, in pixels.
-
-
-    See https://leafletjs.com/reference-1.4.0.html#circlemarker
+    **kwargs
+        Other valid (possibly inherited) options. See:
+        https://leafletjs.com/reference-1.4.0.html#circlemarker
 
     """
 
     _template = Template(u"""
-            {% macro script(this, kwargs) %}
-            var {{this.get_name()}} = L.circleMarker(
-                [{{this.location[0]}}, {{this.location[1]}}],
-                {{ this.options }}
-                )
-                .addTo({{this._parent.get_name()}});
-            {% endmacro %}
-            """)
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.circleMarker(
+                {{ this.location|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)
 
     def __init__(self, location, radius=10, popup=None, tooltip=None, **kwargs):
         super(CircleMarker, self).__init__(location=location, popup=popup,
                                            tooltip=tooltip)
         self._name = 'CircleMarker'
-        self.options = _parse_options(line=False, radius=radius, **kwargs)
+        self.options = path_options(line=False, radius=radius, **kwargs)

--- a/tests/plugins/test_antpath.py
+++ b/tests/plugins/test_antpath.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import folium
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -48,12 +49,12 @@ def test_antpath():
     # We verify that the script part is correct.
     tmpl = Template("""
           {{this.get_name()}} = L.polyline.antPath(
-                  {{this.location}},
-                  {{ this.options }}
+                  {{ this.location|tojson }},
+                  {{ this.options|tojson }}
                 )
                 .addTo({{this._parent.get_name()}});
         """)  # noqa
 
     expected_rendered = tmpl.render(this=antpath)
     rendered = antpath._template.module.script(antpath)
-    assert folium.utilities.compare_rendered(expected_rendered, rendered)
+    assert normalize(expected_rendered) == normalize(rendered)

--- a/tests/plugins/test_beautify_icon.py
+++ b/tests/plugins/test_beautify_icon.py
@@ -11,8 +11,8 @@ from __future__ import (absolute_import, division, print_function)
 from jinja2 import Template
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 
 def test_beautify_icon():
@@ -40,7 +40,7 @@ def test_beautify_icon():
     m.add_child(bm2)
     m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script import is present.
     script = '<script src="https://rawcdn.githack.com/marslan390/BeautifyMarker/master/leaflet-beautify-marker-icon.js"></script>'  # noqa
@@ -52,9 +52,9 @@ def test_beautify_icon():
 
     # We verify that the Beautiful Icons are rendered correctly.
     tmpl = Template(u"""
-                var {{this.get_name()}} = new L.BeautifyIcon.icon({{ this.options }})
+                var {{this.get_name()}} = new L.BeautifyIcon.icon({{ this.options|tojson }})
                 {{this._parent.get_name()}}.setIcon({{this.get_name()}});
             """)  # noqa
 
-    assert tmpl.render(this=ic1) in out
-    assert tmpl.render(this=ic2) in out
+    assert normalize(tmpl.render(this=ic1)) in out
+    assert normalize(tmpl.render(this=ic2)) in out

--- a/tests/plugins/test_boat_marker.py
+++ b/tests/plugins/test_boat_marker.py
@@ -9,8 +9,8 @@ Test BoatMarker
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -34,22 +34,27 @@ def test_boat_marker():
     m.add_child(bm2)
     m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script import is present.
     script = '<script src="https://unpkg.com/leaflet.boatmarker/leaflet.boatmarker.min.js"></script>'  # noqa
     assert script in out
 
     # We verify that the script part is correct.
-    tmpl = Template("""
-                var {{this.get_name()}} = L.boatMarker(
-                    [{{this.location[0]}},{{this.location[1]}}],
-                    {{this.kwargs}}).addTo({{this._parent.get_name()}});
-                {{this.get_name()}}.setHeadingWind({{this.heading}}, {{this.wind_speed}}, {{this.wind_heading}});
-    """)  # noqa
+    tmpl = Template(u"""
+        var {{ this.get_name() }} = L.boatMarker(
+            {{ this.location|tojson }},
+            {{ this.options|tojson }}
+        ).addTo({{ this._parent.get_name() }});
+        {{ this.get_name() }}.setHeadingWind(
+            {{ this.heading }},
+            {{ this.wind_speed }},
+            {{ this.wind_heading }}
+        );
+    """)
 
-    assert tmpl.render(this=bm1) in out
-    assert tmpl.render(this=bm2) in out
+    assert normalize(tmpl.render(this=bm1)) in out
+    assert normalize(tmpl.render(this=bm2)) in out
 
     bounds = m.get_bounds()
     assert bounds == [[34, -43], [46, -30]], bounds
@@ -63,14 +68,15 @@ def test_boat_marker_with_no_wind_speed_or_heading():
         color='#8f8')
     m.add_child(bm1)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script part is correct.
     tmpl = Template("""
-                var {{this.get_name()}} = L.boatMarker(
-                    [{{this.location[0]}},{{this.location[1]}}],
-                    {{this.kwargs}}).addTo({{this._parent.get_name()}});
-                {{this.get_name()}}.setHeading({{this.heading}});
-    """)  # noqa
+        var {{ this.get_name() }} = L.boatMarker(
+            {{ this.location|tojson }},
+            {{ this.options|tojson }}
+        ).addTo({{ this._parent.get_name() }});
+        {{ this.get_name() }}.setHeading({{ this.heading }});
+    """)
 
-    assert tmpl.render(this=bm1) in out
+    assert normalize(tmpl.render(this=bm1)) in out

--- a/tests/plugins/test_dual_map.py
+++ b/tests/plugins/test_dual_map.py
@@ -11,6 +11,7 @@ from jinja2 import Template
 
 import folium
 import folium.plugins
+from folium.utilities import normalize
 
 
 def test_dual_map():
@@ -22,7 +23,7 @@ def test_dual_map():
 
     figure = m.get_root()
     assert isinstance(figure, folium.Figure)
-    out = figure.render()
+    out = normalize(figure.render())
 
     script = '<script src="https://rawcdn.githack.com/jieter/Leaflet.Sync/master/L.Map.Sync.js"></script>'  # noqa
     assert script in out
@@ -32,4 +33,4 @@ def test_dual_map():
         {{ this.m2.get_name() }}.sync({{ this.m1.get_name() }});
     """)
 
-    assert tmpl.render(this=m) in out
+    assert normalize(tmpl.render(this=m)) in out

--- a/tests/plugins/test_fast_marker_cluster.py
+++ b/tests/plugins/test_fast_marker_cluster.py
@@ -8,8 +8,8 @@ Test FastMarkerCluster
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -29,7 +29,7 @@ def test_fast_marker_cluster():
     m.add_child(mc)
     m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that imports
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/leaflet.markercluster.js"></script>' in out  # noqa
@@ -56,4 +56,4 @@ def test_fast_marker_cluster():
         {% endmacro %}
     """)
 
-    assert ''.join(tmpl.render(this=mc).split()) in ''.join(out.split())
+    assert normalize(tmpl.render(this=mc)) in out

--- a/tests/plugins/test_feature_group_sub_group.py
+++ b/tests/plugins/test_feature_group_sub_group.py
@@ -8,8 +8,8 @@ Test MarkerCluster
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -27,17 +27,18 @@ def test_feature_group_sub_group():
     folium.Marker([1, -1]).add_to(g2)
     m.add_child(g2)
     folium.LayerControl().add_to(m)
-    m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that imports
     assert '<script src="https://unpkg.com/leaflet.featuregroup.subgroup@1.0.2/dist/leaflet.featuregroup.subgroup.js"></script>' in out  # noqa
 
     # Verify the script part is okay.
     tmpl = Template("""
-        var {{this.get_name()}} = L.featureGroup.subGroup({{this._group.get_name()}});
-        {{this.get_name()}}.addTo({{this._parent.get_name()}});
+        var {{ this.get_name() }} = L.featureGroup.subGroup(
+            {{ this._group.get_name() }}
+        );
+        {{ this.get_name() }}.addTo({{ this._parent.get_name() }});
     """)
-    assert ''.join(tmpl.render(this=g1).split()) in ''.join(out.split())
-    assert ''.join(tmpl.render(this=g2).split()) in ''.join(out.split())
+    assert normalize(tmpl.render(this=g1)) in out
+    assert normalize(tmpl.render(this=g2)) in out

--- a/tests/plugins/test_float_image.py
+++ b/tests/plugins/test_float_image.py
@@ -8,8 +8,8 @@ Test FloatImage
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -21,7 +21,7 @@ def test_float_image():
     m.add_child(szt)
     m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # Verify that the div has been created.
     tmpl = Template("""
@@ -30,7 +30,7 @@ def test_float_image():
         style="z-index: 999999">
         </img>
     """)
-    assert ''.join(tmpl.render(this=szt).split()) in ''.join(out.split())
+    assert normalize(tmpl.render(this=szt)) in out
 
     # Verify that the style has been created.
     tmpl = Template("""
@@ -42,7 +42,7 @@ def test_float_image():
                 }
         </style>
     """)
-    assert ''.join(tmpl.render(this=szt).split()) in ''.join(out.split())
+    assert normalize(tmpl.render(this=szt)) in out
 
     bounds = m.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds

--- a/tests/plugins/test_fullscreen.py
+++ b/tests/plugins/test_fullscreen.py
@@ -9,31 +9,23 @@ Test Fullscreen
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
 
 def test_fullscreen():
     m = folium.Map([47, 3], zoom_start=1)
-    fs = plugins.Fullscreen()
-    m.add_child(fs)
-    m._repr_html_()
+    fs = plugins.Fullscreen().add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # verify that the fullscreen control was rendered
     tmpl = Template("""
-        L.control.fullscreen({
-            position: '{{this.position}}',
-            title: '{{this.title}}',
-            titleCancel: '{{this.title_cancel}}',
-            forceSeparateButton: {{this.force_separate_button}},
-            }).addTo({{this._parent.get_name()}});
-        {{this._parent.get_name()}}.on('enterFullscreen', function(){
-            console.log('entered fullscreen');
-        });
+        L.control.fullscreen(
+            {{ this.options|tojson }}
+        ).addTo({{this._parent.get_name()}});
     """)
 
-    assert ''.join(tmpl.render(this=fs).split()) in ''.join(out.split())
+    assert normalize(tmpl.render(this=fs)) in out

--- a/tests/plugins/test_heat_map.py
+++ b/tests/plugins/test_heat_map.py
@@ -8,8 +8,8 @@ Test HeatMap
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -25,7 +25,7 @@ def test_heat_map():
     m.add_child(hm)
     m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script import is present.
     script = '<script src="https://leaflet.github.io/Leaflet.heat/dist/leaflet-heat.js"></script>'  # noqa

--- a/tests/plugins/test_heat_map_withtime.py
+++ b/tests/plugins/test_heat_map_withtime.py
@@ -8,16 +8,12 @@ Test HeatMapWithTime
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
 import numpy as np
-
-
-def _normalize(rendered):
-    return ''.join(rendered.split())
 
 
 def test_heat_map_with_time():
@@ -27,11 +23,9 @@ def test_heat_map_with_time():
     move_data = np.random.normal(size=(100, 2)) * 0.01
     data = [(initial_data + move_data * i).tolist() for i in range(100)]
     m = folium.Map([48., 5.], tiles='stamentoner', zoom_start=6)
-    hm = plugins.HeatMapWithTime(data)
-    m.add_child(hm)
-    m._repr_html_()
+    hm = plugins.HeatMapWithTime(data).add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script imports are present.
     script = '<script src="https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"></script>'  # noqa
@@ -87,4 +81,4 @@ def test_heat_map_with_time():
             .addTo({{this._parent.get_name()}});
     """)
 
-    assert _normalize(tmpl.render(this=hm)) in _normalize(out)
+    assert normalize(tmpl.render(this=hm)) in out

--- a/tests/plugins/test_marker_cluster.py
+++ b/tests/plugins/test_marker_cluster.py
@@ -8,8 +8,8 @@ Test MarkerCluster
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -22,14 +22,11 @@ def test_marker_cluster():
     data = np.array([
         np.random.uniform(low=35, high=60, size=N),   # Random latitudes.
         np.random.uniform(low=-12, high=30, size=N),  # Random longitudes.
-        range(N),                                     # Popups.
         ]).T
     m = folium.Map([45., 3.], zoom_start=4)
-    mc = plugins.MarkerCluster(data)
-    m.add_child(mc)
-    m._repr_html_()
+    mc = plugins.MarkerCluster(data).add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that imports
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/leaflet.markercluster.js"></script>' in out  # noqa
@@ -38,24 +35,24 @@ def test_marker_cluster():
 
     # Verify the script part is okay.
     tmpl = Template("""
-        var {{this.get_name()}} = L.markerClusterGroup({
-                {% if this._icon_create_function %}
-                   iconCreateFunction: {{this._icon_create_function}}
-                {% endif %}
-            });
+        var {{this.get_name()}} = L.markerClusterGroup(
+            {{ this.options|tojson }}
+        );
+        {%- if this.icon_create_function is not none %}
+            {{ this.get_name() }}.options.iconCreateFunction =
+                {{ this.icon_create_function.strip() }};
+            {%- endif %}
         {{this._parent.get_name()}}.addLayer({{this.get_name()}});
 
         {% for marker in this._children.values() %}
             var {{marker.get_name()}} = L.marker(
-                [{{marker.location[0]}},{{marker.location[1]}}],
-                {
-                    icon: new L.Icon.Default(),
-                    }
-                )
-                .addTo({{this.get_name()}});
+                {{ marker.location|tojson }},
+                {}
+            ).addTo({{this.get_name()}});
         {% endfor %}
     """)
-    assert ''.join(tmpl.render(this=mc).split()) in ''.join(out.split())
+    expected = normalize(tmpl.render(this=mc))
+    assert expected in out
 
     bounds = m.get_bounds()
     assert bounds == [[35.147332572663785, -11.520684337300109],

--- a/tests/plugins/test_minimap.py
+++ b/tests/plugins/test_minimap.py
@@ -8,8 +8,8 @@ Test MiniMap
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 
 def test_minimap():
@@ -18,7 +18,7 @@ def test_minimap():
     minimap = plugins.MiniMap()
     m.add_child(minimap)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # Verify that a new minimap is getting created.
     assert 'new L.Control.MiniMap' in out
@@ -27,6 +27,6 @@ def test_minimap():
     minimap = plugins.MiniMap(tile_layer="Stamen Toner")
     minimap.add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
     # verify that Stamen Toner tiles are being used
     assert 'https://stamen-tiles' in out

--- a/tests/plugins/test_pattern.py
+++ b/tests/plugins/test_pattern.py
@@ -10,8 +10,8 @@ from __future__ import (absolute_import, division, print_function)
 import os
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 
 def test_pattern():
@@ -43,7 +43,7 @@ def test_pattern():
     data = os.path.join(os.path.dirname(__file__), os.pardir, 'us-states.json')
     folium.GeoJson(data, style_function=style_function).add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script import is present.
     script = '<script src="https://teastman.github.io/Leaflet.pattern/leaflet.pattern.js"></script>'  # noqa

--- a/tests/plugins/test_polyline_text_path.py
+++ b/tests/plugins/test_polyline_text_path.py
@@ -8,8 +8,8 @@ Test PolyLineTextPath
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -44,9 +44,8 @@ def test_polyline_text_path():
 
     m.add_child(wind_line)
     m.add_child(wind_textpath)
-    m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # We verify that the script import is present.
     script = '<script src="https://rawcdn.githack.com/makinacorpus/Leaflet.TextPath/leaflet0.8-dev/leaflet.textpath.js"></script>'  # noqa
@@ -54,14 +53,11 @@ def test_polyline_text_path():
 
     # We verify that the script part is correct.
     tmpl = Template("""
-                {{this.polyline.get_name()}}.setText("{{this.text}}", {
-                    repeat: {{'true' if this.repeat else 'false'}},
-                    center: {{'true' if this.center else 'false'}},
-                    below: {{'true' if this.below else 'false'}},
-                    offset: {{this.offset}},
-                    orientation: {{this.orientation}},
-                    attributes: {{this.attributes}}
-                });
-        """)  # noqa
+        {{ this.polyline.get_name() }}.setText(
+            "{{this.text}}",
+            {{ this.options|tojson }}
+        );
+        """)
 
-    assert tmpl.render(this=wind_textpath) in out
+    expected = normalize(tmpl.render(this=wind_textpath))
+    assert expected in out

--- a/tests/plugins/test_scroll_zoom_toggler.py
+++ b/tests/plugins/test_scroll_zoom_toggler.py
@@ -8,8 +8,8 @@ Test ScrollZoomToggler
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -18,9 +18,8 @@ def test_scroll_zoom_toggler():
     m = folium.Map([45., 3.], zoom_start=4)
     szt = plugins.ScrollZoomToggler()
     m.add_child(szt)
-    m._repr_html_()
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # Verify that the div has been created.
     tmpl = Template("""
@@ -47,7 +46,8 @@ def test_scroll_zoom_toggler():
                 }
         </style>
     """)
-    assert ''.join(tmpl.render(this=szt).split()) in ''.join(out.split())
+    expected = normalize(tmpl.render(this=szt))
+    assert expected in out
 
     # Verify that the script is okay.
     tmpl = Template("""
@@ -57,16 +57,16 @@ def test_scroll_zoom_toggler():
             if (this.scrollEnabled) {
                 this.scrollEnabled = false;
                 this.scrollWheelZoom.disable();
-                }
-            else {
+            } else {
                 this.scrollEnabled = true;
                 this.scrollWheelZoom.enable();
-                }
-            };
+            }
+        };
 
         {{this._parent.get_name()}}.toggleScroll();
     """)
-    assert ''.join(tmpl.render(this=szt).split()) in ''.join(out.split())
+    expected = normalize(tmpl.render(this=szt))
+    assert expected in out
 
     bounds = m.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds

--- a/tests/plugins/test_terminator.py
+++ b/tests/plugins/test_terminator.py
@@ -8,23 +8,22 @@ Test Terminator
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
 
 def test_terminator():
     m = folium.Map([45., 3.], zoom_start=1)
-    t = plugins.Terminator()
-    m.add_child(t)
-    m._repr_html_()
+    t = plugins.Terminator().add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # Verify that the script is okay.
     tmpl = Template('L.terminator().addTo({{this._parent.get_name()}});')
-    assert ''.join(tmpl.render(this=t).split()) in ''.join(out.split())
+    expected = normalize(tmpl.render(this=t))
+    assert expected in out
 
     bounds = m.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -9,8 +9,8 @@ Test TimestampedGeoJson
 from __future__ import (absolute_import, division, print_function)
 
 import folium
-
 from folium import plugins
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -93,11 +93,9 @@ def test_timestamped_geo_json():
         }
 
     m = folium.Map([47, 3], zoom_start=1)
-    tgj = plugins.TimestampedGeoJson(data)
-    m.add_child(tgj)
-    m._repr_html_()
+    tgj = plugins.TimestampedGeoJson(data).add_to(m)
 
-    out = m._parent.render()
+    out = normalize(m._parent.render())
 
     # Verify the imports.
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>' in out
@@ -110,58 +108,65 @@ def test_timestamped_geo_json():
 
     # Verify that the script is okay.
     tmpl = Template("""
-            L.Control.TimeDimensionCustom = L.Control.TimeDimension.extend({
-                _getDisplayDateFormat: function(date){
-                    var newdate = new moment(date);
-                    console.log(newdate)
-                    return newdate.format("{{this.date_options}}");
-                }
-            });
-            {{this._parent.get_name()}}.timeDimension = L.timeDimension({period:"{{this.period}}"});
-            var timeDimensionControl = new L.Control.TimeDimensionCustom({{ this.options }});
-            {{this._parent.get_name()}}.addControl(this.timeDimensionControl);
+        L.Control.TimeDimensionCustom = L.Control.TimeDimension.extend({
+            _getDisplayDateFormat: function(date){
+                var newdate = new moment(date);
+                console.log(newdate)
+                return newdate.format("{{this.date_options}}");
+            }
+        });
+        {{this._parent.get_name()}}.timeDimension = L.timeDimension(
+            {
+                period: {{ this.period|tojson }},
+            }
+        );
+        var timeDimensionControl = new L.Control.TimeDimensionCustom(
+            {{ this.options|tojson }}
+        );
+        {{this._parent.get_name()}}.addControl(this.timeDimensionControl);
 
-            console.log("{{this.marker}}");
-
-            var geoJsonLayer = L.geoJson({{this.data}}, {
-                    pointToLayer: function (feature, latLng) {
-                        if (feature.properties.icon == 'marker') {
-                            if(feature.properties.iconstyle){
-                                return new L.Marker(latLng, {
-                                    icon: L.icon(feature.properties.iconstyle)});
-                            }
-                            //else
-                            return new L.Marker(latLng);
-                        }
-                        if (feature.properties.icon == 'circle') {
-                            if (feature.properties.iconstyle) {
-                                return new L.circleMarker(latLng, feature.properties.iconstyle)
-                                };
-                            //else
-                            return new L.circleMarker(latLng);
+        var geoJsonLayer = L.geoJson({{this.data}}, {
+                pointToLayer: function (feature, latLng) {
+                    if (feature.properties.icon == 'marker') {
+                        if(feature.properties.iconstyle){
+                            return new L.Marker(latLng, {
+                                icon: L.icon(feature.properties.iconstyle)});
                         }
                         //else
-
                         return new L.Marker(latLng);
-                    },
-                    style: function (feature) {
-                        return feature.properties.style;
-                    },
-                    onEachFeature: function(feature, layer) {
-                        if (feature.properties.popup) {
-                        layer.bindPopup(feature.properties.popup);
-                        }
                     }
-                })
+                    if (feature.properties.icon == 'circle') {
+                        if (feature.properties.iconstyle) {
+                            return new L.circleMarker(latLng, feature.properties.iconstyle)
+                            };
+                        //else
+                        return new L.circleMarker(latLng);
+                    }
+                    //else
 
-            var {{this.get_name()}} = L.timeDimension.layer.geoJson(geoJsonLayer,
-                {updateTimeDimension: true,
-                 addlastPoint: {{'true' if this.add_last_point else 'false'}},
-                 duration: {{this.duration}},
-                }).addTo({{this._parent.get_name()}});
+                    return new L.Marker(latLng);
+                },
+                style: function (feature) {
+                    return feature.properties.style;
+                },
+                onEachFeature: function(feature, layer) {
+                    if (feature.properties.popup) {
+                    layer.bindPopup(feature.properties.popup);
+                    }
+                }
+            })
+
+        var {{this.get_name()}} = L.timeDimension.layer.geoJson(
+            geoJsonLayer,
+            {
+                updateTimeDimension: true,
+                addlastPoint: {{ this.add_last_point|tojson }},
+                duration: {{ this.duration }},
+            }
+        ).addTo({{this._parent.get_name()}});
     """)  # noqa
-
-    assert ''.join(tmpl.render(this=tgj).split()) in ''.join(out.split())
+    expected = normalize(tmpl.render(this=tgj))
+    assert expected in out
 
     bounds = m.get_bounds()
     assert bounds == [[-53.0, -158.0], [50.0, 158.0]], bounds

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -98,8 +98,8 @@ def test_divicon():
               </svg>"""  # noqa
     div = folium.DivIcon(html=html)
     assert isinstance(div, Element)
-    assert div.className == 'empty'
-    assert div.html == html
+    assert div.options['className'] == 'empty'
+    assert div.options['html'] == html
 
 
 # ColorLine.

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -15,6 +15,7 @@ import branca.element
 
 import folium
 from folium.features import GeoJson, Choropleth
+from folium.utilities import normalize
 
 import jinja2
 from jinja2 import Environment, PackageLoader
@@ -209,7 +210,7 @@ class TestFolium(object):
 
         # Standard map.
         self.setup()
-        rendered = [line.strip() for line in self.m._parent.render().splitlines() if line.strip()]
+        rendered = self.m._parent.render()
 
         html_templ = self.env.get_template('fol_template.html')
         attr = 'http://openstreetmap.org'
@@ -241,10 +242,9 @@ class TestFolium(object):
                 'world_copy_jump': False,
                 'zoom_control': True
                 }
-        HTML = html_templ.render(tmpl, plugins={})
-        expected = [line.strip() for line in HTML.splitlines() if line.strip()]
+        expected = html_templ.render(tmpl, plugins={})
 
-        assert rendered == expected
+        assert normalize(rendered) == normalize(expected)
 
     def test_choropleth_features(self):
         """Test to make sure that Choropleth function doesn't allow

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,0 +1,40 @@
+"""Verify behavior of Jinja2's `tojson` template filter"""
+
+import jinja2
+import pytest
+
+
+@pytest.mark.parametrize('obj, expected', [
+    (True, 'true'),
+    (1, '1'),
+    (3.14, '3.14'),
+    ('hi', '"hi"'),
+    (
+        '<div style="something">content</div>',
+        '"\\u003cdiv style=\\"something\\"\\u003econtent\\u003c/div\\u003e"'
+    ),
+    ('Mus\u00e9e d\'Orsay', '"Mus\\u00e9e d\\u0027Orsay"'),
+    ([1, 2, 3], '[1, 2, 3]'),
+    ([1, 'hi', False], '[1, "hi", false]'),
+    ([[0, 0], [1, 1]], '[[0, 0], [1, 1]]'),
+    ([(0, 0), (1, 1)], '[[0, 0], [1, 1]]'),
+    ({'hi': 'there'}, '{"hi": "there"}'),
+])
+def test_jinja2_tojson(obj, expected):
+    res = jinja2.Template('{{ obj|tojson }}').render(obj=obj)
+    assert res == expected
+
+
+@pytest.mark.parametrize('obj, expected', [
+    (
+        {'hi': 'there', 'what': 'isup', },
+        '{\n  "hi": "there",\n  "what": "isup"\n}'
+    ),
+    (
+        [(0, 0), (1, 1)],
+        '[\n  [\n    0,\n    0\n  ],\n  [\n    1,\n    1\n  ]\n]',
+    ),
+])
+def test_jinja2_tojson_indented(obj, expected):
+    res = jinja2.Template('{{ obj|tojson(2) }}').render(obj=obj)
+    assert res == expected

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -19,6 +19,7 @@ import pytest
     ([[0, 0], [1, 1]], '[[0, 0], [1, 1]]'),
     ([(0, 0), (1, 1)], '[[0, 0], [1, 1]]'),
     ({'hi': 'there'}, '{"hi": "there"}'),
+    ({'hi': {'there': 1, 'whats': 'up'}}, '{"hi": {"there": 1, "whats": "up"}}'),
 ])
 def test_jinja2_tojson(obj, expected):
     res = jinja2.Template('{{ obj|tojson }}').render(obj=obj)

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -12,6 +12,7 @@ import pytest
 
 from folium import Map
 from folium.map import Popup, Icon
+from folium.utilities import normalize
 
 
 tmpl = u"""
@@ -19,10 +20,6 @@ tmpl = u"""
                 style="width: {width}; height: {height};">
                 {text}</div>
 """.format
-
-
-def _normalize(rendered):
-    return ''.join(rendered.split())
 
 
 def test_popup_ascii():
@@ -66,14 +63,16 @@ def test_popup_sticky():
     popup = Popup('Some text.', sticky=True).add_to(m)
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
-    var {popup_name} = L.popup({{maxWidth: \'100%\', autoClose: false, closeOnClick: false}});
+    var {popup_name} = L.popup({{
+        "autoClose": false, "closeOnClick": false, "maxWidth": "100%"
+    }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">Some text.</div>`)[0];
     {popup_name}.setContent({html_name});
     {map_name}.bindPopup({popup_name});
     """.format(popup_name=popup.get_name(),
                html_name=list(popup.html._children.keys())[0],
                map_name=m.get_name())
-    assert _normalize(rendered) == _normalize(expected)
+    assert normalize(rendered) == normalize(expected)
 
 
 def test_popup_show():
@@ -81,14 +80,17 @@ def test_popup_show():
     popup = Popup('Some text.', show=True).add_to(m)
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
-    var {popup_name} = L.popup({{maxWidth: \'100%\' , autoClose: false}});
+    var {popup_name} = L.popup({{
+        "autoClose": false, "maxWidth": "100%"
+    }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">Some text.</div>`)[0];
     {popup_name}.setContent({html_name});
     {map_name}.bindPopup({popup_name}).openPopup();
     """.format(popup_name=popup.get_name(),
                html_name=list(popup.html._children.keys())[0],
                map_name=m.get_name())
-    assert _normalize(rendered) == _normalize(expected)
+    # assert compare_rendered(rendered, expected)
+    assert normalize(rendered) == normalize(expected)
 
 
 def test_icon_valid_marker_colors():

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -9,6 +9,7 @@ Test raster_layers
 from __future__ import (absolute_import, division, print_function)
 
 import folium
+from folium.utilities import normalize
 
 from jinja2 import Template
 
@@ -114,13 +115,13 @@ def test_image_overlay():
 
     # Verify the script part is okay.
     tmpl = Template("""
-                var {{this.get_name()}} = L.imageOverlay(
-                    '{{ this.url }}',
-                    {{ this.bounds }},
-                    {{ this.options }}
-                    ).addTo({{this._parent.get_name()}});
+        var {{this.get_name()}} = L.imageOverlay(
+            "{{ this.url }}",
+            {{ this.bounds }},
+            {{ this.options }}
+            ).addTo({{this._parent.get_name()}});
     """)
-    assert tmpl.render(this=io) in out
+    assert normalize(tmpl.render(this=io)) in normalize(out)
 
     bounds = m.get_bounds()
     assert bounds == [[0, -180], [90, 180]], bounds

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -2,7 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 
 import pytest
 
-from folium.utilities import camelize, deep_copy, get_obj_in_upper_tree
+from folium.utilities import (
+    camelize,
+    deep_copy,
+    get_obj_in_upper_tree,
+    parse_options,
+)
 from folium import Map, FeatureGroup, Marker, Popup
 
 
@@ -45,3 +50,10 @@ def test_get_obj_in_upper_tree():
         assert get_obj_in_upper_tree(fg, Marker)
     with pytest.raises(ValueError):
         assert get_obj_in_upper_tree(marker, Popup)
+
+
+def test_parse_options():
+    assert parse_options(thing=42) == {'thing': 42}
+    assert parse_options(thing=None) == {}
+    assert parse_options(long_thing=42) == {'longThing': 42}
+    assert parse_options(thing=42, lst=[1, 2]) == {'thing': 42, 'lst': [1, 2]}

--- a/tests/test_vector_layers.py
+++ b/tests/test_vector_layers.py
@@ -11,12 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import json
 
 from folium import Map
-from folium.utilities import get_bounds
+from folium.utilities import get_bounds, normalize
 from folium.vector_layers import Circle, CircleMarker, PolyLine, Polygon, Rectangle
 
-
-def _normalize(rendered):
-    return [line.strip() for line in rendered.splitlines() if line.strip()]
 
 def test_circle():
     m = Map()
@@ -78,11 +75,11 @@ def test_circle():
     """.format(name=circle.get_name(), location=location, radius=radius, map=m.get_name())  # noqa
 
     rendered = circle._template.module.script(circle)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert circle.get_bounds() == [location, location]
     assert json.dumps(circle.to_dict()) == circle.to_json()
     assert circle.location == [-27.551667, -48.478889]
-    assert circle.options == json.dumps(expected_options, sort_keys=True, indent=2)  # noqa
+    assert circle.options == expected_options
 
 
 def test_circle_marker():
@@ -146,11 +143,11 @@ def test_circle_marker():
     """.format(name=circle_marker.get_name(), location=location, radius=radius, map=m.get_name())  # noqa
 
     rendered = circle_marker._template.module.script(circle_marker)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert circle_marker.get_bounds() == expected_bounds
     assert json.dumps(circle_marker.to_dict()) == circle_marker.to_json()
     assert circle_marker.location == location
-    assert circle_marker.options == json.dumps(options, sort_keys=True, indent=2)  # noqa
+    assert circle_marker.options == options
 
 
 def test_rectangle():
@@ -212,10 +209,10 @@ def test_rectangle():
     """.format(name=rectangle.get_name(), location=location, map=m.get_name())
 
     rendered = rectangle._template.module.script(rectangle)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert rectangle.get_bounds() == location
     assert json.dumps(rectangle.to_dict()) == rectangle.to_json()
-    assert rectangle.options == json.dumps(expected_options, sort_keys=True, indent=2)  # noqa
+    assert rectangle.options == expected_options
 
 
 def test_polygon_marker():
@@ -275,10 +272,10 @@ def test_polygon_marker():
     """.format(locations=locations, name=polygon.get_name(), map=m.get_name())
 
     rendered = polygon._template.module.script(polygon)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert polygon.get_bounds() == get_bounds(locations)
     assert json.dumps(polygon.to_dict()) == polygon.to_json()
-    assert polygon.options == json.dumps(expected_options, sort_keys=True, indent=2)  # noqa
+    assert polygon.options == expected_options
 
 
 def test_polyline():
@@ -331,10 +328,10 @@ def test_polyline():
     """.format(locations=locations, name=polyline.get_name(), map=m.get_name())
 
     rendered = polyline._template.module.script(polyline)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert polyline.get_bounds() == get_bounds(locations)
     assert json.dumps(polyline.to_dict()) == polyline.to_json()
-    assert polyline.options == json.dumps(expected_options, sort_keys=True, indent=2)  # noqa
+    assert polyline.options == expected_options
 
 
 def test_mulyipolyline():
@@ -390,7 +387,7 @@ def test_mulyipolyline():
     """.format(locations=locations, name=multipolyline.get_name(), map=m.get_name())
 
     rendered = multipolyline._template.module.script(multipolyline)
-    assert _normalize(rendered) == _normalize(expected_rendered)
+    assert normalize(rendered) == normalize(expected_rendered)
     assert multipolyline.get_bounds() == get_bounds(locations)
     assert json.dumps(multipolyline.to_dict()) == multipolyline.to_json()
-    assert multipolyline.options == json.dumps(expected_options, sort_keys=True, indent=2)  # noqa
+    assert multipolyline.options == expected_options

--- a/tests/test_vector_layers.py
+++ b/tests/test_vector_layers.py
@@ -280,7 +280,7 @@ def test_polygon_marker():
 
 def test_polyline():
     m = Map()
-    locations = [[40, -80], [45, -80]]
+    locations = [[40.0, -80.0], [45.0, -80.0]]
     polyline = PolyLine(locations=locations, popup='I am PolyLine')
     polyline.add_to(m)
 


### PR DESCRIPTION
Don't `json.dumps` options and data, but use Jinja2's `tojson` filter to convert Python variables to JS compatible formats. This works for strings, numbers, bools, lists and dictionaries. I added a test file to verify this behavior.

Normalize the behavior of options. In `__init__`, put options in a `self.options` dictionary using a new `parse_options()` function. Also allow `**kwargs` whenever it makes sense.

This combination: consistent option handling and using `tojson` makes our code and templates more clean and consistent. Allowing `**kwargs` gives users more flexibility.

I also did refactoring of templates whenever I touched them. Have consistent indentation and style.

Fixed the tests for the changes. Consistently use the `normalize` function to normalize rendered output.