### PR TITLE
Replace githack.com CDN with jsdelivr.com

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -47,7 +47,7 @@ _default_css = [
     ('awesome_markers_css',
      'https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css'),  # noqa
     ('awesome_rotate_css',
-     'https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/leaflet.awesome.rotate.css'),  # noqa
+     'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css'),  # noqa
     ]
 
 

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -8,12 +8,12 @@ from jinja2 import Template
 
 _default_js = [
     ('beautify_icon_js',
-     'https://rawcdn.githack.com/marslan390/BeautifyMarker/master/leaflet-beautify-marker-icon.js')
+     'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.js')
     ]
 
 _default_css = [
     ('beautify_icon_css',
-     'https://rawcdn.githack.com/marslan390/BeautifyMarker/master/leaflet-beautify-marker-icon.css')
+     'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.css')
     ]
 
 

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -8,7 +8,7 @@ from jinja2 import Template
 
 _default_js = [
     ('Leaflet.Sync',
-     'https://rawcdn.githack.com/jieter/Leaflet.Sync/master/L.Map.Sync.js')
+     'https://cdn.jsdelivr.net/gh/jieter/Leaflet.Sync/L.Map.Sync.min.js')
     ]
 
 

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -9,18 +9,19 @@ from jinja2 import Template
 
 _default_js = [
     ('iso8601',
-     'https://rawcdn.githack.com/nezasa/iso8601-js-period/master/iso8601.min.js'),
+     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
     ('leaflet.timedimension.min.js',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js'),
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),
     ('heatmap.min.js',
-     'https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/pa7_hm.min.js'),
+     'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_hm.min.js'),
     ('leaflet-heatmap.js',
-     'https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/pa7_leaflet_hm.min.js'),
+     'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_leaflet_hm.min.js'),
     ]
