### PR TITLE
Remove unused Appveyor test settings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,9 +25,6 @@ pillow
 pre-commit
 pycodestyle
 pytest
-pytest-cov
-pytest-flake8
-pytest-xdist
 scipy
 selenium
 setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[tool:pytest]
-flake8-max-line-length = 121
-flake8-ignore =
-    docs/* ALL
-select = C,E,F,W,B,B950
-ignore = E203, E501, W503
-
 [metadata]
 description-file = README.md
 license_file = LICENSE.txt


### PR DESCRIPTION
In https://github.com/python-visualization/folium/pull/1083/ we added config for testing on Appveyor. We are no longer using that, so remove those settings. We switched over to Github Actions fully.

- [pytest-xdist](https://pypi.org/project/pytest-xdist/) is not used, not sure if that would even have an effect on Github Actions.
- [pytest-flake8](https://pypi.org/project/pytest-flake8/) is not used. Instead we have a flake8 pre-commit hook.
- [pytest-cov](https://pypi.org/project/pytest-cov/) is not used. Not that useful for us, since we rely on testing the Notebooks for coverage.

Reason for this PR is I'm cleaning up some of the warnings Pytest is giving:

```
../../../micromamba-root/envs/TEST/lib/python3.7/site-packages/_pytest/config/__init__.py:1294
  /home/runner/micromamba-root/envs/TEST/lib/python3.7/site-packages/_pytest/config/__init__.py:1294: PytestConfigWarning: Unknown config option: ignore
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

../../../micromamba-root/envs/TEST/lib/python3.7/site-packages/_pytest/config/__init__.py:1294
  /home/runner/micromamba-root/envs/TEST/lib/python3.7/site-packages/_pytest/config/__init__.py:1294: PytestConfigWarning: Unknown config option: select
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```