### PR TITLE
WmsTileLayer: allow cql_filter parameter

### DIFF
--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -205,6 +205,7 @@ class WmsTileLayer(Layer):
         transparent=False,
         version="1.1.1",
         attr="",
+        cql_filter=None,
         name=None,
         overlay=True,
         control=True,
@@ -222,6 +223,9 @@ class WmsTileLayer(Layer):
             attribution=attr,
             **kwargs
         )
+        if cql_filter:
+            # special parameter that shouldn't be camelized
+            self.options["cql_filter"] = cql_filter
 
 
 class ImageOverlay(Layer):

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -205,7 +205,6 @@ class WmsTileLayer(Layer):
         transparent=False,
         version="1.1.1",
         attr="",
-        cql_filter=None,
         name=None,
         overlay=True,
         control=True,
@@ -215,6 +214,7 @@ class WmsTileLayer(Layer):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self.url = url
         kwargs["format"] = fmt
+        cql_filter = kwargs.pop("cql_filter", None)
         self.options = parse_options(
             layers=layers,
             styles=styles,

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -66,6 +66,7 @@ def test_wms():
 
     # verify this special case wasn't converted to lowerCamelCase
     assert '"cql_filter": "something",' in html
+    assert "cqlFilter" not in html
 
     bounds = m.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -59,9 +59,13 @@ def test_wms():
         layers="nexrad-n0r-900913",
         attr="Weather data © 2012 IEM Nexrad",
         transparent=True,
+        cql_filter="something",
     )
     w.add_to(m)
-    m._repr_html_()
+    html = m.get_root().render()
+
+    # verify this special case wasn't converted to lowerCamelCase
+    assert '"cql_filter": "something",' in html
 
     bounds = m.get_bounds()
     assert bounds == [[None, None], [None, None]], bounds


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1248

WmsTileLayer users requested a `cql_filter` parameter be passed through without converting to lowerCamelCase notation.