### PR TITLE
test_geojson test does not pass on v0.13.0 tag because of the usage of removed Selenium method #1625

### DIFF
--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -1,5 +1,6 @@
 import folium
 import folium.plugins
+from selenium.webdriver.common.by import By
 from folium.utilities import temp_html_filepath
 
 
@@ -32,5 +33,5 @@ def test_geojson(driver):
         '.leaflet-control-layers-overlays > label:nth-of-type(2)'
     )
     assert control_label.text == 'geojson'
-    control_input = control_label.find_element_by_css_selector('input')
+    control_input = control_label.find_element(By.CSS_SELECTOR, value='input')
     assert control_input.get_attribute('checked') is None


### PR DESCRIPTION
updated the test_geojson with latest find_element method

closes #1625 