### PR TITLE
LayerControl: fix visibility on multiple renders

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -158,6 +158,7 @@ class LayerControl(MacroElement):
 
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
+        self.reset()
         for item in self._parent._children.values():
             if not isinstance(item, Layer) or not item.control:
                 continue


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1199

LayerControl has instance attributes that we fill when the `render` method is called. That means that if `render` is called multiple times, those attributes are changed multiple times. This leads to bugs.

The desired behavior is that each time `render` is called, the instance attributes act as if the instance was freshly created. Achieve this by calling the `reset` method at the beginning of the `render` method. This way, each time `render` is called, empty instance attributes are used.