### PR TITLE
CI: Add weekly scheduled run to all CI workflows

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,11 @@
 name: Publish to PyPI
 
-on: ["push", "pull_request"]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 defaults:
   run:
@@ -19,7 +24,7 @@ jobs:
 
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      
+
 
     - name: Install build tools
       run: |

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,6 +1,11 @@
 name: Code Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   run:

--- a/.github/workflows/test_code_notebooks.yml
+++ b/.github/workflows/test_code_notebooks.yml
@@ -1,6 +1,11 @@
 name: Notebook Code Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   run:

--- a/.github/workflows/test_latest_branca.yml
+++ b/.github/workflows/test_latest_branca.yml
@@ -1,6 +1,11 @@
 name: Code Tests with Latest branca
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   run:

--- a/.github/workflows/test_selenium.yml
+++ b/.github/workflows/test_selenium.yml
@@ -1,6 +1,11 @@
 name: Selenium Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   run:

--- a/.github/workflows/test_style_notebooks.yml
+++ b/.github/workflows/test_style_notebooks.yml
@@ -1,6 +1,11 @@
 name: Notebook Style Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   run:


### PR DESCRIPTION
Adds a weekly scheduled run to all CI workflows, which run each Monday at 06:00 UTC. A periodically scheduled run can detect errors and warnings appearing in changes in upstream dependencies or the build environment. By having a scheduled run they can be traced back easier to a dependency or environment change, then if they would pop up in a random PR.

Also enabled triggering a run manually (the `workflow_dispatch`) and updates [actions/checkout](https://github.com/actions/checkout) to v3.