### PR TITLE
added ref to templates available in folium/templates/tiles to docstring

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -75,12 +75,13 @@ class Map(MacroElement):
     to Folium. Pass any of the following to the "tiles" keyword:
 
         - "OpenStreetMap"
-        - "Mapbox Bright" (Limited levels of zoom for free tiles)
-        - "Mapbox Control Room" (Limited levels of zoom for free tiles)
-        - "Stamen" (Terrain, Toner, and Watercolor)
+        - "Stamen" (Terrain, Toner, Watercolor,
+                    Toner Background, and Toner Labels)
+        - "CartoDB" (Positron, Dark_matter, Positron No Labels,
+                     and Positron Only Labels)
+        - "Mapbox Bright", "Mapbox Control Room" (limited levels of zoom for free tiles)
         - "Cloudmade" (Must pass API key)
         - "Mapbox" (Must pass API key)
-        - "CartoDB" (positron and dark_matter)
 
     You can pass a custom tileset to Folium by passing a Leaflet-style
     URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -25,9 +25,11 @@ class TileLayer(Layer):
     tiles: str, default 'OpenStreetMap'
         Map tileset to use. Can choose from this list of built-in tiles:
             - "OpenStreetMap"
-            - "Stamen Terrain", "Stamen Toner", "Stamen Watercolor"
-            - "CartoDB positron", "CartoDB dark_matter"
-            - "Mapbox Bright", "Mapbox Control Room" (Limited zoom)
+            - "Stamen" (Terrain, Toner, Watercolor,
+                        Toner Background, and Toner Labels)
+            - "CartoDB" (Positron, Dark_matter, Positron No Labels,
+                         and Positron Only Labels)
+            - "Mapbox Bright", "Mapbox Control Room" (limited levels of zoom for free tiles)
             - "Cloudmade" (Must pass API key)
             - "Mapbox" (Must pass API key)
 


### PR DESCRIPTION
The existing docstrings in for folium.Map and folium.TileLayer only specify some of the templates that are already available in folium/templates/tiles. I changed the docstrings in folium.py and raster-layers.py to fix that. 