### PR TITLE
Fix selenium tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ ipykernel
 jupyter_client
 matplotlib
 mplleaflet
-nbconvert
+nbconvert==5.6.*
 nbsphinx
 nbval
 owslib

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -50,7 +50,7 @@ def get_notebook_html(filepath_notebook):
     filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
 
     html_exporter = nbconvert.HTMLExporter()
-    html_exporter.template_file = 'basic.tpl'
+    html_exporter.template_file = 'basic'
     body, _ = html_exporter.from_filename(filepath_notebook)
 
     parser = IframeParser()

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -50,7 +50,9 @@ def get_notebook_html(filepath_notebook):
     filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
 
     html_exporter = nbconvert.HTMLExporter()
-    html_exporter.template_file = 'basic.tpl'
+    nbconvert_path = os.path.abspath(os.path.dirname(nbconvert.__file__))
+    template_path = os.path.join(nbconvert_path, 'templates', 'html', 'basic.tpl')
+    html_exporter.template_file = template_path
     body, _ = html_exporter.from_filename(filepath_notebook)
 
     parser = IframeParser()

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -49,7 +49,7 @@ def get_notebook_html(filepath_notebook, execute=True):
         filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
 
     html_exporter = nbconvert.HTMLExporter()
-    html_exporter.template_file = 'basic'
+    html_exporter.template_file = 'basic.tpl'
     body, _ = html_exporter.from_filename(filepath_notebook)
 
     parser = IframeParser()

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -50,9 +50,7 @@ def get_notebook_html(filepath_notebook):
     filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
 
     html_exporter = nbconvert.HTMLExporter()
-    nbconvert_path = os.path.abspath(os.path.dirname(nbconvert.__file__))
-    template_path = os.path.join(nbconvert_path, 'templates', 'html', 'basic.tpl')
-    html_exporter.template_file = template_path
+    html_exporter.template_file = 'basic.tpl'
     body, _ = html_exporter.from_filename(filepath_notebook)
 
     parser = IframeParser()

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -4,7 +4,6 @@ import glob
 from html.parser import HTMLParser
 import os
 import subprocess
-from urllib.parse import unquote
 
 import nbconvert
 import pytest
@@ -73,10 +72,9 @@ class IframeParser(HTMLParser):
         if tag == 'iframe':
             attrs = dict(attrs)
             if 'data-html' in attrs:
-                html_percentage_encoded = attrs['data-html']
-                html = unquote(html_percentage_encoded)
+                html_base64 = attrs['data-html']
             else:  # legacy, can be removed when all notebooks have `data-html`.
                 src = attrs['src']
                 html_base64 = src.split(',')[-1]
-                html = base64.b64decode(html_base64).decode()
-            self.iframes.append(html)
+            html_bytes = base64.b64decode(html_base64)
+            self.iframes.append(html_bytes)

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -41,13 +41,13 @@ def test_notebook(filepath, driver):
         driver.verify_js_logs()
 
 
-def get_notebook_html(filepath_notebook, execute=True):
+def get_notebook_html(filepath_notebook):
     """Store iframes from a notebook in html files, remove them when done."""
-    if execute:
-        subprocess.run([
-            'jupyter', 'nbconvert', '--to', 'notebook', '--execute', filepath_notebook,
-        ])
-        filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
+    # run the notebook to make sure the output is up-to-date
+    subprocess.run([
+        'jupyter', 'nbconvert', '--to', 'notebook', '--execute', filepath_notebook,
+    ])
+    filepath_notebook = filepath_notebook.replace('.ipynb', '.nbconvert.ipynb')
 
     html_exporter = nbconvert.HTMLExporter()
     html_exporter.template_file = 'basic.tpl'

--- a/tests/selenium/test_selenium.py
+++ b/tests/selenium/test_selenium.py
@@ -4,6 +4,7 @@ import glob
 from html.parser import HTMLParser
 import os
 import subprocess
+from urllib.parse import unquote
 
 import nbconvert
 import pytest
@@ -72,9 +73,10 @@ class IframeParser(HTMLParser):
         if tag == 'iframe':
             attrs = dict(attrs)
             if 'data-html' in attrs:
-                html_base64 = attrs['data-html']
+                html_percentage_encoded = attrs['data-html']
+                html = unquote(html_percentage_encoded)
             else:  # legacy, can be removed when all notebooks have `data-html`.
                 src = attrs['src']
                 html_base64 = src.split(',')[-1]
-            html_bytes = base64.b64decode(html_base64)
-            self.iframes.append(html_bytes)
+                html = base64.b64decode(html_base64).decode()
+            self.iframes.append(html)


### PR DESCRIPTION
`nbconvert` has a new version out, 6.0. It breaks the way we export Jupyter notebooks. We have to use another template or port the basic template we are currently using to the new version.

For now I just fixed the version to 5.6. 

Weirdly enough on my local machine `data-html` is percentage-encoded instead of base64. But this doesn't seem to be the case on Travis.