### PR TITLE
Plugin mbtiles

### DIFF
--- a/folium/plugins/__init__.py
+++ b/folium/plugins/__init__.py
@@ -22,6 +22,7 @@ from folium.plugins.heat_map import HeatMap
 from folium.plugins.heat_map_withtime import HeatMapWithTime
 from folium.plugins.locate_control import LocateControl
 from folium.plugins.marker_cluster import MarkerCluster
+from folium.plugins.mbtiles import MBTiles
 from folium.plugins.measure_control import MeasureControl
 from folium.plugins.minimap import MiniMap
 from folium.plugins.mouse_position import MousePosition
@@ -49,6 +50,7 @@ __all__ = [
     'HeatMapWithTime',
     'LocateControl',
     'MarkerCluster',
+    'MBTiles',
     'MeasureControl',
     'MiniMap',
     'MousePosition',

--- a/folium/plugins/mbtiles.py
+++ b/folium/plugins/mbtiles.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from branca.element import Figure, JavascriptLink
+from jinja2 import Template
+
+from folium.raster_layers import TileLayer
+
+_default_js = _default_js = [
+    ('sql-js',
+     'https://unpkg.com/sql.js@0.3.2/js/sql.js'),
+    ('MBTiles',
+     'https://unpkg.com/leaflet.tilelayer.mbtiles@latest/Leaflet.TileLayer.MBTiles.js')
+    ]
+
+
+class MBTiles(TileLayer):
+    """
+    Class to display raster tiles in MBTiles format.
+
+    See https://wiki.openstreetmap.org/wiki/MBTiles for overview.
+    See https://www.npmjs.com/package/Leaflet.TileLayer.MBTiles for original Leaflet plugin.
+
+    Example
+    -------
+    # Map from Folium Quickstart
+    m = folium.Map(
+        location=[45.5236, -122.6750],
+        tiles='Stamen Toner',
+        zoom_start=13
+    )
+
+    # Add mbtiles layer to Map
+    MBTiles(
+        location=[45.5236, -122.6750],
+        tiles='path/to/your_tiles.mbtiles',
+        zoom_start=13
+    ).add_to(m)
+    """
+
+    _template = Template(u"""
+        {% macro script(this, kwargs) %}
+            var {{ this.get_name() }} = L.tileLayer.mbTiles(
+                {{ this.tiles|tojson }},
+                {{ this.options|tojson }}
+            ).addTo({{ this._parent.get_name() }});
+        {% endmacro %}
+        """)  # noqa
+
+    def render(self, **kwargs):
+        super().render()
+
+        figure = self.get_root()
+        assert isinstance(figure, Figure), 'You cannot render this Element if it is not in a Figure.'
+
+        # Import Javascripts
+        for name, url in _default_js:
+            figure.header.add_child(JavascriptLink(url), name=name)
+

--- a/folium/plugins/mbtiles.py
+++ b/folium/plugins/mbtiles.py
@@ -5,12 +5,12 @@ from jinja2 import Template
 
 from folium.raster_layers import TileLayer
 
-_default_js = _default_js = [
+_default_js = [
     ('sql-js',
      'https://unpkg.com/sql.js@0.3.2/js/sql.js'),
     ('MBTiles',
-     'https://unpkg.com/leaflet.tilelayer.mbtiles@latest/Leaflet.TileLayer.MBTiles.js')
-    ]
+     'https://unpkg.com/Leaflet.TileLayer.MBTiles@1.0.0/Leaflet.TileLayer.MBTiles.js')
+]
 
 
 class MBTiles(TileLayer):
@@ -22,18 +22,21 @@ class MBTiles(TileLayer):
 
     Example
     -------
+    attr_text = 'Attribution Text'
+
     # Map from Folium Quickstart
     m = folium.Map(
         location=[45.5236, -122.6750],
-        tiles='Stamen Toner',
+        tiles=None,
         zoom_start=13
     )
 
     # Add mbtiles layer to Map
     MBTiles(
-        location=[45.5236, -122.6750],
         tiles='path/to/your_tiles.mbtiles',
-        zoom_start=13
+        min_zoom = 0,
+        max_zoom = 18,
+        attr = attr_text
     ).add_to(m)
     """
 
@@ -46,6 +49,10 @@ class MBTiles(TileLayer):
         {% endmacro %}
         """)  # noqa
 
+    def __init__(self, tiles, *args, **kwargs):
+        assert tiles.lower().endswith('.mbtiles')
+        super(MBTiles, self).__init__(tiles=tiles, *args, **kwargs)
+
     def render(self, **kwargs):
         super().render()
 
@@ -55,4 +62,3 @@ class MBTiles(TileLayer):
         # Import Javascripts
         for name, url in _default_js:
             figure.header.add_child(JavascriptLink(url), name=name)
-


### PR DESCRIPTION
PR for issue #1318 to add support for MBTiles.

@Conengmo is correct that the original plugin repo [here](https://www.npmjs.com/package/Leaflet.TileLayer.MBTiles) appears abandoned. However, MBTiles format under the hood is SQLite. The plugin just reads and returns tiles from the Mapbox-spec database. I think it's unlikely that either will change enough to break the plugin. Evidence is that this code still works 4 years later.

The good news is that this plugin is now being maintained [here](https://github.com/0nza1101/leaflet-tilelayer-mbtiles-ts), last updated May 2020. 

I think it'd be good to use the updated repo, but it's structure is beyond my web dev understanding.

Let me know what I can improve here.