+
 
 _default_css = [
     ('leaflet.timedimension.control.min.css',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css')
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
     ]
 
 

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -8,12 +8,12 @@ from jinja2 import Template
 
 _default_js = [
     ('leaflet_measure_js',
-     'https://rawcdn.githack.com/ljagis/leaflet-measure/2.1.7/dist/leaflet-measure.js')
+     'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.js')
     ]
 
 _default_css = [
     ('leaflet_measure_css',
-     'https://rawcdn.githack.com/ljagis/leaflet-measure/2.1.7/dist/leaflet-measure.css')
+     'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.css')
     ]
 
 

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -8,12 +8,12 @@ from jinja2 import Template
 
 _default_js = [
     ('Control_MousePosition_js',
-     'https://rawcdn.githack.com/ardhi/Leaflet.MousePosition/c32f1c84/src/L.Control.MousePosition.js')
+     'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.js')
     ]
 
 _default_css = [
     ('Control_MousePosition_css',
-     'https://rawcdn.githack.com/ardhi/Leaflet.MousePosition/c32f1c84/src/L.Control.MousePosition.css')
+     'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.css')
     ]
 
 

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 
 _default_js = [
     ('polylinetextpath',
-     'https://rawcdn.githack.com/makinacorpus/Leaflet.TextPath/leaflet0.8-dev/leaflet.textpath.js')
+     'https://cdn.jsdelivr.net/npm/leaflet-textpath@1.2.3/leaflet.textpath.min.js')
     ]
 
 

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -15,9 +15,9 @@ _default_js = [
     ('jqueryui1.10.2',
      'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
     ('iso8601',
-     'https://rawcdn.githack.com/nezasa/iso8601-js-period/master/iso8601.min.js'),
+     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
     ('leaflet.timedimension',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js'),  # noqa
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),  # noqa
     ('moment',
      'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js')
 ]
@@ -26,7 +26,7 @@ _default_css = [
     ('highlight.js_css',
      'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
     ('leaflet.timedimension_css',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css')
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
 ]
 
 

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -15,16 +15,16 @@ _default_js = [
     ('jqueryui1.10.2',
      'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
     ('iso8601',
-     'https://rawcdn.githack.com/nezasa/iso8601-js-period/master/iso8601.min.js'),
+     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
     ('leaflet.timedimension',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js'),  # noqa
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),  # noqa
 ]
 
 _default_css = [
     ('highlight.js_css',
      'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
     ('leaflet.timedimension_css',
-     'https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css')  # noqa
+     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')  # noqa
 ]
 
 

--- a/tests/plugins/test_beautify_icon.py
+++ b/tests/plugins/test_beautify_icon.py
@@ -41,11 +41,11 @@ def test_beautify_icon():
     out = normalize(m._parent.render())
 
     # We verify that the script import is present.
-    script = '<script src="https://rawcdn.githack.com/marslan390/BeautifyMarker/master/leaflet-beautify-marker-icon.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.js"></script>'  # noqa
     assert script in out
 
     # We verify that the css import is present.
-    css = '<link rel="stylesheet" href="https://rawcdn.githack.com/marslan390/BeautifyMarker/master/leaflet-beautify-marker-icon.css"/>'  # noqa
+    css = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.css"/>'  # noqa
     assert css in out
 
     # We verify that the Beautiful Icons are rendered correctly.

--- a/tests/plugins/test_dual_map.py
+++ b/tests/plugins/test_dual_map.py
@@ -23,7 +23,7 @@ def test_dual_map():
     assert isinstance(figure, folium.Figure)
     out = normalize(figure.render())
 
-    script = '<script src="https://rawcdn.githack.com/jieter/Leaflet.Sync/master/L.Map.Sync.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/gh/jieter/Leaflet.Sync/L.Map.Sync.min.js"></script>'  # noqa
     assert script in out
 
     tmpl = Template("""

--- a/tests/plugins/test_heat_map_withtime.py
+++ b/tests/plugins/test_heat_map_withtime.py
@@ -26,13 +26,13 @@ def test_heat_map_with_time():
     out = normalize(m._parent.render())
 
     # We verify that the script imports are present.
-    script = '<script src="https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js"></script>'  # noqa
     assert script in out
-    script = '<script src="https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/pa7_hm.min.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_hm.min.js"></script>'  # noqa
     assert script in out
-    script = '<script src="https://rawcdn.githack.com/python-visualization/folium/master/folium/templates/pa7_leaflet_hm.min.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_leaflet_hm.min.js"></script>'  # noqa
     assert script in out
-    script = '<link rel="stylesheet" href="https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css"/>'  # noqa
+    script = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css"/>'  # noqa
     assert script in out
 
     # We verify that the script part is correct.

--- a/tests/plugins/test_polyline_text_path.py
+++ b/tests/plugins/test_polyline_text_path.py
@@ -46,7 +46,7 @@ def test_polyline_text_path():
     out = normalize(m._parent.render())
 
     # We verify that the script import is present.
-    script = '<script src="https://rawcdn.githack.com/makinacorpus/Leaflet.TextPath/leaflet0.8-dev/leaflet.textpath.js"></script>'  # noqa
+    script = '<script src="https://cdn.jsdelivr.net/npm/leaflet-textpath@1.2.3/leaflet.textpath.min.js"></script>'  # noqa
     assert script in out
 
     # We verify that the script part is correct.

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -98,10 +98,10 @@ def test_timestamped_geo_json():
     # Verify the imports.
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>' in out
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>' in out
-    assert '<script src="https://rawcdn.githack.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>' in out
-    assert '<script src="https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"></script>' in out  # noqa
+    assert '<script src="https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js"></script>' in out
+    assert '<script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js"></script>' in out  # noqa
     assert '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css"/>' in out  # noqa
-    assert '<link rel="stylesheet" href="https://rawcdn.githack.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.control.min.css"/>' in out  # noqa
+    assert '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css"/>' in out  # noqa
     assert '<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>' in out
 
     # Verify that the script is okay.


### PR DESCRIPTION
Closes #1307 

Some of the resources we load come from githack.com. We got some reports that these are not accessible in all locations. Replace those urls with ones using jsdelivr.com, which should be better.