### PR TITLE
Fix test failures with latest branca

### DIFF
--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -23,11 +23,6 @@ import pandas as pd
 
 import pytest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
@@ -76,24 +71,22 @@ class TestFolium(object):
 
     def setup(self):
         """Setup Folium Map."""
-        with mock.patch('branca.element.uuid4') as uuid4:
-            uuid4().hex = '0' * 32
-            attr = 'http://openstreetmap.org'
-            self.m = folium.Map(
-                location=[45.5236, -122.6750],
-                width=900,
-                height=400,
-                max_zoom=20,
-                zoom_start=4,
-                max_bounds=True,
-                attr=attr
-            )
+        attr = 'http://openstreetmap.org'
+        self.m = folium.Map(
+            location=[45.5236, -122.6750],
+            width=900,
+            height=400,
+            max_zoom=20,
+            zoom_start=4,
+            max_bounds=True,
+            attr=attr
+        )
         self.env = Environment(loader=PackageLoader('folium', 'templates'))
 
     def test_init(self):
         """Test map initialization."""
 
-        assert self.m.get_name() == 'map_00000000000000000000000000000000'
+        assert self.m.get_name().startswith('map_')
         assert self.m.get_root() == self.m._parent
         assert self.m.location == [45.5236, -122.6750]
         assert self.m.options['zoom'] == 4
@@ -107,11 +100,11 @@ class TestFolium(object):
         assert self.m.global_switches.disable_3d is False
         assert self.m.to_dict() == {
             'name': 'Map',
-            'id': '00000000000000000000000000000000',
+            'id': self.m._id,
             'children': {
                 'openstreetmap': {
                     'name': 'TileLayer',
-                    'id': '00000000000000000000000000000000',
+                    'id': self.m._children["openstreetmap"]._id,
                     'children': {}
                 }
             }


### PR DESCRIPTION
Bianca removed uuid4 recently for performance reasons.

Rather than trying to mock what branch is using now to generate IDs, I think it's better not to mock id generation at all. This required a few changes on how to test the result of `to_dict`.

I wonder, though, wether we really should compare for equality. This will break again whenever branca adds new values to the dict, or changes internals. Maybe it would be better to just assert on specific keys that we are interested in, or not check `to_dict` at all?