### PR TITLE
Geojson: fix show=False when not embedding data

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -422,10 +422,10 @@ class GeoJson(Layer):
             {% if this.style %}
                 style: {{ this.get_name() }}_styler,
             {%- endif %}
-        });
+        }).addTo({{ this._parent.get_name() }});
+
         function {{ this.get_name() }}_add (data) {
-            {{ this.get_name() }}.addData(data)
-                .addTo({{ this._parent.get_name() }});
+            {{ this.get_name() }}.addData(data);
         }
         {%- if this.embed %}
             {{ this.get_name() }}_add({{ this.data|tojson }});


### PR DESCRIPTION
Close #1283.

When we don't embed the data for `GeoJson`, it's loaded by ajax request. Currently we add the GeoJson layer to the map at the end of that request, but that leads to issues. The layer is unknown when layer control is initialized. Fix this by adding the layer to the map before the ajax request.