### PR TITLE
Require Jinja2 version with tojson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 branca>=0.3.0
-jinja2
+jinja2>=2.9
 numpy
 requests


### PR DESCRIPTION
The `tojson` filter was introduced in version 2.9. folium won't work with lower versions.