### PR TITLE
Fix links to master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
     :target: https://pypi.org/project/folium
     :alt: PyPI Package
 
-.. |Travis| image:: https://travis-ci.org/python-visualization/folium.svg?branch=master
+.. |Travis| image:: https://travis-ci.org/python-visualization/folium.svg?branch=main
     :target: https://travis-ci.org/python-visualization/folium
     :alt: Travis Build Status
 
@@ -17,7 +17,7 @@
    :alt: DOI
    
 .. |binder| image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/python-visualization/folium/master?filepath=examples
+ :target: https://mybinder.org/v2/gh/python-visualization/folium/main?filepath=examples
 
 folium
 ======
@@ -56,7 +56,7 @@ Gallery
 There are two galleries of Jupyter notebooks with examples, which you can see
 using Jupyter's nbviewer:
 
-https://nbviewer.jupyter.org/github/python-visualization/folium/tree/master/examples/
+https://nbviewer.jupyter.org/github/python-visualization/folium/tree/main/examples/
 
 https://nbviewer.jupyter.org/github/python-visualization/folium_contrib/tree/master/notebooks/
 
@@ -66,7 +66,7 @@ Contributing
 We love contributions!  folium is open source, built on open source,
 and we'd love to have you hang out in our community.
 
-See `our complete contributor's guide <https://github.com/python-visualization/folium/blob/master/.github/CONTRIBUTING.md>`_ for more info.
+See `our complete contributor's guide <https://github.com/python-visualization/folium/blob/main/.github/CONTRIBUTING.md>`_ for more info.
 
 
 .. |folium| image:: http://python-visualization.github.io/folium/_images/folium_logo.jpg
@@ -76,4 +76,4 @@ See `our complete contributor's guide <https://github.com/python-visualization/f
 Changelog
 ---------
 
-Check the `changelog <https://raw.githubusercontent.com/python-visualization/folium/master/CHANGES.txt>`_ for a detailed list of the latest changes.
+Check the `changelog <https://raw.githubusercontent.com/python-visualization/folium/main/CHANGES.txt>`_ for a detailed list of the latest changes.


### PR DESCRIPTION
Fix various links that still pointed to the master branch.

Some of the links actually still worked, as GitHub silently redirects to main. However, the link to the example notebooks was broken.