### PR TITLE
Use conda-forge for dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The basic workflow for contributing is:
 
    If using `conda` one can create a development environment with:
    ```
-   $ conda create --name FOLIUM python=3.7 --file requirements.txt --file requirements-dev.txt
+   $ conda create --name FOLIUM -c conda-forge python=3.7 --file requirements.txt --file requirements-dev.txt
    ```
 5. Install the dependencies listed in `requirements.txt` and `requirements-dev.txt`.
    ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The basic workflow for contributing is:
 
    If using `conda` one can create a development environment with:
    ```
-   $ conda create --name FOLIUM -c conda-forge python=3.7 --file requirements.txt --file requirements-dev.txt
+   $ conda create --name FOLIUM -c conda-forge python=3 --file requirements.txt --file requirements-dev.txt
    ```
 5. Install the dependencies listed in `requirements.txt` and `requirements-dev.txt`.
    ```


### PR DESCRIPTION
Update CONTRIBUTING instructions to use the conda-forge channel.
Several dependencies are not available in the conda channel