### PR TITLE
Fix broken prefer_canvas option

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -55,16 +55,14 @@ class GlobalSwitches(Element):
 
     _template = Template("""
         <script>
-            L_PREFER_CANVAS = {{ this.prefer_canvas|tojson }};
             L_NO_TOUCH = {{ this.no_touch |tojson}};
             L_DISABLE_3D = {{ this.disable_3d|tojson }};
         </script>
     """)
 
-    def __init__(self, prefer_canvas=False, no_touch=False, disable_3d=False):
+    def __init__(self, no_touch=False, disable_3d=False):
         super(GlobalSwitches, self).__init__()
         self._name = 'GlobalSwitches'
-        self.prefer_canvas = prefer_canvas
         self.no_touch = no_touch
         self.disable_3d = disable_3d
 
@@ -124,11 +122,6 @@ class Map(MacroElement):
         (going from bottom to top).
     control_scale : bool, default False
         Whether to add a control scale on the map.
-    prefer_canvas : bool, default False
-        Forces Leaflet to use the Canvas back-end (if available) for
-        vector layers instead of SVG. This can increase performance
-        considerably in some cases (e.g. many thousands of circle
-        markers on the map).
     no_touch : bool, default False
         Forces Leaflet to not use touch events even if it detects them.
     disable_3d : bool, default False
@@ -269,11 +262,11 @@ class Map(MacroElement):
             max_bounds=max_bounds_array,
             zoom=zoom_start,
             zoom_control=zoom_control,
+            prefer_canvas=prefer_canvas,
             **kwargs
         )
 
         self.global_switches = GlobalSwitches(
-            prefer_canvas,
             no_touch,
             disable_3d
         )

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -122,6 +122,11 @@ class Map(MacroElement):
         (going from bottom to top).
     control_scale : bool, default False
         Whether to add a control scale on the map.
+    prefer_canvas : bool, default False
+        Forces Leaflet to use the Canvas back-end (if available) for
+        vector layers instead of SVG. This can increase performance
+        considerably in some cases (e.g. many thousands of circle
+        markers on the map).
     no_touch : bool, default False
         Forces Leaflet to not use touch events even if it detects them.
     disable_3d : bool, default False

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -103,7 +103,6 @@ class TestFolium(object):
         assert self.m.width == (900, 'px')
         assert self.m.left == (0, '%')
         assert self.m.top == (0, '%')
-        assert self.m.global_switches.prefer_canvas is False
         assert self.m.global_switches.no_touch is False
         assert self.m.global_switches.disable_3d is False
         assert self.m.to_dict() == {
@@ -278,7 +277,7 @@ class TestFolium(object):
                                               'padding': (3, 3), },
                                              sort_keys=True),
             'this': fitbounds,
-            })
+        })
 
         assert ''.join(fit_bounds_rendered.split()) in ''.join(out.split())
 
@@ -310,22 +309,30 @@ class TestFolium(object):
 
     def test_global_switches(self):
         m = folium.Map(prefer_canvas=True)
-        assert m.global_switches.prefer_canvas
+        out = m._parent.render()
+        out_str = ''.join(out.split())
+        assert "preferCanvas:true" in out_str
         assert not m.global_switches.no_touch
         assert not m.global_switches.disable_3d
 
         m = folium.Map(no_touch=True)
-        assert not m.global_switches.prefer_canvas
+        out = m._parent.render()
+        out_str = ''.join(out.split())
+        assert "preferCanvas:false" in out_str
         assert m.global_switches.no_touch
         assert not m.global_switches.disable_3d
 
         m = folium.Map(disable_3d=True)
-        assert not m.global_switches.prefer_canvas
+        out = m._parent.render()
+        out_str = ''.join(out.split())
+        assert "preferCanvas:false" in out_str
         assert not m.global_switches.no_touch
         assert m.global_switches.disable_3d
 
         m = folium.Map(prefer_canvas=True, no_touch=True, disable_3d=True)
-        assert m.global_switches.prefer_canvas
+        out = m._parent.render()
+        out_str = ''.join(out.split())
+        assert "preferCanvas:true" in out_str
         assert m.global_switches.no_touch
         assert m.global_switches.disable_3d
 


### PR DESCRIPTION
Small correction to fix broken prefer_canvas option (Close #1131):
since leaflet 1.0.0, the preferCanvas option is not part of the GlobalSwitch
options, but has to be passed as an option to L.Map.