### PR TITLE
add local file prefix for browser

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -406,7 +406,7 @@ class Map(JSCSSMixin, MacroElement):
     def show_in_browser(self) -> None:
         """Display the Map in the default web browser."""
         with temp_html_filepath(self.get_root().render()) as fname:
-            webbrowser.open(fname)
+            webbrowser.open("file://" + fname)
             print(
                 "Your map should have been opened in your browser automatically."
                 "\nPress ctrl+c to return."


### PR DESCRIPTION
The show_in_browser() method wasn't working at all for me -- no browser popped up, but no error thrown. I'm on a M1 13" Macbook Pro running Ventura 13.1 and Python 3.11.1. 

Adding a "file://" prefix to the fname makes the browser work as expected. This change doesn't break any tests on my end. Tested on MacOS and Debian, don't have access to a windows machine at the moment.

First PR here so if I've done something horrifyingly wrong, let me know! 