### PR TITLE
Fix Choropleth bins list of int

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1514,6 +1514,7 @@ class Choropleth(FeatureGroup):
             # then we 'correct' the last edge for numpy digitize
             # (we add a very small amount to fake an inclusive right interval)
             increasing = bin_edges[0] <= bin_edges[-1]
+            bin_edges = bin_edges.astype(float)
             bin_edges[-1] = np.nextafter(
                 bin_edges[-1], (1 if increasing else -1) * np.inf
             )


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1130

Fix an issue in Choropleth where if  `bins` is a list of integers, adding an inclusive right interval fails. That's because where we use `np.nextafter` it doesn't also convert the data type of `bin_edges` to float. So in practice `np.nextafter` does nothing there. Fix it by first converting `bin_edges` to an array of floats.