### PR TITLE
Change input from deprecated data.to_crs(epsg=4326) to data.to_crs('E…

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -492,8 +492,6 @@ class GeoJson(Layer):
         elif hasattr(data, '__geo_interface__'):
             self.embed = True
             if hasattr(data, 'to_crs'):
-                if isinstance(data.crs, dict) and 'init' in data.crs:
-                    data.crs = data.crs['init']
                 data = data.to_crs('EPSG:4326')
             return json.loads(json.dumps(data.__geo_interface__))
         else:

--- a/folium/features.py
+++ b/folium/features.py
@@ -492,7 +492,7 @@ class GeoJson(Layer):
         elif hasattr(data, '__geo_interface__'):
             self.embed = True
             if hasattr(data, 'to_crs'):
-                data = data.to_crs(epsg='4326')
+                data = data.to_crs('EPSG:4326')
             return json.loads(json.dumps(data.__geo_interface__))
         else:
             raise ValueError('Cannot render objects with any missing geometries'

--- a/folium/features.py
+++ b/folium/features.py
@@ -492,6 +492,8 @@ class GeoJson(Layer):
         elif hasattr(data, '__geo_interface__'):
             self.embed = True
             if hasattr(data, 'to_crs'):
+                if isinstance(data.crs, dict) and 'init' in data.crs:
+                    data.crs = data.crs['init']
                 data = data.to_crs('EPSG:4326')
             return json.loads(json.dumps(data.__geo_interface__))
         else:


### PR DESCRIPTION
The `process_data` method of the `folium.GeoJson` class is using a now deprecated input syntax for re-projecting in `data.to_crs(epsg=4326)`. This triggers a `FutureWarning: '+init=<authority>:<code>' syntax is deprecated. '<authority>:<code>' is the preferred initialization method.` in the `pyproj/crs.py` module. The actual reformatting to '+init=...' syntax is done by the `geopandas/geoseries.py` module, because the old syntax doesn't provide crs as input, only epsg. Warning can be silenced by changing the syntax to `data.to_crs("EPSG=4326")`. Discussion of this problem on stackoverflow is [here](https://stackoverflow.com/questions/59596835/open-street-map-pyproj-how-to-solve-syntax-issue/59703971#59703971). 