### PR TITLE
Fix for TimeSliderChoropleth control breaking when layer turned off and on

### DIFF
--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -118,20 +118,6 @@ class TimeSliderChoropleth(Layer):
                 }
             });
 
-            {{ this.get_name() }}.eachLayer(function (layer) {
-                layer._path.id = 'feature-' + layer.feature.id;
-            });
-
-            d3.selectAll('path')
-            .attr('stroke', 'white')
-            .attr('stroke-width', 0.8)
-            .attr('stroke-dasharray', '5,5')
-            .attr('fill-opacity', 0);
-
-            fill_map();
-
-            {{ this._parent.get_name() }}.on('overlayadd', onOverlayAdd);
-
             function onOverlayAdd(e) {
                 {{ this.get_name() }}.eachLayer(function (layer) {
                     layer._path.id = 'feature-' + layer.feature.id;
@@ -143,8 +129,11 @@ class TimeSliderChoropleth(Layer):
                 .attr('stroke-dasharray', '5,5')
                 .attr('fill-opacity', 0);
 
-                fill_map(); // this fills the map for the initial, starting time value
+                fill_map();
             }
+            {{ this._parent.get_name() }}.on('overlayadd', onOverlayAdd);
+            
+            onOverlayAdd(); // fill map as layer is loaded
         {% endmacro %}
         """)
 

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -132,7 +132,7 @@ class TimeSliderChoropleth(Layer):
                 fill_map();
             }
             {{ this._parent.get_name() }}.on('overlayadd', onOverlayAdd);
-            
+
             onOverlayAdd(); // fill map as layer is loaded
         {% endmacro %}
         """)

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -36,7 +36,6 @@ class TimeSliderChoropleth(Layer):
     """
     _template = Template(u"""
         {% macro script(this, kwargs) %}
-
             var timestamps = {{ this.timestamps|tojson }};
             var styledict = {{ this.styledict|tojson }};
             var current_timestamp = timestamps[0];
@@ -80,9 +79,9 @@ class TimeSliderChoropleth(Layer):
 
             d3.select("#slider").on("input", function() {
                 current_timestamp = timestamps[this.value];
-            var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
-            d3.select("output#slider-value").text(datestring);
-            fill_map();
+                var datestring = new Date(parseInt(current_timestamp)*1000).toDateString();
+                d3.select("output#slider-value").text(datestring);
+                fill_map();
             });
 
             {% if this.highlight %}
@@ -104,7 +103,6 @@ class TimeSliderChoropleth(Layer):
                     }
                     });
                 };
-
             {% endif %}
 
             var {{ this.get_name() }} = L.geoJson(
@@ -129,8 +127,24 @@ class TimeSliderChoropleth(Layer):
             .attr('stroke-width', 0.8)
             .attr('stroke-dasharray', '5,5')
             .attr('fill-opacity', 0);
+
             fill_map();
 
+            {{ this._parent.get_name() }}.on('overlayadd', onOverlayAdd);
+            
+            function onOverlayAdd(e) {
+                {{ this.get_name() }}.eachLayer(function (layer) {
+                    layer._path.id = 'feature-' + layer.feature.id;
+                });
+
+                d3.selectAll('path')
+                .attr('stroke', 'white')
+                .attr('stroke-width', 0.8)
+                .attr('stroke-dasharray', '5,5')
+                .attr('fill-opacity', 0);
+                
+                fill_map(); // this fills the map for the initial, starting time value
+            }
         {% endmacro %}
         """)
 

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -131,7 +131,7 @@ class TimeSliderChoropleth(Layer):
             fill_map();
 
             {{ this._parent.get_name() }}.on('overlayadd', onOverlayAdd);
-            
+
             function onOverlayAdd(e) {
                 {{ this.get_name() }}.eachLayer(function (layer) {
                     layer._path.id = 'feature-' + layer.feature.id;
@@ -142,7 +142,7 @@ class TimeSliderChoropleth(Layer):
                 .attr('stroke-width', 0.8)
                 .attr('stroke-dasharray', '5,5')
                 .attr('fill-opacity', 0);
-                
+
                 fill_map(); // this fills the map for the initial, starting time value
             }
         {% endmacro %}


### PR DESCRIPTION
This is a fix for issue #1379 which shows that turning a TimeSliderChoropleth layer off and on again using the standard LayerControl causes the Choropleth to be broken and for the coloration not to be applied anymore.

I believe that the reason for this is that the colouring is controlled by ID strings, such as 'feature-0', which are defined for each GeoJSON feature but in the code rather than in the feature data itself. When the layer is turned off and on again, all these ID strings are lost, which is why the coloration no longer works.

In my solution I capture the Leaflet overlayadd event, and re-run some of the code to add the IDs again, draw the original dotted outlines for the features, and to call the fill_map() function again to do the initial coloration.

I had provided more information in my original comment to the original github issue #1379 .

Mark.