### PR TITLE
Fix branca version test

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -49,7 +49,7 @@ except ImportError:
     __version__ = "unknown"
 
 
-if tuple(int(x) for x in branca.__version__.split('.')[:2]) < (0, 3):
+if branca.__version__ != 'unknown' and tuple(int(x) for x in branca.__version__.split('.')[:2]) < (0, 3):
     raise ImportError('branca version 0.3.0 or higher is required. '
                       'Update branca with e.g. `pip install branca --upgrade`.')
 


### PR DESCRIPTION
In branca we know use a version 'unknown' for local versions. This breaks this check we have in folium. Fix it in a simple way.