### PR TITLE
Fix documentation generation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,13 @@
 name: Publish Docs
 
-on: ["push", "pull_request"]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
 
 jobs:
   run:


### PR DESCRIPTION
I noticed our documentation hasn't been updated since we moved away from Travis. Probably something wrong in our Github Actions workflow. I noticed we don't run the workflow on release, could that be the issue? To possibly solve this I copied the triggers from the 'Publish to PyPI' workflow.

If this would indeed solve the issue, I suspect we would then have to do a release to update the documentation. Or should I just run the documentation and update the `gh-pages` branch manually?