### PR TITLE
Skip flaky WmsTimeDimension.ipynb test

### DIFF
--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -58,6 +58,8 @@ def find_notebooks():
 
 @pytest.mark.parametrize('filepath', find_notebooks())
 def test_notebook(filepath, driver):
+    if 'WmsTimeDimension' in filepath:
+        pytest.xfail('WmsTimeDimension.ipynb external resource makes this test flaky')
     for filepath_html in get_notebook_html(filepath):
         clean_window(driver)
         driver.get('file://' + filepath_html)


### PR DESCRIPTION
Using WmsTimeDimension.ipynb as a test case is not working well, because the external resource used in the notebook is flaky, it may timeout. Skip this test. I'd be also okay with removing the notebook fully, but maybe that's a bit heavy handed.