### PR TITLE
Remove Stickler config

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,7 +1,0 @@
-linters:
-  flake8:
-    max-line-length: 120
-    max-complexity: 10
-    python: 3
-files:
-  ignore: ['*.ipynb', 'conf.py']


### PR DESCRIPTION
We are not using Stickler CI anymore, remove the now unnecessary config file.