### PR TITLE
add amap tiles

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -78,6 +78,7 @@ class Map(MacroElement):
         - "Mapbox Bright" (Limited levels of zoom for free tiles)
         - "Mapbox Control Room" (Limited levels of zoom for free tiles)
         - "Stamen" (Terrain, Toner, and Watercolor)
+        - "Amap", "AmapSatellite"
         - "Cloudmade" (Must pass API key)
         - "Mapbox" (Must pass API key)
         - "CartoDB" (positron and dark_matter)

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -27,6 +27,7 @@ class TileLayer(Layer):
             - "OpenStreetMap"
             - "Stamen Terrain", "Stamen Toner", "Stamen Watercolor"
             - "CartoDB positron", "CartoDB dark_matter"
+            - "Amap", "AmapSatellite"
             - "Mapbox Bright", "Mapbox Control Room" (Limited zoom)
             - "Cloudmade" (Must pass API key)
             - "Mapbox" (Must pass API key)

--- a/folium/templates/tiles/amap/attr.txt
+++ b/folium/templates/tiles/amap/attr.txt
@@ -1,0 +1,1 @@
+Map data &copy; <a href="https://map.amap.com/">Amap</a>, under <a href="https://lbs.amap.com/home/terms">Terms</a>.

--- a/folium/templates/tiles/amap/tiles.txt
+++ b/folium/templates/tiles/amap/tiles.txt
@@ -1,0 +1,1 @@
+https://webrd01.is.autonavi.com/appmaptile?size=1&scale=1&style=7&x={x}&y={y}&z={z}

--- a/folium/templates/tiles/amapsatellite/attr.txt
+++ b/folium/templates/tiles/amapsatellite/attr.txt
@@ -1,0 +1,1 @@
+Map data &copy; <a href="https://map.amap.com/">Amap</a>, under <a href="https://lbs.amap.com/home/terms">Terms</a>.

--- a/folium/templates/tiles/amapsatellite/tiles.txt
+++ b/folium/templates/tiles/amapsatellite/tiles.txt
@@ -1,0 +1,1 @@
+https://webst01.is.autonavi.com/appmaptile?size=1&scale=1&style=6&x={x}&y={y}&z={z}


### PR DESCRIPTION
This PR add amap tiles. Amap is a reliable and widely used map service in China. Most of users from here are not familiar with the existing built-in tiles in folium now. So there is a gap and we have to set amap tiles attr everytimes. Let's add more built-in tiles.