### PR TITLE
Adding `icon_create_function` argument to Fast Marker Cluster plugin

### DIFF
--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -38,6 +38,9 @@ class FastMarkerCluster(MarkerCluster):
         Whether the Layer will be included in LayerControls.
     show: bool, default True
         Whether the layer will be shown on opening (only for overlays).
+    icon_create_function : string, default None
+        Override the default behaviour, making possible to customize
+        markers colors and sizes.
     **kwargs
         Additional arguments are passed to Leaflet.markercluster options. See
         https://github.com/Leaflet/Leaflet.markercluster
@@ -50,6 +53,10 @@ class FastMarkerCluster(MarkerCluster):
 
                 var data = {{ this.data|tojson }};
                 var cluster = L.markerClusterGroup({{ this.options|tojson }});
+                {%- if this.icon_create_function is not none %}
+                cluster.options.iconCreateFunction =
+                    {{ this.icon_create_function.strip() }};
+                {%- endif %}
 
                 for (var i = 0; i < data.length; i++) {
                     var row = data[i];
@@ -63,11 +70,12 @@ class FastMarkerCluster(MarkerCluster):
         {% endmacro %}""")
 
     def __init__(self, data, callback=None, options=None,
-                 name=None, overlay=True, control=True, show=True, **kwargs):
+                 name=None, overlay=True, control=True, show=True, icon_create_function=None, **kwargs):
         if options is not None:
             kwargs.update(options)  # options argument is legacy
         super(FastMarkerCluster, self).__init__(name=name, overlay=overlay,
                                                 control=control, show=show,
+                                                icon_create_function=icon_create_function,
                                                 **kwargs)
         self._name = 'FastMarkerCluster'
         data = if_pandas_df_convert_to_numpy(data)

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from folium.plugins.marker_cluster import MarkerCluster
-from folium.utilities import validate_location, if_pandas_df_convert_to_numpy
+from folium.utilities import if_pandas_df_convert_to_numpy, validate_location
 
 from jinja2 import Template
 

--- a/tests/plugins/test_fast_marker_cluster.py
+++ b/tests/plugins/test_fast_marker_cluster.py
@@ -44,6 +44,10 @@ def test_fast_marker_cluster():
 
             var data = {{ this.data|tojson }};
             var cluster = L.markerClusterGroup({{ this.options|tojson }});
+            {%- if this.icon_create_function is not none %}
+            cluster.options.iconCreateFunction = 
+                {{ this.icon_create_function.strip() }};
+            {%- endif %}
 
             for (var i = 0; i < data.length; i++) {
                 var row = data[i];

--- a/tests/plugins/test_fast_marker_cluster.py
+++ b/tests/plugins/test_fast_marker_cluster.py
@@ -45,7 +45,7 @@ def test_fast_marker_cluster():
             var data = {{ this.data|tojson }};
             var cluster = L.markerClusterGroup({{ this.options|tojson }});
             {%- if this.icon_create_function is not none %}
-            cluster.options.iconCreateFunction = 
+            cluster.options.iconCreateFunction =
                 {{ this.icon_create_function.strip() }};
             {%- endif %}
 


### PR DESCRIPTION
# Overview
The Fast Marker Cluster plugin is great, especially with the latest changes making it easier to pass in additional data for the markers. A missing feature is the ability to pass in a custom JavaScript function for generating the cluster icons.

To keep things simple, I've copied over the interface from `MakerCluster`, and I'm passing through any function created transparently. The only substantive change required was updating the Fast Marker's Jinja template.

# Testing
## Linting
```bash
$ flake8 folium/plugins/fast_marker_cluster.py --max-line-length=120
$ flake8 tests/plugins/fast_marker_cluster.py --max-line-length=120
```
## Unit Tests
```bash
$ python3 -m pytest tests
========================================= test session starts ==========================================
platform linux -- Python 3.6.7, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /home/gordon/workspace/folium, inifile: setup.cfg
plugins: xdist-1.27.0, forked-1.0.2, flake8-1.0.4, cov-2.6.1, nbval-0.9.1
collected 134 items                                                                                    

tests/test_features.py .........                                                                 [  6%]
tests/test_folium.py ................                                                            [ 18%]
tests/test_jinja.py ..............                                                               [ 29%]
tests/test_map.py .......                                                                        [ 34%]
tests/test_raster_layers.py ....                                                                 [ 37%]
tests/test_repr.py .....                                                                         [ 41%]
tests/test_utilities.py .................................................                        [ 77%]
tests/test_vector_layers.py ......                                                               [ 82%]
tests/plugins/test_antpath.py .                                                                  [ 82%]
tests/plugins/test_beautify_icon.py .                                                            [ 83%]
tests/plugins/test_boat_marker.py ..                                                             [ 85%]
tests/plugins/test_dual_map.py .                                                                 [ 85%]
tests/plugins/test_fast_marker_cluster.py ....                                                   [ 88%]
tests/plugins/test_feature_group_sub_group.py .                                                  [ 89%]
tests/plugins/test_float_image.py .                                                              [ 90%]
tests/plugins/test_fullscreen.py .                                                               [ 91%]
tests/plugins/test_heat_map.py ...                                                               [ 93%]
tests/plugins/test_heat_map_withtime.py .                                                        [ 94%]
tests/plugins/test_marker_cluster.py .                                                           [ 94%]
tests/plugins/test_minimap.py .                                                                  [ 95%]
tests/plugins/test_pattern.py .                                                                  [ 96%]
tests/plugins/test_polyline_text_path.py .                                                       [ 97%]
tests/plugins/test_scroll_zoom_toggler.py .                                                      [ 97%]
tests/plugins/test_terminator.py .                                                               [ 98%]
tests/plugins/test_time_slider_choropleth.py x                                                   [ 99%]
tests/plugins/test_timestamped_geo_json.py .                                                     [100%]

=========================================== warnings summary ===========================================
/home/gordon/.local/lib/python3.6/site-packages/pkg_resources/__init__.py:1151
/home/gordon/.local/lib/python3.6/site-packages/pkg_resources/__init__.py:1151
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
tests/test_folium.py::TestFolium::test_choropleth_features
  /home/gordon/.local/lib/python3.6/site-packages/pkg_resources/__init__.py:1151: DeprecationWarning: Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release.
    self, resource_name

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================= 133 passed, 1 xfailed, 11 warnings in 43.97 seconds ==========================
```
## Ad-hoc Tests
Defining a JS function that determines the cluster class based upon the content of its children's popup content:
```javascript
function (cluster) {
   var childCount = cluster.getChildCount();
   var childMarkers = cluster.getAllChildMarkers();
   
   // Working out proportion of children whose popup content starts with "+"
   var withinProportion = 0.0;
   for (i = 0; i < childCount; i++) {
     var popup = childMarkers[i].getPopup();
     var content = popup.getContent();
     if (content[0] == "+") {
       withinProportion += 1.0;
     }
   }
   withinProportion /= childCount;
   
   // Working out class based upon proportion
   var c = ' marker-cluster-';
   if (withinProportion > 0.9) {
     c += 'small';
   } 
   else if (withinProportion > 0.8) {
     c += 'medium';
   } 
   else {
     c += 'large';
   }
   
   return L.divIcon({ html: '<div><span>' + cluster.getChildCount() + '</span></div>' , 
                     className: 'marker-cluster' + c,
                     iconSize: new L.Point(40, 40)});
};
```
Function is saved as a multiline string in `icon_create`.

Passing into the Marker cluster:
```python
fast_marker_cluster = FastMarkerCluster(
    data=data,
    callback=callback,
    icon_create_function=icon_create
)
```
Resulting map with clusters customised based on child content:
![fast_cluster_test](https://user-images.githubusercontent.com/1272984/54814728-fc1cda00-4c98-11e9-869c-16ce7c549c32.png)
