### PR TITLE
Fix broken attribution for built-in tiles.

### DIFF
--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -90,6 +90,23 @@ class TileLayer(Layer):
         self._name = 'TileLayer'
         self._env = ENV
 
+        tiles_flat = ''.join(tiles.lower().strip().split())
+        if tiles_flat in ('cloudmade', 'mapbox') and not API_key:
+            raise ValueError('You must pass an API key if using Cloudmade'
+                             ' or non-default Mapbox tiles.')
+        templates = list(self._env.list_templates(
+            filter_func=lambda x: x.startswith('tiles/')))
+        tile_template = 'tiles/' + tiles_flat + '/tiles.txt'
+        attr_template = 'tiles/' + tiles_flat + '/attr.txt'
+
+        if tile_template in templates and attr_template in templates:
+            self.tiles = self._env.get_template(tile_template).render(API_key=API_key)  # noqa
+            attr = self._env.get_template(attr_template).render()
+        else:
+            self.tiles = tiles
+            if not attr:
+                raise ValueError('Custom tiles must have an attribution.')
+
         self.options = parse_options(
             min_zoom=min_zoom,
             max_zoom=max_zoom,
@@ -102,23 +119,6 @@ class TileLayer(Layer):
             opacity=opacity,
             **kwargs
         )
-        tiles_flat = ''.join(tiles.lower().strip().split())
-        if tiles_flat in ('cloudmade', 'mapbox') and not API_key:
-            raise ValueError('You must pass an API key if using Cloudmade'
-                             ' or non-default Mapbox tiles.')
-        templates = list(self._env.list_templates(
-            filter_func=lambda x: x.startswith('tiles/')))
-        tile_template = 'tiles/' + tiles_flat + '/tiles.txt'
-        attr_template = 'tiles/' + tiles_flat + '/attr.txt'
-
-        if tile_template in templates and attr_template in templates:
-            self.tiles = self._env.get_template(tile_template).render(API_key=API_key)  # noqa
-            self.attr = self._env.get_template(attr_template).render()
-        else:
-            self.tiles = tiles
-            if not attr:
-                raise ValueError('Custom tiles must have an attribution.')
-            self.attr = attr
 
 
 class WmsTileLayer(Layer):

--- a/folium/templates/tiles/cartodbdark_matter/attr.txt
+++ b/folium/templates/tiles/cartodbdark_matter/attr.txt
@@ -1,1 +1,1 @@
-(c) <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors (c) <a href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a href ="http://cartodb.com/attributions">attributions</a>
+&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cartodbpositron/attr.txt
+++ b/folium/templates/tiles/cartodbpositron/attr.txt
@@ -1,1 +1,1 @@
-(c) <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors (c) <a href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a href ="http://cartodb.com/attributions">attributions</a>
+&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cloudmade/attr.txt
+++ b/folium/templates/tiles/cloudmade/attr.txt
@@ -1,1 +1,1 @@
-Map data (c) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery (c) <a href="http://cloudmade.com">CloudMade</a>
+Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://cloudmade.com">CloudMade</a>

--- a/folium/templates/tiles/mapbox/attr.txt
+++ b/folium/templates/tiles/mapbox/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://www.mapbox.com/m">Mapbox</a> Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/mapboxbright/attr.txt
+++ b/folium/templates/tiles/mapboxbright/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://www.mapbox.com/m">Mapbox</a> Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/mapboxcontrolroom/attr.txt
+++ b/folium/templates/tiles/mapboxcontrolroom/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://www.mapbox.com/m">Mapbox</a> Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/openstreetmap/attr.txt
+++ b/folium/templates/tiles/openstreetmap/attr.txt
@@ -1,1 +1,1 @@
-Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.
+Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.

--- a/folium/templates/tiles/stamenterrain/attr.txt
+++ b/folium/templates/tiles/stamenterrain/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/stamentoner/attr.txt
+++ b/folium/templates/tiles/stamentoner/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.
+Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.

