### PR TITLE
Move JS/CSS links to class attributes

### DIFF
--- a/folium/elements.py
+++ b/folium/elements.py
@@ -1,0 +1,21 @@
+from branca.element import Figure, Element, JavascriptLink, CssLink
+
+
+class JSCSSMixin(Element):
+    """Render links to external Javascript and CSS resources."""
+
+    default_js = []
+    default_css = []
+
+    def render(self, **kwargs):
+        figure = self.get_root()
+        assert isinstance(figure, Figure), ('You cannot render this Element '
+                                            'if it is not in a Figure.')
+
+        for name, url in self.default_js:
+            figure.header.add_child(JavascriptLink(url), name=name)
+
+        for name, url in self.default_css:
+            figure.header.add_child(CssLink(url), name=name)
+
+        super().render(**kwargs)

--- a/folium/features.py
+++ b/folium/features.py
@@ -14,6 +14,7 @@ from branca.colormap import LinearColormap, StepColormap
 from branca.element import (Element, Figure, JavascriptLink, MacroElement)
 from branca.utilities import color_brewer
 
+from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import (FeatureGroup, Icon, Layer, Marker, Tooltip)
 from folium.utilities import (
@@ -36,7 +37,7 @@ import numpy as np
 import requests
 
 
-class RegularPolygonMarker(Marker):
+class RegularPolygonMarker(JSCSSMixin, Marker):
     """
     Custom markers using the Leaflet Data Vis Framework.
 
@@ -69,6 +70,11 @@ class RegularPolygonMarker(Marker):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('dvf_js',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet-dvf/0.3.0/leaflet-dvf.markers.min.js'),
+    ]
+
     def __init__(self, location, number_of_sides=4, rotation=0, radius=15,
                  popup=None, tooltip=None, **kwargs):
         super(RegularPolygonMarker, self).__init__(
@@ -83,21 +89,8 @@ class RegularPolygonMarker(Marker):
             radius=radius,
         ))
 
-    def render(self, **kwargs):
-        """Renders the HTML representation of the element."""
-        super(RegularPolygonMarker, self).render()
 
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        figure.header.add_child(
-            JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/leaflet-dvf/0.3.0/leaflet-dvf.markers.min.js'),
-            # noqa
-            name='dvf_js')
-
-
-class Vega(Element):
+class Vega(JSCSSMixin, Element):
     """
     Creates a Vega chart element.
 
@@ -128,6 +121,15 @@ class Vega(Element):
     """
     _template = Template(u'')
 
+    default_js = [
+        ('d3',
+         'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js'),
+        ('vega',
+         'https://cdnjs.cloudflare.com/ajax/libs/vega/1.4.3/vega.min.js'),
+        ('jquery',
+         'https://code.jquery.com/jquery-2.1.0.min.js'),
+    ]
+
     def __init__(self, data, width=None, height=None,
                  left='0%', top='0%', position='relative'):
         super(Vega, self).__init__()
@@ -147,6 +149,8 @@ class Vega(Element):
 
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
+        super().render(**kwargs)
+
         self.json = json.dumps(self.data)
 
         self._parent.html.add_child(Element(Template("""
@@ -170,18 +174,6 @@ class Vega(Element):
                 top: {{this.top[0]}}{{this.top[1]}};
             </style>
             """).render(this=self, **kwargs)), name=self.get_name())
-
-        figure.header.add_child(
-            JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js'),  # noqa
-            name='d3')
-
-        figure.header.add_child(
-            JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/vega/1.4.3/vega.min.js'),  # noqa
-            name='vega')
-
-        figure.header.add_child(
-            JavascriptLink('https://code.jquery.com/jquery-2.1.0.min.js'),
-            name='jquery')
 
         figure.script.add_child(
             Template("""function vega_parse(spec, div) {
@@ -649,7 +641,7 @@ class GeoJsonStyleMapper:
         del (mapping[key_longest])
 
 
-class TopoJson(Layer):
+class TopoJson(JSCSSMixin, Layer):
     """
     Creates a TopoJson object for plotting into a Map.
 
@@ -721,6 +713,11 @@ class TopoJson(Layer):
         {% endmacro %}
         """)  # noqa
 
+    default_js = [
+        ('topojson',
+         'https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min.js'),
+    ]
+
     def __init__(self, data, object_path, style_function=None,
                  name=None, overlay=True, control=True, show=True,
                  smooth_factor=None, tooltip=None):
@@ -769,14 +766,6 @@ class TopoJson(Layer):
         """Renders the HTML representation of the element."""
         self.style_data()
         super(TopoJson, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        figure.header.add_child(
-            JavascriptLink('https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min.js'),  # noqa
-            name='topojson')
 
     def get_bounds(self):
         """

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -8,8 +8,9 @@ Make beautiful, interactive maps with Python and Leaflet.js
 import time
 import warnings
 
-from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
+from branca.element import Element, Figure, MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.map import FitBounds
 from folium.raster_layers import TileLayer
 from folium.utilities import (
@@ -67,7 +68,7 @@ class GlobalSwitches(Element):
         self.disable_3d = disable_3d
 
 
-class Map(MacroElement):
+class Map(JSCSSMixin, MacroElement):
     """Create a Map with Folium and Leaflet.js
 
     Generate a base map of given width and height with either default
@@ -208,6 +209,10 @@ class Map(MacroElement):
         {% endmacro %}
         """)
 
+    # use the module variables for backwards compatibility
+    default_js = _default_js
+    default_css = _default_css
+
     def __init__(
             self,
             location=None,
@@ -340,14 +345,6 @@ class Map(MacroElement):
 
         # Set global switches
         figure.header.add_child(self.global_switches, name='global_switches')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)
 
         figure.header.add_child(Element(
             '<style>html, body {'

--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -1,18 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.vector_layers import path_options, BaseMultiLocation
 
 from jinja2 import Template
 
-_default_js = [
-    ('antpath',
-     'https://cdn.jsdelivr.net/npm/leaflet-ant-path@1.1.2/dist/leaflet-ant-path.min.js')
-]
 
-
-class AntPath(BaseMultiLocation):
+class AntPath(JSCSSMixin, BaseMultiLocation):
     """
     Class for drawing AntPath polyline overlays on a map.
 
@@ -42,6 +36,11 @@ class AntPath(BaseMultiLocation):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('antpath',
+         'https://cdn.jsdelivr.net/npm/leaflet-ant-path@1.1.2/dist/leaflet-ant-path.min.js')
+    ]
+
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super(AntPath, self).__init__(
             locations,
@@ -63,14 +62,3 @@ class AntPath(BaseMultiLocation):
             'color': kwargs.pop('color', '#0000FF'),
             'pulseColor': kwargs.pop('pulse_color', '#FFFFFF'),
         })
