### PR TITLE
Remove future imports and Six

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 ::
 
- branca, jinja2, requests, and six.
+ branca, jinja2 and requests.
 
 Some functionalities may require extra dependencies
 `numpy`, `pandas`, `geopandas`, `altair`, etc.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<head>    
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    
+        <script>
+            L_PREFER_CANVAS = false;
+            L_NO_TOUCH = false;
+            L_DISABLE_3D = false;
+        </script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.js"></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.4.0/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css"/>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"/>
+    <link rel="stylesheet" href="https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css"/>
+    <style>html, body {width: 100%;height: 100%;margin: 0;padding: 0;}</style>
+    <style>#map {position:absolute;top:0;bottom:0;right:0;left:0;}</style>
+    
+            <meta name="viewport" content="width=device-width,
+                initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+            <style>
+                #map_d19ea42a01d7424e899dfb6eb4ab0d7b {
+                    position: relative;
+                    width: 100.0%;
+                    height: 100.0%;
+                    left: 0.0%;
+                    top: 0.0%;
+                }
+            </style>
+        
+</head>
+<body>    
+    
+            <div class="folium-map" id="map_d19ea42a01d7424e899dfb6eb4ab0d7b" ></div>
+        
+</body>
+<script>    
+    
+                var bounds = null;
+
+            var map_d19ea42a01d7424e899dfb6eb4ab0d7b = L.map(
+                "map_d19ea42a01d7424e899dfb6eb4ab0d7b",
+                {
+                    center: [45.5236, -122.675],
+                    zoom: 10,
+                    maxBounds: bounds,
+                    layers: [],
+                    worldCopyJump: false,
+                    crs: L.CRS.EPSG3857,
+                    zoomControl: true,
+                }
+            );
+
+            
+
+        
+    
+            var tile_layer_872f9c8b47294f9095ed47e2fbacdd62 = L.tileLayer(
+                "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                {"detectRetina": false, "maxNativeZoom": 18, "maxZoom": 18, "minZoom": 0, "noWrap": false, "opacity": 1, "subdomains": "abc", "tms": false}
+            ).addTo(map_d19ea42a01d7424e899dfb6eb4ab0d7b);
+        
+</script>

--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 import sys
 
 import branca

--- a/folium/features.py
+++ b/folium/features.py
@@ -34,8 +34,6 @@ import numpy as np
 
 import requests
 
-from six import binary_type, text_type
-
 
 class RegularPolygonMarker(Marker):
     """
@@ -134,7 +132,7 @@ class Vega(Element):
         super(Vega, self).__init__()
         self._name = 'Vega'
         self.data = data.to_json() if hasattr(data, 'to_json') else data
-        if isinstance(self.data, text_type) or isinstance(data, binary_type):
+        if isinstance(self.data, str):
             self.data = json.loads(self.data)
 
         # Size Parameters.
@@ -226,7 +224,7 @@ class VegaLite(Element):
         super(self.__class__, self).__init__()
         self._name = 'VegaLite'
         self.data = data.to_json() if hasattr(data, 'to_json') else data
-        if isinstance(self.data, text_type) or isinstance(data, binary_type):
+        if isinstance(self.data, str):
             self.data = json.loads(self.data)
 
         self.json = json.dumps(self.data)
@@ -473,7 +471,7 @@ class GeoJson(Layer):
         if isinstance(data, dict):
             self.embed = True
             return data
-        elif isinstance(data, text_type) or isinstance(data, binary_type):
+        elif isinstance(data, str):
             if data.lower().startswith(('http:', 'ftp:', 'https:')):
                 if not self.embed:
                     self.embed_link = data

--- a/folium/features.py
+++ b/folium/features.py
@@ -5,8 +5,6 @@ Leaflet GeoJson and miscellaneous features.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import json
 import warnings
 import functools

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -5,8 +5,6 @@ Make beautiful, interactive maps with Python and Leaflet.js
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import time
 import warnings
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -5,8 +5,6 @@ Classes for drawing maps.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 from collections import OrderedDict
 
 import warnings

--- a/folium/map.py
+++ b/folium/map.py
@@ -15,8 +15,6 @@ from folium.utilities import validate_location, camelize, parse_options
 
 from jinja2 import Template
 
-from six import binary_type, text_type
-
 
 class Layer(MacroElement):
     """An abstract class for everything that is a Layer on the map.
@@ -342,8 +340,8 @@ class Popup(Element):
 
         if isinstance(html, Element):
             self.html.add_child(html)