--- a/folium/templates/tiles/stamenwatercolor/attr.txt
+++ b/folium/templates/tiles/stamenwatercolor/attr.txt
@@ -1,1 +1,1 @@
-Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
+Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -133,10 +133,10 @@ class TestFolium(object):
         for tiles in default_tiles:
             m = folium.Map(location=[45.5236, -122.6750], tiles=tiles)
             tiles = "".join(tiles.lower().strip().split())
-            url = f"tiles/{tiles}/tiles.txt"
-            attr = f"tiles/{tiles}/attr.txt"
-            url = m._env.get_template(url).render()
-            attr = m._env.get_template(attr).render()
+            url = "tiles/{}/tiles.txt".format
+            attr = "tiles/{}/attr.txt".format
+            url = m._env.get_template(url(tiles)).render()
+            attr = m._env.get_template(attr(tiles)).render()
 
             assert m._children[tiles].tiles == url
             assert htmlsafe_json_dumps(attr) in m._parent.render()

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -13,10 +13,10 @@ import branca.element
 
 import folium
 from folium.features import GeoJson, Choropleth
-from folium.utilities import normalize
 
 import jinja2
 from jinja2 import Environment, PackageLoader
+from jinja2.utils import htmlsafe_json_dumps
 
 import numpy as np
 import pandas as pd
@@ -114,24 +114,32 @@ class TestFolium(object):
                     'name': 'TileLayer',
                     'id': '00000000000000000000000000000000',
                     'children': {}
-                    }
                 }
             }
+        }
 
     def test_builtin_tile(self):
         """Test custom maptiles."""
 
-        default_tiles = ['OpenStreetMap', 'Stamen Terrain', 'Stamen Toner']
+        default_tiles = [
+            "OpenStreetMap",
+            "Stamen Terrain",
+            "Stamen Toner",
+            "Mapbox Bright",
+            "Mapbox Control Room",
+            "CartoDB positron",
+            "CartoDB dark_matter",
+        ]
         for tiles in default_tiles:
             m = folium.Map(location=[45.5236, -122.6750], tiles=tiles)
-            tiles = ''.join(tiles.lower().strip().split())
-            url = 'tiles/{}/tiles.txt'.format
-            attr = 'tiles/{}/attr.txt'.format
-            url = m._env.get_template(url(tiles)).render()
-            attr = m._env.get_template(attr(tiles)).render()
+            tiles = "".join(tiles.lower().strip().split())
+            url = f"tiles/{tiles}/tiles.txt"
+            attr = f"tiles/{tiles}/attr.txt"
+            url = m._env.get_template(url).render()
+            attr = m._env.get_template(attr).render()
 
             assert m._children[tiles].tiles == url
-            assert m._children[tiles].attr == attr
+            assert htmlsafe_json_dumps(attr) in m._parent.render()
 
         bounds = m.get_bounds()
         assert bounds == [[None, None], [None, None]], bounds
@@ -139,15 +147,15 @@ class TestFolium(object):
     def test_custom_tile(self):
         """Test custom tile URLs."""
 
-        url = 'http://{s}.custom_tiles.org/{z}/{x}/{y}.png'
-        attr = 'Attribution for custom tiles'
+        url = "http://{s}.custom_tiles.org/{z}/{x}/{y}.png"
+        attr = "Attribution for custom tiles"
 
         with pytest.raises(ValueError):
             folium.Map(location=[45.5236, -122.6750], tiles=url)
 
         m = folium.Map(location=[45.52, -122.67], tiles=url, attr=attr)
         assert m._children[url].tiles == url
-        assert m._children[url].attr == attr
+        assert attr in m._parent.render()
 
         bounds = m.get_bounds()
         assert bounds == [[None, None], [None, None]], bounds


### PR DESCRIPTION
Small correction to fix broken attribution for built-in tiles (Closes #1117).

- `self.attr` (from `Map`) has been removed (`attribution` now set with `options`)
- updated tests

Maybe the attribution files (`attr.txt`) should be reviewed and updated too ?
