### PR TITLE
Use synchronous ajax in GeoJson

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -428,17 +428,20 @@ class GeoJson(Layer):
             {% if this.style %}
                 style: {{ this.get_name() }}_styler,
             {%- endif %}
-        }).addTo({{ this._parent.get_name() }});
+        });
 
         function {{ this.get_name() }}_add (data) {
-            {{ this.get_name() }}.addData(data);
+            {{ this.get_name() }}
+                .addData(data)
+                .addTo({{ this._parent.get_name() }});
         }
         {%- if this.embed %}
             {{ this.get_name() }}_add({{ this.data|tojson }});
         {%- else %}
-            $.ajax({{ this.embed_link|tojson }}, {dataType: 'json'})
+            $.ajax({{ this.embed_link|tojson }}, {dataType: 'json', async: false})
                 .done({{ this.get_name() }}_add);
         {%- endif %}
+
         {% endmacro %}
         """)  # noqa
 

--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -1,0 +1,36 @@
+import folium
+import folium.plugins
+from folium.utilities import temp_html_filepath
+
+
+def test_geojson(driver):
+    """Verify that loading data in GeoJson works well for different use cases.
+
+    Prevent two regressions:
+    - https://github.com/python-visualization/folium/pull/1190
+    - https://github.com/python-visualization/folium/pull/1289
+
+    """
+    data_url = 'https://cdn.jsdelivr.net/gh/python-visualization/folium@master/examples/data/search_bars_rome.json'
+
+    m = folium.Map((41.9, 12.5), zoom_start=10, tiles='cartodbpositron')
+    marker_cluster = folium.plugins.MarkerCluster(name='cluster').add_to(m)
+    folium.GeoJson(data_url, embed=False).add_to(marker_cluster)
+    folium.GeoJson(data_url, embed=False, show=False, name='geojson').add_to(m)
+    folium.LayerControl(collapsed=False).add_to(m)
+
+    html = m.get_root().render()
+    with temp_html_filepath(html) as filepath:
+        driver.get_file(filepath)
+        assert driver.wait_until('.folium-map')
+        driver.verify_js_logs()
+    # Verify the marker cluster is shown, it's a yellow icon with '18' in it.
+    icon = driver.wait_until('.leaflet-marker-icon.marker-cluster > div > span')
+    assert icon.text == '18'
+    # Verify the second GeoJson layer is not shown, because we used show=False.
+    control_label = driver.wait_until(
+        '.leaflet-control-layers-overlays > label:nth-of-type(2)'
+    )
+    assert control_label.text == 'geojson'
+    control_input = control_label.find_element_by_css_selector('input')
+    assert control_input.get_attribute('checked') is None


### PR DESCRIPTION
Close #1209 

Two earlier PRs did conflicting changes: #1190 (merged July 2019) and #1289 (merged April 2020) are at odds with each other. This PR tries to resolve that.

Two requirements:
- Add the `GeoJson` JS object to its parent after loading the data.
- Add the `GeoJson` JS object to its parent before continuing with the rest of the code.

Two make both requirements come true we'll have to make the ajax request that loads the geojson data synchronously.

I added a test case that verifies both requirements are satisfied.