### PR TITLE
Bootstrap 5 (take 2)

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -29,7 +29,7 @@ _default_js = [
     ('jquery',
      'https://code.jquery.com/jquery-1.12.4.min.js'),
     ('bootstrap',
-     'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'),
+     'https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js'),
     ('awesome_markers',
      'https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js'),  # noqa
     ]
@@ -38,9 +38,10 @@ _default_css = [
     ('leaflet_css',
      'https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet.css'),
     ('bootstrap_css',
-     'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css'),
-    ('bootstrap_theme_css',
-     'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css'),  # noqa
+     'https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css'),
+    # glyphicons came from Bootstrap 3 and are used for Awesome Markers
+    ('glyphicons_css',
+     'https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css'),
     ('awesome_markers_font_css',
      'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css'),  # noqa
     ('awesome_markers_css',


### PR DESCRIPTION
Second take of https://github.com/python-visualization/folium/pull/1644, which was reverted in https://github.com/python-visualization/folium/pull/1648.

This time don't host the icons ourselves, but use a standalone version on the official Bootstrap CDN. It was referenced here: https://stackoverflow.com/questions/18222849/bootstrap-3-glyphicons-cdn

If at some point this becomes unavailable I'm afraid we'll just have to drop Glyphicons. Bootstrap 3 is a bit old now, so while sad it's not completely unexpected support disappears at some point. But for now let's hope this CDN endpoint stays up.