### PR TITLE
Fix Marker location validation for numpy array

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -275,7 +275,7 @@ class Marker(MacroElement):
                  draggable=False, **kwargs):
         super(Marker, self).__init__()
         self._name = 'Marker'
-        self.location = validate_location(location) if location else None
+        self.location = validate_location(location) if location is not None else None
         self.options = parse_options(
             draggable=draggable or None,
             autoPan=draggable or None,

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -3,7 +3,7 @@ Folium map Tests
 ----------------
 
 """
-
+import numpy as np
 import pytest
 
 from folium import Map
@@ -146,6 +146,10 @@ def test_marker_valid_location():
     marker.add_to(m)
     with pytest.raises(ValueError):
         m.render()
+
+
+def test_marker_numpy_array_as_location():
+    Marker(np.array([0, 0]))
 
 
 @pytest.mark.filterwarnings('ignore::UserWarning')


### PR DESCRIPTION
When passing a Numpy array as location for a Marker, currently an error is raised:

```
>       self.location = validate_location(location) if location else None
E       ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

That's because we use `if location`. Change it to `if location is not None`, which is more specific.

(Found this while working on https://github.com/python-visualization/folium/pull/1343 )