### PR TITLE
Type hints [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ geckodriver.log
 geckodriver.tar.gz
 geckodriver/
 miniconda.sh
+.mypy_cache

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -4,11 +4,17 @@
 Wraps leaflet TileLayer, WmsTileLayer (TileLayer.WMS), ImageOverlay, and VideoOverlay
 
 """
+from typing import Optional, Any, Sequence, Callable
 
 from branca.element import Element, Figure
 
 from folium.map import Layer
-from folium.utilities import image_to_url, mercator_transform, parse_options
+from folium.utilities import (
+    image_to_url,
+    mercator_transform,
+    parse_options,
+    TypeJsonValue,
+)
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -77,11 +83,25 @@ class TileLayer(Layer):
         {% endmacro %}
         """)
 
-    def __init__(self, tiles='OpenStreetMap', min_zoom=0, max_zoom=18,
-                 max_native_zoom=None, attr=None, API_key=None,
-                 detect_retina=False, name=None, overlay=False,
-                 control=True, show=True, no_wrap=False, subdomains='abc',
-                 tms=False, opacity=1, **kwargs):
+    def __init__(
+            self,
+            tiles: str = 'OpenStreetMap',
+            min_zoom: int = 0,
+            max_zoom: int = 18,
+            max_native_zoom: Optional[int] = None,
+            attr: Optional[str] = None,
+            API_key: Optional[str] = None,
+            detect_retina: bool = False,
+            name: Optional[str] = None,
+            overlay: bool = False,
+            control: bool = True,
+            show: bool = True,
+            no_wrap: bool = False,
+            subdomains: str = 'abc',
+            tms: bool = False,
+            opacity: float = 1,
+            **kwargs
+    ):
 
         self.tile_name = (name if name is not None else
                           ''.join(tiles.lower().strip().split()))
@@ -166,9 +186,21 @@ class WmsTileLayer(Layer):
         {% endmacro %}
         """)  # noqa
 
-    def __init__(self, url, layers, styles='', fmt='image/jpeg',
-                 transparent=False, version='1.1.1', attr='',
-                 name=None, overlay=True, control=True, show=True, **kwargs):
+    def __init__(
+            self,
+            url: str,
+            layers: str,
+            styles: str = '',
+            fmt: str = 'image/jpeg',
+            transparent: bool = False,
+            version: str = '1.1.1',
+            attr: str = '',
+            name: Optional[str] = None,
+            overlay: bool = True,
+            control: bool = True,
+            show: bool = True,
+            **kwargs
+    ):
         super(WmsTileLayer, self).__init__(name=name, overlay=overlay,
                                            control=control, show=show)
         self.url = url
@@ -238,9 +270,20 @@ class ImageOverlay(Layer):
         {% endmacro %}
         """)
 
-    def __init__(self, image, bounds, origin='upper', colormap=None,
-                 mercator_project=False, pixelated=True,
-                 name=None, overlay=True, control=True, show=True, **kwargs):
+    def __init__(
+            self,
+            image: Any,
+            bounds: Sequence[Sequence[float]],
+            origin: str = 'upper',
+            colormap: Optional[Callable] = None,
+            mercator_project: bool = False,
+            pixelated: bool = True,
+            name: Optional[str] = None,
+            overlay: bool = True,
+            control: bool = True,
+            show: bool = True,
+            **kwargs
+    ):
         super(ImageOverlay, self).__init__(name=name, overlay=overlay,
                                            control=control, show=show)
         self._name = 'ImageOverlay'
@@ -250,13 +293,13 @@ class ImageOverlay(Layer):
         if mercator_project:
             image = mercator_transform(
                 image,
-                [bounds[0][0], bounds[1][0]],
+                (bounds[0][0], bounds[1][0]),
                 origin=origin
             )
 
         self.url = image_to_url(image, origin=origin, colormap=colormap)
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> None:
         super(ImageOverlay, self).render()
 
         figure = self.get_root()
@@ -278,7 +321,7 @@ class ImageOverlay(Layer):
             """
             figure.header.add_child(Element(pixelated), name='leaflet-image-layer')  # noqa
 
-    def _get_self_bounds(self):
+    def _get_self_bounds(self) -> Sequence[Sequence[float]]:
         """
         Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]].