-
-    def render(self, **kwargs):
-        super(AntPath, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('beautify_icon_js',
-     'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.js')
-    ]
 
-_default_css = [
-    ('beautify_icon_css',
-     'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.css')
-    ]
-
-
-class BeautifyIcon(MacroElement):
+class BeautifyIcon(JSCSSMixin, MacroElement):
     """
     Create a BeautifyIcon that can be added to a Marker
 
@@ -65,6 +56,15 @@ class BeautifyIcon(MacroElement):
     ICON_SHAPE_TYPES = ['circle', 'circle-dot', 'doughnut', 'rectangle-dot',
                         'marker', None]
 
+    default_js = [
+        ('beautify_icon_js',
+         'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.js')
+    ]
+    default_css = [
+        ('beautify_icon_css',
+         'https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.css')
+    ]
+
     def __init__(self, icon=None, icon_shape=None, border_width=3,
                  border_color='#000', text_color='#000',
                  background_color='#FFF', inner_icon_style='', spin=False,
@@ -85,18 +85,3 @@ class BeautifyIcon(MacroElement):
             text=number,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(BeautifyIcon, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Marker
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('markerclusterjs',
-     'https://unpkg.com/leaflet.boatmarker/leaflet.boatmarker.min.js'),
-    ]
 
-
-class BoatMarker(Marker):
+class BoatMarker(JSCSSMixin, Marker):
     """Add a Marker in the shape of a boat.
 
     Parameters
