### PR TITLE
Updated Font Awesome to version 6.2.0 from 4.6.3

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -42,7 +42,7 @@ _default_css = [
     ('bootstrap_theme_css',
      'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css'),  # noqa
     ('awesome_markers_font_css',
-     'https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css'),  # noqa
+     'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css'),  # noqa
     ('awesome_markers_css',
      'https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css'),  # noqa
     ('awesome_rotate_css',


### PR DESCRIPTION
###  Changelog

Updated Font Awesome to Version 6.2.0

Files Changes:

./folium/folium.py

### Closes

Closes Issues  #1532 and #923

### Screenshots

![before](https://user-images.githubusercontent.com/47243708/198873988-69065aa1-7e13-4697-9354-6377c513a958.png)
Before

![after](https://user-images.githubusercontent.com/47243708/198874013-4a1a7261-aa9c-4c0e-a2a6-d4e7c49dd4d7.png)
After

### Example

``` 
    import folium

    start_coords = (40.009515, -105.242714)

    folium_map = folium.Map(location=start_coords, zoom_start=5)

    folium.Marker(location=[41.009515, -105.242714],icon=folium.Icon(color="black",icon="fa-solid fa-satellite",prefix="fa")).add_to(folium_map)

    folium.Marker(location=[42.009515, -105.242714],icon=folium.Icon(color="black",icon="fa-solid fa-yin-yang",prefix="fa")).add_to(folium_map)

    folium.Marker(location=[43.009515, -105.242714],icon=folium.Icon(color="black",icon="fa-solid fa-volcano",prefix="fa")).add_to(folium_map)

    folium.Marker(location=[44.009515, -105.242714],icon=folium.Icon(color="black",icon="fa-solid fa-viruses",prefix="fa")).add_to(folium_map)

    folium.Marker(location=[45.009515, -105.242714],icon=folium.Icon(color="black",icon="fa-solid fa-wallet",prefix="fa")).add_to(folium_map)
```

