### PR TITLE
Enabled 'position' to control placement of the search box (issue 1302)

### DIFF
--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -49,12 +49,12 @@ class Search(MacroElement):
                 {% endif %}
                 collapsed: {{this.collapsed|tojson|safe}},
                 textPlaceholder: '{{this.placeholder}}',
+                position:'{{this.position}}',                
             {% if this.geom_type == 'Point' %}
                 initial: false,
                 {% if this.search_zoom %}
                 zoom: {{this.search_zoom}},
                 {% endif %}
-                position:'{{this.position}}',
                 hideMarkerOnCollapse: true
             {% else %}
                 marker: false,


### PR DESCRIPTION
The search plugin was stuck at the top-left corner in 0.10.1. Fixed by moving the "position" attribute out of the "if this.geom_type" statement since positioning of the search box shouldn't be conditional on the GeoJSON geometry type.

Closes #1302 