-        elif isinstance(html, text_type) or isinstance(html, binary_type):
-            self.html.add_child(Html(text_type(html), script=script))
+        elif isinstance(html, str):
+            self.html.add_child(Html(html, script=script))
 
         self.show = show
         self.options = parse_options(

--- a/folium/plugins/__init__.py
+++ b/folium/plugins/__init__.py
@@ -8,8 +8,6 @@ Wrap some of the most popular leaflet external plugins.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 from folium.plugins.antpath import AntPath
 from folium.plugins.beautify_icon import BeautifyIcon
 from folium.plugins.boat_marker import BoatMarker

--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.vector_layers import path_options, BaseMultiLocation

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.utilities import parse_options

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.map import Marker

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
 
 from jinja2 import Template

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from folium.plugins.marker_cluster import MarkerCluster
 from folium.utilities import validate_location, if_pandas_df_convert_to_numpy
 

--- a/folium/plugins/feature_group_sub_group.py
+++ b/folium/plugins/feature_group_sub_group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.map import Layer

--- a/folium/plugins/float_image.py
+++ b/folium/plugins/float_image.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import MacroElement
 
 from jinja2 import Template

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.utilities import parse_options

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.map import Layer

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function
-
 from branca.element import CssLink, Figure, JavascriptLink
 
 from folium.map import Layer, Marker

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.utilities import parse_options

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.raster_layers import TileLayer

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.utilities import parse_options

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink, MacroElement
 
 from folium.folium import Map

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.features import MacroElement

--- a/folium/plugins/scroll_zoom_toggler.py
+++ b/folium/plugins/scroll_zoom_toggler.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import MacroElement
 
 from jinja2 import Template

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from jinja2 import Template

--- a/folium/plugins/terminator.py
+++ b/folium/plugins/terminator.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink, MacroElement
 
 from jinja2 import Template

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Figure, JavascriptLink
 
 from folium.features import GeoJson

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 import json
 
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import CssLink, Figure, JavascriptLink
 
 from folium.map import Layer

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -12,8 +12,6 @@ from folium.utilities import image_to_url, mercator_transform, parse_options
 
 from jinja2 import Environment, PackageLoader, Template
 
-from six import binary_type, text_type
-
 
 ENV = Environment(loader=PackageLoader('folium', 'templates'))
 
@@ -120,8 +118,6 @@ class TileLayer(Layer):
             self.tiles = tiles
             if not attr:
                 raise ValueError('Custom tiles must have an attribution.')
-            if isinstance(attr, binary_type):
-                attr = text_type(attr, 'utf8')
             self.attr = attr
 
 

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -5,8 +5,6 @@ Wraps leaflet TileLayer, WmsTileLayer (TileLayer.WMS), ImageOverlay, and VideoOv
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 from branca.element import Element, Figure
 
 from folium.map import Layer

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -10,15 +10,13 @@ from contextlib import contextmanager
 import copy
 import uuid
 import collections
+from urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 
 import numpy as np
 try:
     import pandas as pd
 except ImportError:
     pd = None
-
-from six import binary_type, text_type
-from six.moves.urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
@@ -130,7 +128,7 @@ def image_to_url(image, colormap=None, origin='upper'):
         0. and 1.  You can use colormaps from `matplotlib.cm`.
 
     """
-    if isinstance(image, (text_type, binary_type)) and not _is_url(image):
+    if isinstance(image, str) and not _is_url(image):
         fileformat = os.path.splitext(image)[-1][1:]
         with io.open(image, 'rb') as f:
             img = f.read()

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-
 import base64
 import io
 import json

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -5,8 +5,6 @@ Wraps leaflet Polyline, Polygon, Rectangle, Circlem and CircleMarker
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 from branca.element import MacroElement
 
 from folium.map import Marker, Popup, Tooltip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ branca>=0.3.0
 jinja2
 numpy
 requests
-six

--- a/tests/plugins/test_antpath.py
+++ b/tests/plugins/test_antpath.py
@@ -5,8 +5,6 @@ Test AntPath
 -------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_beautify_icon.py
+++ b/tests/plugins/test_beautify_icon.py
@@ -6,8 +6,6 @@ Test BeautifyIcon
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 from jinja2 import Template
 
 import folium

--- a/tests/plugins/test_boat_marker.py
+++ b/tests/plugins/test_boat_marker.py
@@ -6,8 +6,6 @@ Test BoatMarker
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_dual_map.py
+++ b/tests/plugins/test_dual_map.py
@@ -5,8 +5,6 @@ Test DualMap
 ------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 from jinja2 import Template
 
 import folium

--- a/tests/plugins/test_fast_marker_cluster.py
+++ b/tests/plugins/test_fast_marker_cluster.py
@@ -5,8 +5,6 @@ Test FastMarkerCluster
 ----------------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium.plugins import FastMarkerCluster
 from folium.utilities import normalize

--- a/tests/plugins/test_feature_group_sub_group.py
+++ b/tests/plugins/test_feature_group_sub_group.py
@@ -5,8 +5,6 @@ Test MarkerCluster
 ------------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_float_image.py
+++ b/tests/plugins/test_float_image.py
@@ -5,8 +5,6 @@ Test FloatImage
 ---------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_fullscreen.py
+++ b/tests/plugins/test_fullscreen.py
@@ -6,8 +6,6 @@ Test Fullscreen
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_heat_map.py
+++ b/tests/plugins/test_heat_map.py
@@ -5,8 +5,6 @@ Test HeatMap
 ------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium.plugins import HeatMap
 from folium.utilities import normalize

--- a/tests/plugins/test_heat_map_withtime.py
+++ b/tests/plugins/test_heat_map_withtime.py
@@ -5,8 +5,6 @@ Test HeatMapWithTime
 ------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_marker_cluster.py
+++ b/tests/plugins/test_marker_cluster.py
@@ -5,8 +5,6 @@ Test MarkerCluster
 ------------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_minimap.py
+++ b/tests/plugins/test_minimap.py
@@ -5,8 +5,6 @@ Test MiniMap
 ---------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_pattern.py
+++ b/tests/plugins/test_pattern.py
@@ -6,7 +6,6 @@ Test pattern
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 import os
 
 import folium

--- a/tests/plugins/test_polyline_text_path.py
+++ b/tests/plugins/test_polyline_text_path.py
@@ -5,8 +5,6 @@ Test PolyLineTextPath
 ---------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_scroll_zoom_toggler.py
+++ b/tests/plugins/test_scroll_zoom_toggler.py
@@ -5,8 +5,6 @@ Test ScrollZoomToggler
 ----------------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_terminator.py
+++ b/tests/plugins/test_terminator.py
@@ -5,8 +5,6 @@ Test Terminator
 ---------------
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/plugins/test_time_slider_choropleth.py
+++ b/tests/plugins/test_time_slider_choropleth.py
@@ -4,8 +4,6 @@ tests TimeSliderChoropleth
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import json
 
 from branca.colormap import linear

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -6,8 +6,6 @@ Test TimestampedGeoJson
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium import plugins
 from folium.utilities import normalize

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -14,8 +14,6 @@ from branca.element import Element
 import folium
 from folium import Map, Popup
 
-from six import text_type
-
 import pytest
 
 
@@ -49,7 +47,7 @@ def test_figure_creation():
 def test_figure_rendering():
     f = folium.Figure()
     out = f.render()
-    assert type(out) is text_type
+    assert type(out) is str
 
     bounds = f.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -23,8 +23,6 @@ import pandas as pd
 
 import pytest
 
-from six import PY3
-
 try:
     from unittest import mock
 except ImportError:
@@ -293,20 +291,7 @@ class TestFolium(object):
                     for child in self.m._children.values()])
 
     def test_tile_attr_unicode(self):
-        """Test tile attribution unicode
-
-        Test does not cover b'юникод'
-        because for python 3 bytes can only contain ASCII literal characters.
-        """
-
-        if not PY3:
-            m = folium.Map(location=[45.5236, -122.6750],
-                           tiles='test', attr=b'unicode')
-            m._parent.render()
-        else:
-            m = folium.Map(location=[45.5236, -122.6750],
-                           tiles='test', attr=u'юникод')
-            m._parent.render()
+        """Test tile attribution unicode"""
         m = folium.Map(location=[45.5236, -122.6750],
                        tiles='test', attr='юникод')
         m._parent.render()

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -6,8 +6,6 @@ Folium Tests
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import json
 import os
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -6,8 +6,6 @@ Folium map Tests
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import pytest
 
 from folium import Map

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -6,8 +6,6 @@ Test raster_layers
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import folium
 from folium.utilities import normalize
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -6,8 +6,6 @@ Folium _repr_*_ Tests
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import io
 import sys
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/test_vector_layers.py
+++ b/tests/test_vector_layers.py
@@ -6,8 +6,6 @@ Test Vector Layers
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 import json
 
 from folium import Map


### PR DESCRIPTION
Remove lines with `from __future__ import`.

Remove the use of the `six` library.

I'm assuming nobody will pass `byte` objects instead of `str`.