@@ -323,8 +366,18 @@ class VideoOverlay(Layer):
         {% endmacro %}
         """)
 
-    def __init__(self, video_url, bounds, autoplay=True, loop=True,
-                 name=None, overlay=True, control=True, show=True, **kwargs):
+    def __init__(
+            self,
+            video_url: str,
+            bounds: Sequence[Sequence[float]],
+            autoplay: bool = True,
+            loop: bool = True,
+            name: Optional[str] = None,
+            overlay: bool = True,
+            control: bool = True,
+            show: bool = True,
+            **kwargs: TypeJsonValue
+    ):
         super(VideoOverlay, self).__init__(name=name, overlay=overlay,
                                            control=control, show=show)
         self._name = 'VideoOverlay'
@@ -337,7 +390,7 @@ class VideoOverlay(Layer):
             **kwargs
         )
 
-    def _get_self_bounds(self):
+    def _get_self_bounds(self) -> Sequence[Sequence[float]]:
         """
         Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]]

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -10,9 +10,25 @@ from contextlib import contextmanager
 import copy
 import uuid
 import collections
+from typing import (
+    Iterable,
+    Sequence,
+    Union,
+    List,
+    Optional,
+    Callable,
+    Tuple,
+    Iterator,
+    Type,
+    Dict,
+    Any,
+)
 from urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 
 import numpy as np
+
+from branca.element import Element
+
 try:
     import pandas as pd
 except ImportError:
@@ -22,8 +38,16 @@ except ImportError:
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard('')
 
+TypeLine = Iterable[Sequence[float]]
+TypeMultiLine = Union[TypeLine, Iterable[TypeLine]]
 
-def validate_location(location):  # noqa: C901
+TypeJsonValueNoNone = Union[str, float, bool, Sequence, dict]
+TypeJsonValue = Union[TypeJsonValueNoNone, None]
+
+TypePathOptions = Union[bool, str, float, None]
+
+
+def validate_location(location: Sequence[float]) -> List[float]:  # noqa: C901
     """Validate a single lat/lon coordinate pair and convert to a list
 
     Validate that location:
@@ -32,10 +56,6 @@ def validate_location(location):  # noqa: C901
     * allows indexing (i.e. has an ordering)
     * where both values are floats (or convertible to float)
     * and both values are not NaN
-
-    Returns
-    -------
-    list[float, float]
 
     """
     if isinstance(location, np.ndarray) \
@@ -66,14 +86,25 @@ def validate_location(location):  # noqa: C901
     return [float(x) for x in coords]
 
 
-def validate_locations(locations):
-    """Validate an iterable with multiple lat/lon coordinate pairs.
+def validate_locations(locations: TypeLine) -> List[List[float]]:
+    """Validate an iterable with lat/lon coordinate pairs."""
+    locations = if_pandas_df_convert_to_numpy(locations)
+    try:
+        iter(locations)
+    except TypeError:
+        raise TypeError('Locations should be an iterable with coordinate pairs,'
+                        ' but instead got {!r}.'.format(locations))
+    try:
+        next(iter(locations))
+    except StopIteration:
+        raise ValueError('Locations is empty.')
+    return [validate_location(coord_pair) for coord_pair in locations]
 
-    Returns
-    -------
-    list[list[float, float]] or list[list[list[float, float]]]
 
-    """
+def validate_multi_locations(
+        locations: TypeMultiLine
+) -> Union[List[List[float]], List[List[List[float]]]]:
+    """Validate an iterable with possibly nested lists of coordinate pairs."""
     locations = if_pandas_df_convert_to_numpy(locations)
     try:
         iter(locations)
@@ -85,16 +116,17 @@ def validate_locations(locations):
     except StopIteration:
         raise ValueError('Locations is empty.')
     try:
-        float(next(iter(next(iter(next(iter(locations)))))))
+        float(next(iter(next(iter(next(iter(locations)))))))  # type: ignore
     except (TypeError, StopIteration):
         # locations is a list of coordinate pairs
-        return [validate_location(coord_pair) for coord_pair in locations]
+        return [validate_location(coord_pair)  # type: ignore
+                for coord_pair in locations]
     else:
         # locations is a list of a list of coordinate pairs, recurse
-        return [validate_locations(lst) for lst in locations]
+        return [validate_locations(lst) for lst in locations]  # type: ignore
 
 
-def if_pandas_df_convert_to_numpy(obj):
+def if_pandas_df_convert_to_numpy(obj: Any) -> Any:
     """Return a Numpy array from a Pandas dataframe.
 
     Iterating over a DataFrame has weird side effects, such as the first
@@ -106,7 +138,11 @@ def if_pandas_df_convert_to_numpy(obj):
         return obj
 
 
-def image_to_url(image, colormap=None, origin='upper'):
+def image_to_url(
+        image: Any,
+        colormap: Optional[Callable] = None,
+        origin: str = 'upper',
+) -> str:
     """
     Infers the type of an image argument and transforms it into a URL.
 
