### PR TITLE
allow passing TileLayer to Map

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -97,9 +97,10 @@ class Map(JSCSSMixin, MacroElement):
         Width of the map.
     height: pixel int or percentage string (default: '100%')
         Height of the map.
-    tiles: str, default 'OpenStreetMap'
+    tiles: str or TileLayer, default 'OpenStreetMap'
         Map tileset to use. Can choose from a list of built-in tiles,
-        pass a custom URL or pass `None` to create a map without tiles.
+        pass a custom URL, pass a TileLayer object,
+        or pass `None` to create a map without tiles.
         For more advanced tile layer options, use the `TileLayer` class.
     min_zoom: int, default 0
         Minimum allowed zoom level for the tile layer that is created.
@@ -282,7 +283,9 @@ class Map(JSCSSMixin, MacroElement):
 
         self.objects_to_stay_in_front = []
 
-        if tiles:
+        if isinstance(tiles, TileLayer):
+            self.add_child(tiles)
+        elif tiles:
             tile_layer = TileLayer(tiles=tiles, attr=attr,
                                    min_zoom=min_zoom, max_zoom=max_zoom)
             self.add_child(tile_layer, name=tile_layer.tile_name)

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -153,7 +153,7 @@ class TestFolium(object):
         url = "http://{s}.custom_tiles.org/{z}/{x}/{y}.png"
         attr = "Attribution for custom tiles"
         m = folium.Map(location=[45.52, -122.67], tiles=TileLayer(url, attr=attr))
-        assert m._children[url].tiles == url
+        assert next(iter(m._children.values())).tiles == url
         assert attr in m._parent.render()
 
     def test_feature_group(self):

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -10,6 +10,7 @@ import os
 import branca.element
 
 import folium
+from folium import TileLayer
 from folium.features import GeoJson, Choropleth
 
 import jinja2
@@ -147,6 +148,13 @@ class TestFolium(object):
 
         bounds = m.get_bounds()
         assert bounds == [[None, None], [None, None]], bounds
+
+    def test_tilelayer_object(self):
+        url = "http://{s}.custom_tiles.org/{z}/{x}/{y}.png"
+        attr = "Attribution for custom tiles"
+        m = folium.Map(location=[45.52, -122.67], tiles=TileLayer(url, attr=attr))
+        assert m._children[url].tiles == url
+        assert attr in m._parent.render()
 
     def test_feature_group(self):
         """Test FeatureGroup."""


### PR DESCRIPTION
Looking at https://github.com/python-visualization/folium/issues/1316 and https://github.com/python-visualization/folium/issues/1033, this seemed like an obvious improvement that doesn't actually increase the parameter footprint of the `Map` class.

With this change a user doesn't have to do the following:

```
m = Map(tiles=None)
TileLayer().add_to(m)
```

but can do this directly:

```
m = Map(tiles=TileLayer())
```

**Discussion**

I still think we should be careful to add more parameters to `Map`, to prevent it from becoming a god-class. If `Map` has the same parameters as `TileLayer`, we are doing something wrong. I think we should stick with `Map` having the `tiles` argument as a convenience, and have users use `TileLayer` when they want to do more advanced things.

Maybe a way to make this more clear is by allowing the `tiles` argument of `Map` to only be one of the pre-defined string arguments or a `TileLayer`, but not a custom url. Users wanting to use a custom url are thus forced to use `TileLayer`. That way we could also scrap the `attr` argument of `Map`.

Since that would mean breaking changes for some users, I don't think we should actually go ahead with that.