### PR TITLE
Upgrade bootstrap css 3.2 to 4.5

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -40,7 +40,7 @@ _default_css = [
     ('leaflet_css',
      'https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet.css'),
     ('bootstrap_css',
-     'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css'),
+     'https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css'),
     ('bootstrap_theme_css',
      'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css'),  # noqa
     ('awesome_markers_font_css',


### PR DESCRIPTION
As requested in #1479

Didn't add any error on top of existing ones. 
(Done : 
run flake8 folium --max-line-length=120
run python -m pytest tests --ignore=tests/selenium
run python -m pytest tests/selenium)

This updates bootstrap's CSS. 