### PR TITLE
Polyline documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ miniconda.sh
 latest_logs/
 *.nbconvert.ipynb
 folium/_version.py
+.vscode/
+venv/


### PR DESCRIPTION
Added documentation about Polylines inside `Quickstart`, so that Polylines are also visible when starting using Folium


Note that I also added the following to `.gitignore`:
* VSCode's `.vscode` 
*  `venv/`