### PR TITLE
Fix stale bit.ly link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 before_install:
   # Install miniconda and create TEST env.
   - |
-    wget http://bit.ly/miniconda -O miniconda.sh
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     bash miniconda.sh -b -p $HOME/miniconda
     export PATH="$HOME/miniconda/bin:$PATH"
     conda config --set always_yes yes --set changeps1 no --set show_channel_urls true


### PR DESCRIPTION
We were downloading an old version of `miniconda` and wasting CI time updating packages later.