### PR TITLE
Use Xenial on Travis to fix nbval on Py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   global:
     - secure: "MTRxGE7N7I60vOk3f32NZjL2BLmP1H0W11HqfcbDO9IEN9Pb47mXQW6rNF0ZqOTt78kWtcHsR2non+nrLIjkglAb4psjUWOdQVh73y3JU4OrXqGCLssgIq9m6fMGOeFWvdektKG4v0TlnYwLhd6Lzes6eTrc+Z2UMHf4dZtuOPs="
 
+dist: xenial
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Nbval is a package that tests our notebooks. To make it work on Travis we should either use a newer Ubuntu version than the default, or test on Py 3.6 instead of 3.7.

In this change I'm trying running all Travis tests on Ubuntu Xenial instead of the default Trusty.

https://docs.travis-ci.com/user/reference/overview/#linux