### PR TITLE
rendering draw and edit options to json

### DIFF
--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -44,8 +44,8 @@ class Draw(MacroElement):
         {% macro script(this, kwargs) %}
             var options = {
               position: {{ this.position|tojson }},
-              draw: {{ this.draw_options }},
-              edit: {{ this.edit_options }},
+              draw: {{ this.draw_options|tojson }},
+              edit: {{ this.edit_options|tojson }},
             }
             // FeatureGroup is to store editable layers.
             var drawnItems = new L.featureGroup().addTo(


### PR DESCRIPTION
I wanted the ability to remove some the drawing methods from the Draw Toolbar. This could only be done if given a `false` value, which requires to options to be converted to json. Here is an example:
```python
import folium
from folium.plugins import Draw
m = folium.Map()
Draw(
    draw_options={
        'polyline':False,
        'polygon':False,
        'circle':False,
        'marker':False,
        'circlemarker':False,
    }
).add_to(m)
m.save('testing.html')
```
![image](https://user-images.githubusercontent.com/997120/61094401-eaa43d00-a403-11e9-9368-088489f20610.png)
