### PR TITLE
GeoJson: add to parent after data

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -421,14 +421,16 @@ class GeoJson(Layer):
             {% if this.style %}
                 style: {{ this.get_name() }}_styler,
             {%- endif %}
-        }).addTo({{ this._parent.get_name() }});
+        });
+        function {{ this.get_name() }}_add (data) {
+            {{ this.get_name() }}.addData(data)
+                .addTo({{ this._parent.get_name() }});
+        }
         {%- if this.embed %}
-            {{ this.get_name() }}.addData({{ this.data|tojson }});
+            {{ this.get_name() }}_add({{ this.data|tojson }});
         {%- else %}
-            $.ajax({url: {{ this.embed_link|tojson }}, dataType: 'json', async: true,
-                success: function(data) {
-                    {{ this.get_name() }}.addData(data);
-            }});
+            $.ajax({{ this.embed_link|tojson }}, {dataType: 'json'})
+                .done({{ this.get_name() }}_add);
         {%- endif %}
         {% endmacro %}
         """)  # noqa


### PR DESCRIPTION
When using `GeoJson` with non-embedded data, in JS, don't add the object to the parent object until the data has been added.

This should solve the issue where geojson doesn't work with marker_cluster anymore. While not breaking the interaction between geojson and layercontrol.

An alternative is to make the ajax call synchronously, but that doesn't seem like a better approach to me.