@@ -144,7 +180,7 @@ def image_to_url(image, colormap=None, origin='upper'):
     return url.replace('\n', ' ')
 
 
-def _is_url(url):
+def _is_url(url: str) -> bool:
     """Check to see if `url` has a valid protocol."""
     try:
         return urlparse(url).scheme in _VALID_URLS
@@ -152,7 +188,11 @@ def _is_url(url):
         return False
 
 
-def write_png(data, origin='upper', colormap=None):
+def write_png(
+        data: Any,
+        origin: str = 'upper',
+        colormap: Optional[Callable] = None,
+) -> bytes:
     """
     Transform an array of data into a PNG string.
     This can be written to disk using binary I/O, or encoded using base64
@@ -184,9 +224,7 @@ def write_png(data, origin='upper', colormap=None):
     PNG formatted byte string
 
     """
-    if colormap is None:
-        def colormap(x):
-            return (x, x, x, 1)
+    colormap = colormap or (lambda x: (x, x, x, 1))
 
     arr = np.atleast_3d(data)
     height, width, nblayers = arr.shape
@@ -239,7 +277,12 @@ def write_png(data, origin='upper', colormap=None):
         png_pack(b'IEND', b'')])
 
 
-def mercator_transform(data, lat_bounds, origin='upper', height_out=None):
+def mercator_transform(
+        data: Any,
+        lat_bounds: Tuple[float, float],
+        origin: str = 'upper',
+        height_out: Optional[int] = None,
+) -> np.ndarray:
     """
     Transforms an image computed in (longitude,latitude) coordinates into
     the a Mercator projection image.
@@ -266,7 +309,6 @@ def mercator_transform(data, lat_bounds, origin='upper', height_out=None):
     See https://en.wikipedia.org/wiki/Web_Mercator for more details.
 
     """
-    import numpy as np
 
     def mercator(x):
         return np.arcsinh(np.tan(x*np.pi/180.))*180./np.pi
@@ -300,7 +342,7 @@ def mercator_transform(data, lat_bounds, origin='upper', height_out=None):
     return out
 
 
-def none_min(x, y):
+def none_min(x: Optional[float], y: Optional[float]) -> Optional[float]:
     if x is None:
         return y
     elif y is None:
@@ -309,7 +351,7 @@ def none_min(x, y):
         return min(x, y)
 
 
-def none_max(x, y):
+def none_max(x: Optional[float], y: Optional[float]) -> Optional[float]:
     if x is None:
         return y
     elif y is None:
@@ -318,7 +360,7 @@ def none_max(x, y):
         return max(x, y)
 
 
-def iter_coords(obj):
+def iter_coords(obj: Any) -> Iterator[Tuple[float, ...]]:
     """
     Returns all the coordinate tuples from a geometry or feature.
 
@@ -340,7 +382,7 @@ def iter_coords(obj):
                 yield f
 
 
-def _locations_mirror(x):
+def _locations_mirror(x: Any) -> Any:
     """
     Mirrors the points in a list-of-list-of-...-of-list-of-points.
     For example:
@@ -357,13 +399,16 @@ def _locations_mirror(x):
         return x
 
 
-def get_bounds(locations, lonlat=False):
+def get_bounds(
+        locations: Any,
+        lonlat: bool = False,
+) -> List[List[Optional[float]]]:
     """
     Computes the bounds of the object in the form
     [[lat_min, lon_min], [lat_max, lon_max]]
 
     """
