### PR TITLE
Fix isort usage in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       args: [--max-line-length=120]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       additional_dependencies: [toml]


### PR DESCRIPTION
isort is broken in pre-commit: https://github.com/PyCQA/isort/issues/2077. Upgrading to isort 5.12.0 should solve the issue.