@@ -50,6 +44,11 @@ class BoatMarker(Marker):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('markerclusterjs',
+         'https://unpkg.com/leaflet.boatmarker/leaflet.boatmarker.min.js'),
+    ]
+
     def __init__(self, location, popup=None, icon=None,
                  heading=0, wind_heading=None, wind_speed=0, **kwargs):
         super(BoatMarker, self).__init__(
@@ -62,14 +61,3 @@ class BoatMarker(Marker):
         self.wind_heading = wind_heading
         self.wind_speed = wind_speed
         self.options = parse_options(**kwargs)
-
-    def render(self, **kwargs):
-        super(BoatMarker, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -1,21 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
+from branca.element import Element, Figure, MacroElement
+
+from folium.elements import JSCSSMixin
 
 from jinja2 import Template
 
-_default_js = [
-    ('leaflet_draw_js',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js')
-    ]
 
-_default_css = [
-    ('leaflet_draw_css',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css')
-    ]
-
-
-class Draw(MacroElement):
+class Draw(JSCSSMixin, MacroElement):
     """
     Vector drawing and editing plugin for Leaflet.
 
@@ -94,6 +86,15 @@ class Draw(MacroElement):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('leaflet_draw_js',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js')
+    ]
+    default_css = [
+        ('leaflet_draw_css',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css')
+    ]
+
     def __init__(self, export=False, filename='data.geojson',
                  position='topleft', draw_options=None, edit_options=None):
         super(Draw, self).__init__()
@@ -110,14 +111,6 @@ class Draw(MacroElement):
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '
                                             'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)
 
         export_style = """
             <style>

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -1,18 +1,14 @@
-from branca.element import MacroElement, Figure, JavascriptLink
+from branca.element import MacroElement, Figure
 
+from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import LayerControl
 from folium.utilities import deep_copy
 
 from jinja2 import Template
 
-_default_js = [
-    ('Leaflet.Sync',
-     'https://cdn.jsdelivr.net/gh/jieter/Leaflet.Sync/L.Map.Sync.min.js')
-    ]
 
-
-class DualMap(MacroElement):
+class DualMap(JSCSSMixin, MacroElement):
     """Create two maps in the same window.
 
     Adding children to this objects adds them to both maps. You can access
@@ -49,6 +45,11 @@ class DualMap(MacroElement):
             {{ this.m2.get_name() }}.sync({{ this.m1.get_name() }});
         {% endmacro %}
     """)
+
+    default_js = [
+        ('Leaflet.Sync',
+         'https://cdn.jsdelivr.net/gh/jieter/Leaflet.Sync/L.Map.Sync.min.js')
+    ]
 
     def __init__(self, location=None, layout='horizontal', **kwargs):
         super(DualMap, self).__init__()
@@ -94,14 +95,6 @@ class DualMap(MacroElement):
         self.children_for_m2.append((child, name, index))
 
     def render(self, **kwargs):
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
         super(DualMap, self).render(**kwargs)
 
         for child, name, index in self.children_for_m2:

--- a/folium/plugins/feature_group_sub_group.py
+++ b/folium/plugins/feature_group_sub_group.py
@@ -1,18 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Layer
 
 from jinja2 import Template
 
-_default_js = [
-    ('featuregroupsubgroupjs',
-     'https://unpkg.com/leaflet.featuregroup.subgroup@1.0.2/dist/leaflet.featuregroup.subgroup.js'),
-    ]
 
-
-class FeatureGroupSubGroup(Layer):
+class FeatureGroupSubGroup(JSCSSMixin, Layer):
     """
     Creates a Feature Group that adds its child layers into a parent group when
     added to a map (e.g. through LayerControl). Useful to create nested groups,
@@ -69,20 +63,14 @@ class FeatureGroupSubGroup(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('featuregroupsubgroupjs',
+         'https://unpkg.com/leaflet.featuregroup.subgroup@1.0.2/dist/leaflet.featuregroup.subgroup.js'),
+    ]
+
     def __init__(self, group, name=None, overlay=True, control=True, show=True):
         super(FeatureGroupSubGroup, self).__init__(name=name, overlay=overlay,
                                                    control=control, show=show)
 
         self._group = group
         self._name = 'FeatureGroupSubGroup'
-
-    def render(self, **kwargs):
-        super(FeatureGroupSubGroup, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('Control.Fullscreen.js',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js')
-    ]
 
-_default_css = [
-    ('Control.FullScreen.css',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.css')
-    ]
-
-
-class Fullscreen(MacroElement):
+class Fullscreen(JSCSSMixin, MacroElement):
     """
     Adds a fullscreen button to your map.
 
@@ -46,6 +37,15 @@ class Fullscreen(MacroElement):
         {% endmacro %}
         """)  # noqa
 
+    default_js = [
+        ('Control.Fullscreen.js',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js')
+    ]
+    default_css = [
+        ('Control.FullScreen.css',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.css')
+    ]
+
     def __init__(self, position='topleft', title='Full Screen',
                  title_cancel='Exit Full Screen', force_separate_button=False,
                  **kwargs):
@@ -58,18 +58,3 @@ class Fullscreen(MacroElement):
             force_separate_button=force_separate_button,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(Fullscreen, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -1,20 +1,12 @@
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
-from jinja2 import Template
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
-_default_js = [
-    ('Control.Geocoder.js',
-     'https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js')
-    ]
-
-_default_css = [
-    ('Control.Geocoder.css',
-     'https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css')
-    ]
+from jinja2 import Template
 
 
-class Geocoder(MacroElement):
+class Geocoder(JSCSSMixin, MacroElement):
     """A simple geocoder for Leaflet that by default uses OSM/Nominatim.
 
     Please respect the Nominatim usage policy:
@@ -44,6 +36,15 @@ class Geocoder(MacroElement):
         {% endmacro %}
     """)
 
+    default_js = [
+        ('Control.Geocoder.js',
+         'https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js')
+    ]
+    default_css = [
+        ('Control.Geocoder.css',
+         'https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css')
+    ]
+
     def __init__(
             self,
             collapsed=False,
@@ -59,15 +60,3 @@ class Geocoder(MacroElement):
             defaultMarkGeocode=add_marker,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(Geocoder, self).render(**kwargs)
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -2,8 +2,7 @@
 
 import warnings
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Layer
 from folium.utilities import (
     none_max,
@@ -17,13 +16,8 @@ from jinja2 import Template
 
 import numpy as np
 
-_default_js = [
-    ('leaflet-heat.js',
-     'https://cdn.jsdelivr.net/gh/python-visualization/folium@master/folium/templates/leaflet_heat.min.js'),  # noqa
-    ]
 
-
-class HeatMap(Layer):
+class HeatMap(JSCSSMixin, Layer):
     """
     Create a Heatmap layer
 
@@ -61,6 +55,11 @@ class HeatMap(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('leaflet-heat.js',
+         'https://cdn.jsdelivr.net/gh/python-visualization/folium@master/folium/templates/leaflet_heat.min.js'),
+    ]
+
     def __init__(self, data, name=None, min_opacity=0.5, max_zoom=18,
                  radius=25, blur=15, gradient=None,
                  overlay=True, control=True, show=True, **kwargs):
@@ -84,17 +83,6 @@ class HeatMap(Layer):
             gradient=gradient,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(HeatMap, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
 
     def _get_self_bounds(self):
         """

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -1,31 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Element, Figure, JavascriptLink
+from branca.element import Element, Figure
 
+from folium.elements import JSCSSMixin
 from folium.map import Layer
 from folium.utilities import none_max, none_min
 
 from jinja2 import Template
 
-_default_js = [
-    ('iso8601',
-     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
-    ('leaflet.timedimension.min.js',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),
-    ('heatmap.min.js',
-     'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_hm.min.js'),
-    ('leaflet-heatmap.js',
-     'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_leaflet_hm.min.js'),
-    ]
 
-
-_default_css = [
-    ('leaflet.timedimension.control.min.css',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
-    ]
-
-
-class HeatMapWithTime(Layer):
+class HeatMapWithTime(JSCSSMixin, Layer):
     """
     Create a HeatMapWithTime layer
 
@@ -122,6 +106,21 @@ class HeatMapWithTime(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('iso8601',
+         'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
+        ('leaflet.timedimension.min.js',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),
+        ('heatmap.min.js',
+         'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_hm.min.js'),
+        ('leaflet-heatmap.js',
+         'https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/pa7_leaflet_hm.min.js'),
+    ]
+    default_css = [
+        ('leaflet.timedimension.control.min.css',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
+    ]
+
     def __init__(self, data, index=None, name=None, radius=15, min_opacity=0,
                  max_opacity=0.6, scale_radius=False, gradient=None,
                  use_local_extrema=False, auto_play=False,
@@ -177,14 +176,6 @@ class HeatMapWithTime(Layer):
         figure = self.get_root()
         assert isinstance(figure, Figure), ('You cannot render this Element '
                                             'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)
 
         figure.header.add_child(
             Element(

--- a/folium/plugins/locate_control.py
+++ b/folium/plugins/locate_control.py
@@ -3,24 +3,15 @@
 Based on leaflet plugin: https://github.com/domoritz/leaflet-locatecontrol
 """
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('Control_locate_min_js',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.66.2/L.Control.Locate.min.js')
-    ]
 
-_default_css = [
-    ('Control_locate_min_css',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.66.2/L.Control.Locate.min.css')
-    ]
-
-
-class LocateControl(MacroElement):
+class LocateControl(JSCSSMixin, MacroElement):
     """Control plugin to geolocate the user.
 
     This plugins adds a button to the map, and when it's clicked shows the current
@@ -65,22 +56,17 @@ class LocateControl(MacroElement):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('Control_locate_min_js',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.66.2/L.Control.Locate.min.js')
+    ]
+    default_css = [
+        ('Control_locate_min_css',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.66.2/L.Control.Locate.min.css')
+    ]
+
     def __init__(self, auto_start=False, **kwargs):
         super(LocateControl, self).__init__()
         self._name = 'LocateControl'
         self.auto_start = auto_start
         self.options = parse_options(**kwargs)
-
-    def render(self, **kwargs):
-        super(LocateControl, self).render(**kwargs)
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -1,26 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Layer, Marker
 from folium.utilities import validate_locations, parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('markerclusterjs',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/leaflet.markercluster.js')
-    ]
 
-_default_css = [
-    ('markerclustercss',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/MarkerCluster.css'),
-    ('markerclusterdefaultcss',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/MarkerCluster.Default.css')
-    ]
-
-
-class MarkerCluster(Layer):
+class MarkerCluster(JSCSSMixin, Layer):
     """
     Provides Beautiful Animated Marker Clustering functionality for maps.
 
@@ -71,6 +58,18 @@ class MarkerCluster(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('markerclusterjs',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/leaflet.markercluster.js')
+    ]
+
+    default_css = [
+        ('markerclustercss',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/MarkerCluster.css'),
+        ('markerclusterdefaultcss',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.1.0/MarkerCluster.Default.css')
+    ]
+
     def __init__(self, locations=None, popups=None, icons=None, name=None,
                  overlay=True, control=True, show=True,
                  icon_create_function=None, options=None, **kwargs):
@@ -91,18 +90,3 @@ class MarkerCluster(Layer):
         if icon_create_function is not None:
             assert isinstance(icon_create_function, str)
         self.icon_create_function = icon_create_function
-
-    def render(self, **kwargs):
-        super(MarkerCluster, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('leaflet_measure_js',
-     'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.js')
-    ]
 
-_default_css = [
-    ('leaflet_measure_css',
-     'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.css')
-    ]
-
-
-class MeasureControl(MacroElement):
+class MeasureControl(JSCSSMixin, MacroElement):
     """ Add a measurement widget on the map.
 
     Parameters
@@ -41,6 +32,16 @@ class MeasureControl(MacroElement):
         {% endmacro %}
         """)  # noqa
 
+    default_js = [
+        ('leaflet_measure_js',
+         'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.js')
+    ]
+
+    default_css = [
+        ('leaflet_measure_css',
+         'https://cdn.jsdelivr.net/gh/ljagis/leaflet-measure@2.1.7/dist/leaflet-measure.min.css')
+    ]
+
     def __init__(self, position='topright', primary_length_unit='meters',
                  secondary_length_unit='miles', primary_area_unit='sqmeters',
                  secondary_area_unit='acres', **kwargs):
@@ -56,18 +57,3 @@ class MeasureControl(MacroElement):
             secondary_area_unit=secondary_area_unit,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(MeasureControl, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -1,24 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.raster_layers import TileLayer
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('Control_MiniMap_js',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.js')
-    ]
 
-_default_css = [
-    ('Control_MiniMap_css',
-     'https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.css'),
-    ]
-
-
-class MiniMap(MacroElement):
+class MiniMap(JSCSSMixin, MacroElement):
     """Add a minimap (locator) to an existing map.
 
     Uses the Leaflet plugin by Norkart under BSD 2-Clause "Simplified" License.
@@ -85,6 +76,15 @@ class MiniMap(MacroElement):
         {% endmacro %}
     """)  # noqa
 
+    default_js = [
+        ('Control_MiniMap_js',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.js')
+    ]
+    default_css = [
+        ('Control_MiniMap_css',
+         'https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.css'),
+    ]
+
     def __init__(self, tile_layer=None, position='bottomright', width=150,
                  height=150, collapsed_width=25, collapsed_height=25,
                  zoom_level_offset=-5, zoom_level_fixed=None,
@@ -117,17 +117,3 @@ class MiniMap(MacroElement):
             minimized=minimized,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-        super(MiniMap, self).render()
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('Control_MousePosition_js',
-     'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.js')
-    ]
 
-_default_css = [
-    ('Control_MousePosition_css',
-     'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.css')
-    ]
-
-
-class MousePosition(MacroElement):
+class MousePosition(JSCSSMixin, MacroElement):
     """Add a field that shows the coordinates of the mouse position.
 
     Uses the Leaflet plugin by Ardhi Lukianto under MIT license.
@@ -64,6 +55,15 @@ class MousePosition(MacroElement):
         {% endmacro %}
     """)
 
+    default_js = [
+        ('Control_MousePosition_js',
+         'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.js')
+    ]
+    default_css = [
+        ('Control_MousePosition_css',
+         'https://cdn.jsdelivr.net/gh/ardhi/Leaflet.MousePosition/src/L.Control.MousePosition.min.css')
+    ]
+
     def __init__(self, position='bottomright', separator=' : ',
                  empty_string='Unavailable', lng_first=False, num_digits=5,
                  prefix='', lat_formatter=None, lng_formatter=None, **kwargs):
@@ -82,18 +82,3 @@ class MousePosition(MacroElement):
         )
         self.lat_formatter = lat_formatter or 'undefined'
         self.lng_formatter = lng_formatter or 'undefined'
-
-    def render(self, **kwargs):
-        super(MousePosition, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.utilities import get_obj_in_upper_tree, parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('pattern',
-     'https://teastman.github.io/Leaflet.pattern/leaflet.pattern.js')
-    ]
 
 
-class StripePattern(MacroElement):
+class StripePattern(JSCSSMixin, MacroElement):
     """Fill Pattern for polygon composed of alternating lines.
 
     Add these to the 'fillPattern' field in GeoJson style functions.
@@ -47,6 +44,11 @@ class StripePattern(MacroElement):
         {% endmacro %}
     """)
 
+    default_js = [
+        ('pattern',
+         'https://teastman.github.io/Leaflet.pattern/leaflet.pattern.js')
+    ]
+
     def __init__(self, angle=.5, weight=4, space_weight=4,
                  color="#000000", space_color="#ffffff",
                  opacity=0.75, space_opacity=0.0, **kwargs):
@@ -68,16 +70,8 @@ class StripePattern(MacroElement):
         self.parent_map = get_obj_in_upper_tree(self, Map)
         super(StripePattern, self).render(**kwargs)
 
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
 
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-
-class CirclePattern(MacroElement):
+class CirclePattern(JSCSSMixin, MacroElement):
     """Fill Pattern for polygon composed of repeating circles.
 
     Add these to the 'fillPattern' field in GeoJson style functions.
@@ -117,6 +111,11 @@ class CirclePattern(MacroElement):
         {% endmacro %}
     """)
 
+    default_js = [
+        ('pattern',
+         'https://teastman.github.io/Leaflet.pattern/leaflet.pattern.js')
+    ]
+
     def __init__(self, width=20, height=20, radius=12, weight=2.0,
                  color="#3388ff", fill_color="#3388ff",
                  opacity=0.75, fill_opacity=0.5):
@@ -142,11 +141,3 @@ class CirclePattern(MacroElement):
     def render(self, **kwargs):
         self.parent_map = get_obj_in_upper_tree(self, Map).get_name()
         super(CirclePattern, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -9,7 +9,6 @@ from folium.utilities import get_obj_in_upper_tree, parse_options
 from jinja2 import Template
 
 
-
 class StripePattern(JSCSSMixin, MacroElement):
     """Fill Pattern for polygon composed of alternating lines.
 

--- a/folium/plugins/polyline_offset.py
+++ b/folium/plugins/polyline_offset.py
@@ -1,18 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function
-
-from branca.element import JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.vector_layers import PolyLine
 
-_default_js = [
-    ('polylineoffset',
-     'https://cdn.jsdelivr.net/npm/leaflet-polylineoffset@1.1.1/leaflet.polylineoffset.min.js')
-    ]
 
-
-class PolyLineOffset(PolyLine):
+class PolyLineOffset(JSCSSMixin, PolyLine):
     """
     Add offset capabilities to the PolyLine class.
 
@@ -47,6 +39,11 @@ class PolyLineOffset(PolyLine):
 
     """
 
+    default_js = [
+        ('polylineoffset',
+         'https://cdn.jsdelivr.net/npm/leaflet-polylineoffset@1.1.1/leaflet.polylineoffset.min.js')
+    ]
+
     def __init__(self, locations, popup=None, tooltip=None, offset=0, **kwargs):
         super(PolyLineOffset, self).__init__(
             locations=locations, popup=popup, tooltip=tooltip, **kwargs
@@ -54,11 +51,3 @@ class PolyLineOffset(PolyLine):
         self._name = "PolyLineOffset"
         # Add PolyLineOffset offset.
         self.options.update({"offset": offset})
-
-    def render(self, **kwargs):
-        super(PolyLineOffset, self).render()
-        figure = self.get_root()
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.features import MacroElement
 from folium.utilities import parse_options
 
 from jinja2 import Template
 
-_default_js = [
-    ('polylinetextpath',
-     'https://cdn.jsdelivr.net/npm/leaflet-textpath@1.2.3/leaflet.textpath.min.js')
-    ]
 
-
-class PolyLineTextPath(MacroElement):
+class PolyLineTextPath(JSCSSMixin, MacroElement):
     """
     Shows a text along a PolyLine.
 
@@ -51,6 +45,11 @@ class PolyLineTextPath(MacroElement):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('polylinetextpath',
+         'https://cdn.jsdelivr.net/npm/leaflet-textpath@1.2.3/leaflet.textpath.min.js')
+    ]
+
     def __init__(self, polyline, text, repeat=False, center=False, below=False,
                  offset=0, orientation=0, attributes=None, **kwargs):
         super(PolyLineTextPath, self).__init__()
@@ -66,14 +65,3 @@ class PolyLineTextPath(MacroElement):
             attributes=attributes,
             **kwargs
         )
-
-    def render(self, **kwargs):
-        super(PolyLineTextPath, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -3,6 +3,7 @@
 from branca.element import MacroElement
 
 from folium import Map
+from folium.elements import JSCSSMixin
 from folium.features import FeatureGroup, GeoJson, TopoJson
 from folium.plugins import MarkerCluster
 from folium.utilities import parse_options
@@ -10,7 +11,7 @@ from folium.utilities import parse_options
 from jinja2 import Template
 
 
-class Search(MacroElement):
+class Search(JSCSSMixin, MacroElement):
     """
     Adds a search tool to your map.
 

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
 from folium import Map
 from folium.features import FeatureGroup, GeoJson, TopoJson
@@ -8,17 +8,6 @@ from folium.plugins import MarkerCluster
 from folium.utilities import parse_options
 
 from jinja2 import Template
-
-
-_default_js = [
-    ('Leaflet.Search.js',
-     'https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js')
-    ]
-
-_default_css = [
-    ('Leaflet.Search.css',
-     'https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.css')
-    ]
 
 
 class Search(MacroElement):
@@ -95,6 +84,15 @@ class Search(MacroElement):
         {% endmacro %}
         """)  # noqa
 
+    default_js = [
+        ('Leaflet.Search.js',
+         'https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js')
+    ]
+    default_css = [
+        ('Leaflet.Search.css',
+         'https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.css')
+    ]
+
     def __init__(self, layer, search_label=None, search_zoom=None,
                  geom_type='Point', position='topleft', placeholder='Search',
                  collapsed=False, **kwargs):
@@ -130,16 +128,5 @@ class Search(MacroElement):
         else:
             keys = None
         self.test_params(keys=keys)
-        super(Search, self).render()
 
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)
+        super().render(**kwargs)

--- a/folium/plugins/semicircle.py
+++ b/folium/plugins/semicircle.py
@@ -1,21 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Marker
 from folium.utilities import parse_options
+from folium.vector_layers import path_options
 
 from jinja2 import Template
 
-from folium.vector_layers import path_options
 
-_default_js = [
-    ('semicirclejs',
-     'https://cdn.jsdelivr.net/npm/leaflet-semicircle@2.0.4/Semicircle.min.js')
-]
-
-
-class SemiCircle(Marker):
+class SemiCircle(JSCSSMixin, Marker):
     """Add a marker in the shape of a semicircle, similar to the Circle class.
 
     Use (direction and arc) or (start_angle and stop_angle), not both.
@@ -57,6 +50,11 @@ class SemiCircle(Marker):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('semicirclejs',
+         'https://cdn.jsdelivr.net/npm/leaflet-semicircle@2.0.4/Semicircle.min.js')
+    ]
+
     def __init__(self, location, radius,
                  direction=None, arc=None,
                  start_angle=None, stop_angle=None,
@@ -73,13 +71,3 @@ class SemiCircle(Marker):
         if not ((direction is None and arc is None) and (start_angle is not None and stop_angle is not None)
                 or (direction is not None and arc is not None) and (start_angle is None and stop_angle is None)):
             raise ValueError("Invalid arguments. Either provide direction and arc OR start_angle and stop_angle")
-
-    def render(self, **kwargs):
-        super(SemiCircle, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/terminator.py
+++ b/folium/plugins/terminator.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
+
+from folium.elements import JSCSSMixin
 
 from jinja2 import Template
 
-_default_js = [
-    ('terminator',
-     'https://unpkg.com/@joergdietrich/leaflet.terminator')
-    ]
 
-
-class Terminator(MacroElement):
+class Terminator(JSCSSMixin, MacroElement):
     """
     Leaflet.Terminator is a simple plug-in to the Leaflet library to
     overlay day and night regions on maps.
@@ -22,17 +19,11 @@ class Terminator(MacroElement):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('terminator',
+         'https://unpkg.com/@joergdietrich/leaflet.terminator')
+    ]
+
     def __init__(self):
         super(Terminator, self).__init__()
         self._name = 'Terminator'
-
-    def render(self, **kwargs):
-        super(Terminator, self).render(**kwargs)
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.features import GeoJson
 from folium.map import Layer
 
 from jinja2 import Template
 
-_default_js = [
-    ('d3v4',
-     'https://d3js.org/d3.v4.min.js')
-    ]
 
-
-class TimeSliderChoropleth(Layer):
+class TimeSliderChoropleth(JSCSSMixin, Layer):
     """
     Creates a TimeSliderChoropleth plugin to append into a map with Map.add_child.
 
@@ -137,6 +131,11 @@ class TimeSliderChoropleth(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('d3v4',
+         'https://d3js.org/d3.v4.min.js')
+    ]
+
     def __init__(self, data, styledict, name=None, overlay=True, control=True,
                  show=True):
         super(TimeSliderChoropleth, self).__init__(name=name, overlay=overlay,
@@ -157,13 +156,3 @@ class TimeSliderChoropleth(Layer):
 
         self.timestamps = timestamps
         self.styledict = styledict
-
-    def render(self, **kwargs):
-        super(TimeSliderChoropleth, self).render(**kwargs)
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -2,35 +2,16 @@
 
 import json
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import MacroElement
 
+from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.utilities import parse_options, get_bounds
 
 from jinja2 import Template
 
-_default_js = [
-    ('jquery2.0.0',
-     'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js'),
-    ('jqueryui1.10.2',
-     'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
-    ('iso8601',
-     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
-    ('leaflet.timedimension',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),  # noqa
-    ('moment',
-     'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js')
-]
 
-_default_css = [
-    ('highlight.js_css',
-     'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
-    ('leaflet.timedimension_css',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
-]
-
-
-class TimestampedGeoJson(MacroElement):
+class TimestampedGeoJson(JSCSSMixin, MacroElement):
     """
     Creates a TimestampedGeoJson plugin from timestamped GeoJSONs to append
     into a map with Map.add_child.
@@ -157,6 +138,26 @@ class TimestampedGeoJson(MacroElement):
         {% endmacro %}
         """)  # noqa
 
+    default_js = [
+        ('jquery2.0.0',
+         'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js'),
+        ('jqueryui1.10.2',
+         'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
+        ('iso8601',
+         'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
+        ('leaflet.timedimension',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),
+        # noqa
+        ('moment',
+         'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js')
+    ]
+    default_css = [
+        ('highlight.js_css',
+         'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
+        ('leaflet.timedimension_css',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
+    ]
+
     def __init__(self, data, transition_time=200, loop=True, auto_play=True,
                  add_last_point=True, period='P1D', min_speed=0.1, max_speed=10,
                  loop_button=False, date_options='YYYY-MM-DD HH:mm:ss',
@@ -196,19 +197,7 @@ class TimestampedGeoJson(MacroElement):
         assert isinstance(self._parent, Map), (
             'TimestampedGeoJson can only be added to a Map object.'
         )
-        super(TimestampedGeoJson, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)
+        super().render(**kwargs)
 
     def _get_self_bounds(self):
         """

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from branca.element import CssLink, Figure, JavascriptLink
-
+from folium.elements import JSCSSMixin
 from folium.map import Layer
 from folium.raster_layers import WmsTileLayer
 from folium.utilities import parse_options
@@ -9,26 +8,7 @@ from folium.utilities import parse_options
 from jinja2 import Template
 
 
-_default_js = [
-    ('jquery2.0.0',
-     'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js'),
-    ('jqueryui1.10.2',
-     'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
-    ('iso8601',
-     'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
-    ('leaflet.timedimension',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),  # noqa
-]
-
-_default_css = [
-    ('highlight.js_css',
-     'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
-    ('leaflet.timedimension_css',
-     'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')  # noqa
-]
-
-
-class TimestampedWmsTileLayers(Layer):
+class TimestampedWmsTileLayers(JSCSSMixin, Layer):
     """
     Creates a TimestampedWmsTileLayer that takes a WmsTileLayer and adds time
     control with the Leaflet.TimeDimension plugin.
@@ -116,6 +96,23 @@ class TimestampedWmsTileLayers(Layer):
         {% endmacro %}
         """)
 
+    default_js = [
+        ('jquery2.0.0',
+         'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js'),
+        ('jqueryui1.10.2',
+         'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js'),
+        ('iso8601',
+         'https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js'),
+        ('leaflet.timedimension',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js'),
+    ]
+    default_css = [
+        ('highlight.js_css',
+         'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css'),
+        ('leaflet.timedimension_css',
+         'https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.css')
+    ]
+
     def __init__(self, data, transition_time=200, loop=False, auto_play=False,
                  period='P1D', time_interval=False, name=None):
         super(TimestampedWmsTileLayers, self).__init__(name=name,
@@ -139,18 +136,3 @@ class TimestampedWmsTileLayers(Layer):
             self.layers = [data]
         else:
             self.layers = data  # Assume iterable
-
-    def render(self, **kwargs):
-        super(TimestampedWmsTileLayers, self).render()
-
-        figure = self.get_root()
-        assert isinstance(figure, Figure), ('You cannot render this Element '
-                                            'if it is not in a Figure.')
-
-        # Import Javascripts
-        for name, url in _default_js:
-            figure.header.add_child(JavascriptLink(url), name=name)
-
-        # Import Css
-        for name, url in _default_css:
-            figure.header.add_child(CssLink(url), name=name)


### PR DESCRIPTION
I wanted to do this before we release. We recently moved the links to external JS and CSS resources to module variables: https://github.com/python-visualization/folium/pull/1312. This was a good thing. But I was thinking that it would make things much more DRY if we move them to the classes instead, because then we can render them in one place.

I made a mixin class that renders JS and CSS links. I thought about subclassing `MacroElement` and using that subclass throughout the code, but I think using a mixin is a bit more clean here.

This change allows us to remove duplicated code while still allowing users to replace the JS/CSS links.