### PR TITLE
added message when key_on not found in geojson

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1110,8 +1110,7 @@ class Choropleth(FeatureGroup):
             def color_scale_fun(x):
                 key_of_x = get_by_key(x, key_on)
                 if not key_of_x:
-                    if len(key_on) > 0:
-                        raise("key_on value not found in geojson")
+                    raise ValueError("key_on `{!r}` not found in GeoJSON.".format(key_on))
 
                 if key_of_x not in color_data.keys():
                     return nan_fill_color, nan_fill_opacity

--- a/folium/features.py
+++ b/folium/features.py
@@ -1109,6 +1109,9 @@ class Choropleth(FeatureGroup):
 
             def color_scale_fun(x):
                 key_of_x = get_by_key(x, key_on)
+                if not key_of_x:
+                    if len(key_on) > 0:
+                        raise("key_on value not found in geojson")
 
                 if key_of_x not in color_data.keys():
                     return nan_fill_color, nan_fill_opacity


### PR DESCRIPTION
This address #918 and raises a TypeError "key_on value not found in geojson" when key_on is given, but not found in the geojson file.