### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/examples/FloatImage.ipynb
+++ b/examples/FloatImage.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/python-visualization/folium/blob/master/examples/FloatImage.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) could look like.

If it makes sense I can submit a further PR adding it to the other notebooks in this folder.