### PR TITLE
MeasureControl: workaround for Leaflet>=1.8.0

### DIFF
--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -28,6 +28,21 @@ class MeasureControl(JSCSSMixin, MacroElement):
                 {{ this.options|tojson }});
             {{this._parent.get_name()}}.addControl({{this.get_name()}});
 
+            // Workaround for using this plugin with Leaflet>=1.8.0
+            // https://github.com/ljagis/leaflet-measure/issues/171
+            L.Control.Measure.include({
+                _setCaptureMarkerIcon: function () {
+                    // disable autopan
+                    this._captureMarker.options.autoPanOnFocus = false;
+                    // default function
+                    this._captureMarker.setIcon(
+                        L.divIcon({
+                            iconSize: this._map.getSize().multiplyBy(2)
+                        })
+                    );
+                },
+            });
+
         {% endmacro %}
         """
     )  # noqa


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1737.

This plugin broke for Leaflet 1.8.0. A workaround has been shared upstream, apply it in our template.