### PR TITLE
Don't allow latest-branca test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
   - name: "tarball"
     env: PY=3.7
   allow_failures:
-  - name: latest-branca
-    env: PY=3.7
   - name: linkcheck
     env: PY=3.7
   - name: notebooks-conding-standard


### PR DESCRIPTION
We test folium against the master branch of branca. When we made some big changes in branca we set this test to allow failure, because it would fail all the time. Now that it's stable don't allow failure again. The lastest folium should work with the lastest branca and if it does not we want to be warned early.