### PR TITLE
Add API_key param to folium.Map

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -135,6 +135,8 @@ class Map(MacroElement):
         rare environments) even if they're supported.
     zoom_control : bool, default True
         Display zoom controls on the map.
+    API_key: str, default None
+        API key for Cloudmade or Mapbox tiles.
     **kwargs
         Additional keyword arguments are passed to Leaflets Map class:
         https://leafletjs.com/reference-1.5.1.html#map
@@ -232,6 +234,7 @@ class Map(MacroElement):
             disable_3d=False,
             png_enabled=False,
             zoom_control=True,
+            API_key=None,
             **kwargs
     ):
         super(Map, self).__init__()
@@ -280,7 +283,8 @@ class Map(MacroElement):
 
         if tiles:
             tile_layer = TileLayer(tiles=tiles, attr=attr,
-                                   min_zoom=min_zoom, max_zoom=max_zoom)
+                                   min_zoom=min_zoom, max_zoom=max_zoom,
+                                   API_key=API_key)
             self.add_child(tile_layer, name=tile_layer.tile_name)
 
     def _repr_html_(self, **kwargs):

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -368,7 +368,7 @@ class TestFolium(object):
         bounds = self.m.get_bounds()
         assert bounds == [[18.948267, -178.123152], [71.351633, 173.304726]], bounds  # noqa
 
-    def test_api_key_param():
+    def test_api_key_param(self):
         """
         Test that folium.Map can accept an API_key and pass it down to the tile layer.
         """

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -367,3 +367,14 @@ class TestFolium(object):
         self.m._parent.render()
         bounds = self.m.get_bounds()
         assert bounds == [[18.948267, -178.123152], [71.351633, 173.304726]], bounds  # noqa
+
+    def test_api_key_param():
+        """
+        Test that folium.Map can accept an API_key and pass it down to the tile layer.
+        """
+        m = folium.Map(tiles='Mapbox', API_key='abc123')
+
+        # This assertion is not ideal because it access the private _children
+        # attribute, but there isn't currently another way to test this
+        # behavior.
+        assert 'abc123' in m._children['mapbox'].tiles


### PR DESCRIPTION
`folium.Map`'s examples say that it takes an `API_key` param, but it's actually missing. Add it and pass it through to the `TileLayer`.