### PR TITLE
Fix topojson object path

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -24,6 +24,7 @@ from folium.utilities import (
     get_bounds,
     get_obj_in_upper_tree,
     image_to_url,
+    javascript_identifier_path_to_array_notation,
     none_max,
     none_min,
     parse_options,
@@ -901,7 +902,7 @@ class TopoJson(JSCSSMixin, Layer):
             var {{ this.get_name() }} = L.geoJson(
                 topojson.feature(
                     {{ this.get_name() }}_data,
-                    {{ this.get_name() }}_data.{{ this.object_path }}
+                    {{ this.get_name() }}_data{{ this._safe_object_path }}
                 ),
                 {
                 {%- if this.smooth_factor is not none %}
@@ -949,6 +950,9 @@ class TopoJson(JSCSSMixin, Layer):
             self.data = data
 
         self.object_path = object_path
+        self._safe_object_path = javascript_identifier_path_to_array_notation(
+            object_path
+        )
 
         if style_function is None:
 

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -493,3 +493,12 @@ def parse_options(**kwargs):
 def escape_backticks(text):
     """Escape backticks so text can be used in a JS template."""
     return re.sub(r"(?<!\\)`", r"\`", text)
+
+
+def escape_double_quotes(text):
+    return text.replace('"', r"\"")
+
+
+def javascript_identifier_path_to_array_notation(path):
+    """Convert a path like obj1.obj2 to array notation: ["obj1"]["obj2"]."""
+    return "".join(f'["{escape_double_quotes(x)}"]' for x in path.split("."))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -208,7 +208,7 @@ def test_escape_double_quotes(text, result):
 @pytest.mark.parametrize(
     "text,result",
     [
-        ("bla", "bla"),
+        ("bla", '["bla"]'),
         ("obj-1.obj2", '["obj-1"]["obj2"]'),
         ('obj-1.obj"2', r'["obj-1"]["obj\"2"]'),
     ],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -7,8 +7,10 @@ from folium.utilities import (
     _is_url,
     camelize,
     deep_copy,
+    escape_double_quotes,
     get_obj_in_upper_tree,
     if_pandas_df_convert_to_numpy,
+    javascript_identifier_path_to_array_notation,
     parse_options,
     validate_location,
     validate_locations,
@@ -189,3 +191,27 @@ def test_parse_options():
 )
 def test_is_url(url):
     assert _is_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "text,result",
+    [
+        ("bla", "bla"),
+        ('bla"bla', r"bla\"bla"),
+        ('"bla"bla"', r"\"bla\"bla\""),
+    ],
+)
+def test_escape_double_quotes(text, result):
+    assert escape_double_quotes(text) == result
+
+
+@pytest.mark.parametrize(
+    "text,result",
+    [
+        ("bla", "bla"),
+        ("obj-1.obj2", '["obj-1"]["obj2"]'),
+        ('obj-1.obj"2', r'["obj-1"]["obj\"2"]'),
+    ],
+)
+def test_javascript_identifier_path_to_array_notation(text, result):
+    assert javascript_identifier_path_to_array_notation(text) == result


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/828

Fix an issue with Topojson object paths. With the current code each item in the path should be a valid Javascript identifier, but users may not know this.

I looked into JS identifier validation, but I don't think that's the way to go:

- Topojson doesn't demand the objects have valid JS identifiers as names.
- There are many ways in which a JS identifier can be invalid, so it's hard to test.
- Users may be unable to change their Topojson data easily.

Instead I opted to convert the path to an array notation: `obj1.obj2` -> `["obj1"]["obj2"]`. After we escape double quotes any string should work. With this, object paths that include hyphens work.

Alternatively, only look for hyphens and raise an error if we see one. I'd rather fix the complete problem instead of just one specific case. But if this change is too complex, that might be a small step to take instead.