-    bounds = [[None, None], [None, None]]
+    bounds: List[List[Optional[float]]] = [[None, None], [None, None]]
     for point in iter_coords(locations):
         bounds = [
             [
@@ -380,7 +425,7 @@ def get_bounds(locations, lonlat=False):
     return bounds
 
 
-def camelize(key):
+def camelize(key: str) -> str:
     """Convert a python_style_variable_name to lowerCamelCase.
 
     Examples
@@ -394,7 +439,7 @@ def camelize(key):
                    for i, x in enumerate(key.split('_')))
 
 
-def _parse_size(value):
+def _parse_size(value: Union[str, float]) -> Tuple[float, str]:
     try:
         if isinstance(value, (int, float)):
             value_type = 'px'
@@ -410,7 +455,7 @@ def _parse_size(value):
     return value, value_type
 
 
-def compare_rendered(obj1, obj2):
+def compare_rendered(obj1: str, obj2: str) -> bool:
     """
     Return True/False if the normalized rendered version of
     two folium map objects are the equal or not.
@@ -419,7 +464,7 @@ def compare_rendered(obj1, obj2):
     return normalize(obj1) == normalize(obj2)
 
 
-def normalize(rendered):
+def normalize(rendered: str) -> str:
     """Return the input string without non-functional spaces or newlines."""
     out = ''.join([line.strip()
                    for line in rendered.splitlines()
@@ -429,7 +474,7 @@ def normalize(rendered):
 
 
 @contextmanager
-def _tmp_html(data):
+def _tmp_html(data: str) -> Iterator[str]:
     """Yields the path of a temporary HTML file containing data."""
     filepath = ''
     try:
@@ -442,7 +487,7 @@ def _tmp_html(data):
             os.remove(filepath)
 
 
-def deep_copy(item_original):
+def deep_copy(item_original: Element) -> Element:
     """Return a recursive deep-copy of item where each copy has a new ID."""
     item = copy.copy(item_original)
     item._id = uuid.uuid4().hex
@@ -456,18 +501,18 @@ def deep_copy(item_original):
     return item
 
 
-def get_obj_in_upper_tree(element, cls):
+def get_obj_in_upper_tree(element: Element, cls: Type) -> Element:
     """Return the first object in the parent tree of class `cls`."""
-    if not hasattr(element, '_parent'):
+    parent = element._parent
+    if parent is None:
         raise ValueError('The top of the tree was reached without finding a {}'
                          .format(cls))
-    parent = element._parent
     if not isinstance(parent, cls):
         return get_obj_in_upper_tree(parent, cls)
     return parent
 
 
-def parse_options(**kwargs):
+def parse_options(**kwargs: TypeJsonValue) -> Dict[str, TypeJsonValueNoNone]:
     """Return a dict with lower-camelcase keys and non-None values.."""
     return {camelize(key): value
             for key, value in kwargs.items()

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,9 @@ ignore =
     *.enc
     tests
     tests/*
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-folium._version]
+ignore_errors = True

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -10,7 +10,7 @@ from folium.utilities import (
     camelize,
     deep_copy,
     get_obj_in_upper_tree,
-    parse_options,
+    parse_options, validate_multi_locations,
 )
 
 
@@ -67,8 +67,8 @@ def test_validate_locations(locations):
 @pytest.mark.parametrize('locations', [
     [[(0, 5), (1, 6), (2, 7)], [(3, 8), (4, 9)]],
 ])
-def test_validate_locations_multi(locations):
-    outcome = validate_locations(locations)
+def test_validate_multi_locations(locations):
+    outcome = validate_multi_locations(locations)
     assert outcome == [[[0, 5], [1, 6], [2, 7]], [[3, 8], [4, 9]]]
 
 


### PR DESCRIPTION
I tried out adding type hints to the main modules (not the plugins).

**Rationale**
For users that use folium in an ad-hoc way the type hints may help in finding out what input a function accepts. And they may use an IDLE that gives those warnings automatically.

Users that write software with folium can now run Mypy on their software and get warnings for when their code is not compatible with folium.

For folium developers it becomes easier to work, because with explicit types you can change things with more confidence. And it forces you to think better about how a function should work.

**Remarks**
- This makes folium in compatible with Python 3.5 because of some variable type hints that are necessary.
- Many of the data inputs can be anything, a list, dict, Numpy array, Pandas dataframe, or something else... I typed these with `Any`, which is fine.

**Changes**
- Split the `validate_locations` function into a version for normal lines and one for multi-lines. This makes it more robust for classes that use normal lines and the type hints more accurate.
- `path_options`: define the two keyword arguments on usage. This is necessary for mypy and is more explicit as well. Change the `radius` argument from a bool/float into an optional float.
- Mypy cannot handle function definitions that replace optional arguments, so I replaced these with lambdas.

**Unrelated changes**
- `get_obj_in_upper_tree` had a bug. It assumed the top of a tree was reached if there's no `_parent` instance attribute. But actually all `Element` instances have this attribute, but it's `None` if there's no parent.

**Merge plan**
Don't merge this until we did a release. Ideally have Selenium tests up first so we can merge this with more confidence.