### PR TITLE
don't use python build until we have a pyproject.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,15 @@ jobs:
 
     - name: Install build tools
       run: |
-        python -m pip install --upgrade pip wheel setuptools setuptools_scm build twine "branca>=0.3.0" "jinja2>=2.9" numpy requests
+        python -m pip install --upgrade pip wheel setuptools setuptools_scm twine "branca>=0.3.0" "jinja2>=2.9" numpy requests
 
       shell: bash
 
     - name: Build binary wheel
-      run: python -m build --sdist --wheel . --outdir dist
+      run: pip wheel . -w dist --no-deps
+
+    - name: Build sdist
+      run: python setup.py sdist
 
     - name: CheckFiles
       run: |


### PR DESCRIPTION
@Conengmo I'm doing the wheel and sdist in the "old" fashion until we have a pyproject.toml. That is probably the reason why the releases versions are a bit odd.