### PR TITLE
FloatImage: use any kwargs as CSS

### DIFF
--- a/folium/plugins/float_image.py
+++ b/folium/plugins/float_image.py
@@ -3,17 +3,34 @@ from jinja2 import Template
 
 
 class FloatImage(MacroElement):
-    """Adds a floating image in HTML canvas on top of the map."""
+    """Adds a floating image in HTML canvas on top of the map.
+
+    Parameters
+    ----------
+    image: str
+        Url to image location. Can also be an inline image using a data URI
+        or a local file using `file://`.
+    bottom: int, default 75
+        Vertical position from the bottom, as a percentage of screen height.
+    left: int, default 75
+        Horizontal position from the left, as a percentage of screen width.
+    **kwargs
+        Additional keyword arguments are applied as CSS properties.
+        For example: `width='300px'`.
+
+    """
 
     _template = Template(
         """
             {% macro header(this,kwargs) %}
                 <style>
                     #{{this.get_name()}} {
-                        position:absolute;
-                        bottom:{{this.bottom}}%;
-                        left:{{this.left}}%;
-                        width:{{this.width}}%;
+                        position: absolute;
+                        bottom: {{this.bottom}}%;
+                        left: {{this.left}}%;
+                        {%- for property, value in this.css.items() %}
+                          {{ property }}: {{ value }};
+                        {%- endfor %}
                         }
                 </style>
             {% endmacro %}
@@ -27,10 +44,10 @@ class FloatImage(MacroElement):
             """
     )
 
-    def __init__(self, image, bottom=75, left=75, width=100):
+    def __init__(self, image, bottom=75, left=75, **kwargs):
         super().__init__()
         self._name = "FloatImage"
         self.image = image
         self.bottom = bottom
         self.left = left
-        self.width = width
+        self.css = kwargs

--- a/tests/plugins/test_float_image.py
+++ b/tests/plugins/test_float_image.py
@@ -13,7 +13,7 @@ from folium.utilities import normalize
 def test_float_image():
     m = folium.Map([45.0, 3.0], zoom_start=4)
     url = "https://raw.githubusercontent.com/SECOORA/static_assets/master/maps/img/rose.png"
-    szt = plugins.FloatImage(url, bottom=60, left=70, width=20)
+    szt = plugins.FloatImage(url, bottom=60, left=70, width="20%")
     m.add_child(szt)
     m._repr_html_()
 
@@ -35,10 +35,10 @@ def test_float_image():
         """
         <style>
             #{{this.get_name()}} {
-                position:absolute;
-                bottom:60%;
-                left:70%;
-                width:20%;
+                position: absolute;
+                bottom: 60%;
+                left: 70%;
+                width: 20%;
                 }
         </style>
     """


### PR DESCRIPTION
Fixes https://github.com/python-visualization/folium/issues/1667.

We introduced a regression in https://github.com/python-visualization/folium/pull/1570 by always setting `width` to 100 %. At first I wanted to fix it by making the argument optional. But then, after also checking https://github.com/python-visualization/folium/issues/1001 again, I opted to just open up the class to any CSS properties. With users being able to apply any CSS, we shouldn't hear about this again.

Note that this does mean an API change compared to version 0.13.0, since `width` will now require a unit like '%' or 'px' instead of just an integer. But I think that's a good thing. I didn't want to mess with the `bottom` and `left` parameters though, because I assume those have been around for much longer.