### PR TITLE
Fix marker color bug

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -220,7 +220,7 @@ class Icon(MacroElement):
             warnings.warn('color argument of Icon should be one of: {}.'
                           .format(self.color_options), stacklevel=2)
         self.options = parse_options(
-            color=color,
+            marker_color=color,
             icon_color=icon_color,
             icon=icon,
             prefix=prefix,


### PR DESCRIPTION
With the recent big change the `color` argument of `Icon` got screwed up. It's not passed on to it's JS class correctly. It's JS name is `markerColor`, not `color`.

Closes #1106