### PR TITLE
Remove deprecated tilesets

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -150,20 +150,16 @@ class Map(MacroElement):
 
     Examples
     --------
-    >>> m = folium.Map(location=[45.523, -122.675],
-    ...                        width=750, height=500)
-    >>> m = folium.Map(location=[45.523, -122.675],
-                               tiles='Mapbox Control Room')
-    >>> m = folium.Map(location=(45.523, -122.675), max_zoom=20,
-                               tiles='Cloudmade', API_key='YourKey')
+    >>> m = folium.Map(location=[45.523, -122.675], width=750, height=500)
+    >>> m = folium.Map(location=[45.523, -122.675], tiles='cartodb positron')
     >>> m = folium.Map(
     ...    location=[45.523, -122.675],
     ...    zoom_start=2,
-    ...    tiles='http://{s}.tiles.mapbox.com/v3/mapbox.control-room/{z}/{x}/{y}.png',
+    ...    tiles='https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=mytoken',
     ...    attr='Mapbox attribution'
     ...)
 
-    """
+    """  # noqa
     _template = Template(u"""
         {% macro header(this, kwargs) %}
             <meta name="viewport" content="width=device-width,

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -27,9 +27,6 @@ class TileLayer(Layer):
             - "OpenStreetMap"
             - "Stamen Terrain", "Stamen Toner", "Stamen Watercolor"
             - "CartoDB positron", "CartoDB dark_matter"
-            - "Mapbox Bright", "Mapbox Control Room" (Limited zoom)
-            - "Cloudmade" (Must pass API key)
-            - "Mapbox" (Must pass API key)
 
         You can pass a custom tileset to Folium by passing a Leaflet-style
         URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
@@ -47,8 +44,6 @@ class TileLayer(Layer):
         If provided you can zoom in past this level. Else tiles will turn grey.
     attr: string, default None
         Map tile attribution; only required if passing custom tile URL.
-    API_key: str, default None
-        API key for Cloudmade or Mapbox tiles.
     detect_retina: bool, default False
         If true and user is on a retina display, it will request four
         tiles of half the specified size and a bigger zoom level in place
@@ -82,7 +77,7 @@ class TileLayer(Layer):
         """)
 
     def __init__(self, tiles='OpenStreetMap', min_zoom=0, max_zoom=18,
-                 max_native_zoom=None, attr=None, API_key=None,
+                 max_native_zoom=None, attr=None,
                  detect_retina=False, name=None, overlay=False,
                  control=True, show=True, no_wrap=False, subdomains='abc',
                  tms=False, opacity=1, **kwargs):
@@ -95,16 +90,20 @@ class TileLayer(Layer):
         self._env = ENV
 
         tiles_flat = ''.join(tiles.lower().strip().split())
-        if tiles_flat in ('cloudmade', 'mapbox') and not API_key:
-            raise ValueError('You must pass an API key if using Cloudmade'
-                             ' or non-default Mapbox tiles.')
+        if tiles_flat in {'cloudmade', 'mapbox', 'mapboxbright', 'mapboxcontrolroom'}:
+            # added in May 2020 after v0.11.0, remove in a future release
+            raise ValueError(
+                'Built-in templates for Mapbox and Cloudmade have been removed. '
+                'You can still use these providers by passing a URL to the `tiles` '
+                'argument. See the documentation of the `TileLayer` class.'
+            )
         templates = list(self._env.list_templates(
             filter_func=lambda x: x.startswith('tiles/')))
         tile_template = 'tiles/' + tiles_flat + '/tiles.txt'
         attr_template = 'tiles/' + tiles_flat + '/attr.txt'
 
         if tile_template in templates and attr_template in templates:
-            self.tiles = self._env.get_template(tile_template).render(API_key=API_key)  # noqa
+            self.tiles = self._env.get_template(tile_template).render()
             attr = self._env.get_template(attr_template).render()
         else:
             self.tiles = tiles

--- a/folium/templates/tiles/cloudmade/attr.txt
+++ b/folium/templates/tiles/cloudmade/attr.txt
@@ -1,1 +1,0 @@
-Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://cloudmade.com">CloudMade</a>

--- a/folium/templates/tiles/cloudmade/tiles.txt
+++ b/folium/templates/tiles/cloudmade/tiles.txt
@@ -1,1 +1,0 @@
-http://{s}.tile.cloudmade.com/{{ API_key }}/997/256/{z}/{x}/{y}.png

--- a/folium/templates/tiles/mapbox/attr.txt
+++ b/folium/templates/tiles/mapbox/attr.txt
@@ -1,1 +1,0 @@
-Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/mapbox/tiles.txt
+++ b/folium/templates/tiles/mapbox/tiles.txt
@@ -1,1 +1,0 @@
-http://{s}.tiles.mapbox.com/v3/{{ API_key }}/{z}/{x}/{y}.png

--- a/folium/templates/tiles/mapboxbright/attr.txt
+++ b/folium/templates/tiles/mapboxbright/attr.txt
@@ -1,1 +1,0 @@
-Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/mapboxbright/tiles.txt
+++ b/folium/templates/tiles/mapboxbright/tiles.txt
@@ -1,1 +1,0 @@
-https://{s}.tiles.mapbox.com/v3/mapbox.world-bright/{z}/{x}/{y}.png

--- a/folium/templates/tiles/mapboxcontrolroom/attr.txt
+++ b/folium/templates/tiles/mapboxcontrolroom/attr.txt
@@ -1,1 +1,0 @@
-Map tiles by &copy; <a href="http://www.mapbox.com/about/maps">Mapbox</a> Data by &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.

--- a/folium/templates/tiles/mapboxcontrolroom/tiles.txt
+++ b/folium/templates/tiles/mapboxcontrolroom/tiles.txt
@@ -1,1 +1,0 @@
-https://{s}.tiles.mapbox.com/v3/mapbox.control-room/{z}/{x}/{y}.png

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -124,8 +124,6 @@ class TestFolium(object):
             "OpenStreetMap",
             "Stamen Terrain",
             "Stamen Toner",
-            "Mapbox Bright",
-            "Mapbox Control Room",
             "CartoDB positron",
             "CartoDB dark_matter",
         ]

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -59,16 +59,6 @@ def test_custom_tile_subdomains():
     assert 'mytilesubdomain' in out
 
 
-def test_tilelayer_api_key():
-    """Test cloudmade tiles and the API key."""
-    with pytest.raises(ValueError):
-        folium.TileLayer(tiles='cloudmade')
-
-    tile_layer = folium.TileLayer(tiles='cloudmade', API_key='###')
-    cloudmade = 'http://{s}.tile.cloudmade.com/###/997/256/{z}/{x}/{y}.png'
-    assert tile_layer.tiles == cloudmade
-
-
 def test_wms():
     m = folium.Map([40, -100], zoom_start=4)
     url = 'http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi'


### PR DESCRIPTION
Clean up some of the built-in tileset templates.

Cloudmade no longer provides a public API. Our version of the Mapbox API is outdated, see https://github.com/python-visualization/folium/issues/922

It's quite trivial for users to keep using Mapbox, they just have to pass the API url to the `tiles` argument. I reckon that's what current Mapbox users are already doing. So I don't see a need to update our template to v4.

We can also drop the `API_key` argument which was only used for Cloudmade and Mapbox.

Raise an exception if a users tries to use the removed tilesets, providing help on how to resolve.

Closes #922