### PR TITLE
Hover tooltips for TimestampedGeoJson

### DIFF
--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -68,8 +68,9 @@ class TimestampedGeoJson(JSCSSMixin, MacroElement):
     ...           'coordinates': [[-70,-25],[-70,35],[70,35]],
     ...           },
     ...         'properties': {
-    ...           'times': [1435708800000, 1435795200000, 1435881600000]
-    ...           }
+    ...           'times': [1435708800000, 1435795200000, 1435881600000],
+    ...           'tooltip': 'my tooltip text'
+    ...           },
     ...         }
     ...       ]
     ...     })

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -124,6 +124,9 @@ class TimestampedGeoJson(JSCSSMixin, MacroElement):
                         if (feature.properties.popup) {
                         layer.bindPopup(feature.properties.popup);
                         }
+                        if (feature.properties.tooltip) {
+                        layer.bindTooltip(feature.properties.tooltip);
+                        }
                     }
                 })
 

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -151,6 +151,9 @@ def test_timestamped_geo_json():
                     if (feature.properties.popup) {
                     layer.bindPopup(feature.properties.popup);
                     }
+                    if (feature.properties.tooltip) {
+                        layer.bindTooltip(feature.properties.tooltip);
+                    }
                 }
             })
 


### PR DESCRIPTION
Add support for tooltips in TimestampedGeoJson objects.
Currently only popup (i.e. onclick) is supported, this adds tooltip (i.e. hover).
Usage is by defining a property in the geojson called 'tooltip'