### PR TITLE
added reference to free Leaflet tile providers

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -83,7 +83,12 @@ class Map(MacroElement):
         - "CartoDB" (positron and dark_matter)
 
     You can pass a custom tileset to Folium by passing a Leaflet-style
-    URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``
+    URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
+
+    You can find a list of free tile providers here:
+    ``http://leaflet-extras.github.io/leaflet-providers/preview/``.
+    Be sure to check their terms and conditions and to provide attribution
+    with the `attr` keyword.
 
     Parameters
     ----------

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -32,8 +32,12 @@ class TileLayer(Layer):
             - "Mapbox" (Must pass API key)
 
         You can pass a custom tileset to Folium by passing a Leaflet-style
-        URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``
-        You must then also provide attribution, use the `attr` keyword.
+        URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
+
+        You can find a list of free tile providers here:
+        ``http://leaflet-extras.github.io/leaflet-providers/preview/``.
+        Be sure to check their terms and conditions and to provide attribution
+        with the `attr` keyword.
     min_zoom: int, default 0
         Minimum allowed zoom level for this tile layer.
     max_zoom: int, default 18


### PR DESCRIPTION
Added a reference to the list of free tile providers available at http://leaflet-extras.github.io/leaflet-providers/preview/, with the advice to check terms and conditions. Only changed the docstring in folium.py and raster-layers.py. This should hopefully avoid hours and hours of research to those who are not familiar with folium, map charts, tile layers, etc. 