### PR TITLE
Load iso08601-js-period lib in heatmap with time plugin

### DIFF
--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -162,6 +162,10 @@ class HeatMapWithTime(Layer):
                                             'if it is not in a Figure.')
 
         figure.header.add_child(
+            JavascriptLink('https://rawcdn.githack.com/nezasa/iso8601-js-period/master/iso8601.min.js'),  # noqa
+            name='iso8601')
+
+        figure.header.add_child(
             JavascriptLink('https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js'),  # noqa
             name='leaflet.timedimension.min.js')
 


### PR DESCRIPTION
This would close #1221.

Leaflet TimeDimension needs the iso8601-js-period library. It's listed in the basic usage example: https://github.com/socib/Leaflet.TimeDimension#examples-and-basic-usage

For me this fixes the issue with TimeDimension v1.1.1.