### PR TITLE
Map.show_in_browser() using temp file

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -384,7 +384,7 @@ class Map(JSCSSMixin, MacroElement):
                 'Your map should have been opened in your browser automatically.'
                 '\nPress ctrl+c to return.'
             )
-            # Block until stopped by user, so we can remove the temporary file
+            # Block until stopped by user, afterwards remove the temporary file
             try:
                 while True:
                     time.sleep(100)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -5,6 +5,7 @@ Make beautiful, interactive maps with Python and Leaflet.js
 
 import time
 import warnings
+import webbrowser
 
 from branca.element import Element, Figure, MacroElement
 
@@ -374,6 +375,21 @@ class Map(JSCSSMixin, MacroElement):
             '</style>'), name='map_style')
 
         super(Map, self).render(**kwargs)
+
+    def show_in_browser(self):
+        """Display the Map in the default web browser."""
+        with temp_html_filepath(self.get_root().render()) as fname:
+            webbrowser.open(fname)
+            print(
+                'Your map should have been opened in your browser automatically.'
+                '\nPress ctrl+c to return.'
+            )
+            # Block until stopped by user, so we can remove the temporary file
+            try:
+                while True:
+                    time.sleep(100)
+            except KeyboardInterrupt:
+                pass
 
     def fit_bounds(self, bounds, padding_top_left=None,
                    padding_bottom_right=None, padding=None, max_zoom=None):


### PR DESCRIPTION
Alternative for https://github.com/python-visualization/folium/pull/953/.

Related issue: https://github.com/python-visualization/folium/issues/946

Allow opening a Map in the browser directly. But instead of using a server, use a temporary file instead. In functionality it should be equivalent, but the code is simpler.