### PR TITLE
Remove iter_points utility function

### DIFF
--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -5,7 +5,7 @@ import json
 from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.folium import Map
-from folium.utilities import iter_points, none_max, none_min, parse_options
+from folium.utilities import parse_options, get_bounds
 
 from jinja2 import Template
 
@@ -227,17 +227,4 @@ class TimestampedGeoJson(MacroElement):
                 data = {'type': 'Feature', 'geometry': data}
             data = {'type': 'FeatureCollection', 'features': [data]}
 
-        bounds = [[None, None], [None, None]]
-        for feature in data['features']:
-            for point in iter_points(feature.get('geometry', {}).get('coordinates', {})):  # noqa
-                bounds = [
-                    [
-                        none_min(bounds[0][0], point[1]),
-                        none_min(bounds[0][1], point[0]),
-                        ],
-                    [
-                        none_max(bounds[1][0], point[1]),
-                        none_max(bounds[1][1], point[0]),
-                        ],
-                    ]
-        return bounds
+        return get_bounds(data, lonlat=True)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -410,24 +410,6 @@ def _parse_size(value):
     return value, value_type
 
 
-def iter_points(x):
-    """Iterates over a list representing a feature, and returns a list of points,
-    whatever the shape of the array (Point, MultiPolyline, etc).
-    """
-    if not isinstance(x, (list, tuple)):
-        raise ValueError('List/tuple type expected. Got {!r}.'.format(x))
-    if len(x):
-        if isinstance(x[0], (list, tuple)):
-            out = []
-            for y in x:
-                out += iter_points(y)
-            return out
-        else:
-            return [x]
-    else:
-        return []
-
-
 def compare_rendered(obj1, obj2):
     """
     Return True/False if the normalized rendered version of


### PR DESCRIPTION
We have a utility function `iter_points` that's used [in only one plugin](https://github.com/python-visualization/folium/search?q=iter_points&type=Code). We don't need it, because we have a better function called `iter_coords`. Furthermore, in that one plugin we can even remove a bunch of code and replace it with the same functionality we already have in the `get_bounds` function.