### PR TITLE
Remove unused `name_getter` variable in GeoJsonPopup template.

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1001,7 +1001,6 @@ class GeoJsonPopup(GeoJsonDetail):
 
     _template = Template(u"""
     {% macro script(this, kwargs) %}
-    let name_getter = '{{this._parent.get_name()}}';
     {{ this._parent.get_name() }}.bindPopup(""" + GeoJsonDetail.base_template +
                          u""",{{ this.popup_options | tojson | safe }});
                      {% endmacro %}


### PR DESCRIPTION
Resolves #1346. I checked the rest of the repository for any references to this variable and nothing came up.

Running the test suite and linting _locally_ did come up with a few errors/warnings, but nothing related to this feature, but does it does seem to pass CI.