### PR TITLE
Send events as console logs

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -191,7 +191,7 @@ class Map(JSCSSMixin, MacroElement):
             );
             
             {{ this.get_name() }}.on('click', function(e) {        
-                console.log(JSON.stringify({polygon_created: e.latlng}));    
+                console.log(JSON.stringify({MAP_CLICK: e.latlng}));    
             });
 
             {%- if this.control_scale %}

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -191,7 +191,8 @@ class Map(JSCSSMixin, MacroElement):
             );
             
             {{ this.get_name() }}.on('click', function(e) {        
-                console.log(JSON.stringify({MAP_CLICK: e.latlng}));    
+                console.log(JSON.stringify({event: 'MAP_CLICK', value: e.latlng}));    
+                
             });
 
             {%- if this.control_scale %}

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -191,7 +191,7 @@ class Map(JSCSSMixin, MacroElement):
             );
             
             {{ this.get_name() }}.on('click', function(e) {        
-                console.log({JSON.stringify({polygon_created: e.latlng}));    
+                console.log(JSON.stringify({polygon_created: e.latlng}));    
             });
 
             {%- if this.control_scale %}

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -191,7 +191,7 @@ class Map(JSCSSMixin, MacroElement):
             );
             
             {{ this.get_name() }}.on('click', function(e) {        
-                console.log(JSON.stringify(e.latlng));    
+                console.log({JSON.stringify({polygon_created: e.latlng}));    
             });
 
             {%- if this.control_scale %}

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -191,7 +191,7 @@ class Map(JSCSSMixin, MacroElement):
             );
             
             {{ this.get_name() }}.on('click', function(e) {        
-                console.log(JSON.stringify({event: 'MAP_CLICK', value: e.latlng}));    
+                console.log(JSON.stringify({event: 'MAP_CLICKED', value: e.latlng}));    
                 
             });
 

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -189,9 +189,14 @@ class Map(JSCSSMixin, MacroElement):
                     {%- endfor %}
                 }
             );
+            
+            {{ this.get_name() }}.on('click', function(e) {        
+                console.log(JSON.stringify(e.latlng));    
+            });
 
             {%- if this.control_scale %}
             L.control.scale().addTo({{ this.get_name() }});
+            
             {%- endif %}
 
             {% if this.objects_to_stay_in_front %}

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -60,9 +60,9 @@ class Draw(JSCSSMixin, MacroElement):
                     type = e.layerType;
                 var coords = JSON.stringify(layer.toGeoJSON());
                 layer.on('click', function() {
-                    alert(coords);
                     console.log(coords);
                 });
+                console.log({polygon_created: coords});
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {
@@ -102,6 +102,8 @@ class Draw(JSCSSMixin, MacroElement):
         self.position = position
         self.draw_options = draw_options or {}
         self.edit_options = edit_options or {}
+
+
 
     def render(self, **kwargs):
         super(Draw, self).render(**kwargs)

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -62,7 +62,7 @@ class Draw(JSCSSMixin, MacroElement):
                 layer.on('click', function() {
                     console.log(coords);
                 });
-                console.log(JSON.stringify({polygon_created: coords}));
+                console.log(JSON.stringify({polygon_created: layer.toGeoJSON()}));
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -60,7 +60,7 @@ class Draw(JSCSSMixin, MacroElement):
                     type = e.layerType;
                 var coords = JSON.stringify(layer.toGeoJSON());
                 layer.on('click', function(e) {
-                    console.log(JSON.stringify({event: 'POLYGON_CLICKED', value: [layer.toGeoJSON(),e]}));
+                    console.log(JSON.stringify({event: 'POLYGON_CLICKED', value: [layer.toGeoJSON(),e.latlng]}));
                 });
                 console.log(JSON.stringify({event: 'POLYGON_CREATED', value: layer.toGeoJSON()}));
                 drawnItems.addLayer(layer);

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -60,9 +60,9 @@ class Draw(JSCSSMixin, MacroElement):
                     type = e.layerType;
                 var coords = JSON.stringify(layer.toGeoJSON());
                 layer.on('click', function() {
-                    console.log(coords);
+                    console.log(JSON.stringify({POLYGON_CLICKED: layer.toGeoJSON()}));
                 });
-                console.log(JSON.stringify({polygon_created: layer.toGeoJSON()}));
+                console.log(JSON.stringify({POLYGON_CREATED: layer.toGeoJSON()}));
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -59,10 +59,10 @@ class Draw(JSCSSMixin, MacroElement):
                 var layer = e.layer,
                     type = e.layerType;
                 var coords = JSON.stringify(layer.toGeoJSON());
-                layer.on('click', function() {
-                    console.log(JSON.stringify({POLYGON_CLICKED: layer.toGeoJSON()}));
+                layer.on('click', function(e) {
+                    console.log(JSON.stringify({event: 'POLYGON_CLICKED', value: layer.toGeoJSON()}));
                 });
-                console.log(JSON.stringify({POLYGON_CREATED: layer.toGeoJSON()}));
+                console.log(JSON.stringify({event: 'POLYGON_CREATED', value: [layer.toGeoJSON(),e]}));
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -60,9 +60,9 @@ class Draw(JSCSSMixin, MacroElement):
                     type = e.layerType;
                 var coords = JSON.stringify(layer.toGeoJSON());
                 layer.on('click', function(e) {
-                    console.log(JSON.stringify({event: 'POLYGON_CLICKED', value: layer.toGeoJSON()}));
+                    console.log(JSON.stringify({event: 'POLYGON_CLICKED', value: [layer.toGeoJSON(),e]}));
                 });
-                console.log(JSON.stringify({event: 'POLYGON_CREATED', value: [layer.toGeoJSON(),e]}));
+                console.log(JSON.stringify({event: 'POLYGON_CREATED', value: layer.toGeoJSON()}));
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -62,7 +62,7 @@ class Draw(JSCSSMixin, MacroElement):
                 layer.on('click', function() {
                     console.log(coords);
                 });
-                console.log({polygon_created: coords});
+                console.log(JSON.stringify({polygon_created: coords}));
                 drawnItems.addLayer(layer);
              });
             {{ this._parent.get_name() }}.on('draw:created', function(e) {


### PR DESCRIPTION
Hi, I share this code that I am using to receive events in Python using Qt library.

These modifications allowed me to receive:
 - Mouse Click
 - Polygon Creation
 - Polygon Click
 
It should be really easy to add more events in different layers, elements, and features using this logic.

I feel that folium would be much more useful with two-way communication with python.

For reading the vents in PyQt6 I use:

```
class WebEnginePage(QWebEnginePage):
    def javaScriptConsoleMessage(self, level, msg, line, sourceID):
        event = (json.loads(msg))
        print(event)

web_map = QWebEngineView()
page = WebEnginePage(web_map)
web_map.setPage(page)
m = folium.Map(location=settings.COORDINATES, zoom_start=13)
tile = folium.TileLayer(
    tiles='http://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',
    attr='Google',
    name='Google Satellite',
    overlay=False,
    control=True
).add_to(m)

data = io.BytesIO()
m.save(data, close_file=False)
web_map.setHtml(data.getvalue().decode())

```


