### PR TITLE
Multiple instances of TimeSliderChoropleth on a single map

### DIFF
--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -41,6 +41,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
 
             let slider_body = d3.select("body").insert("div", "div.folium-map")
                 .attr("id", "slider_{{ this.get_name() }}");
+            $("#slider_{{ this.get_name() }}").hide();
             // insert time slider label
             slider_body.append("output")
                 .attr("width", "100")
@@ -118,6 +119,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
 
             {%- if this.show %}
             {{ this.get_name() }}.addTo({{ this._parent.get_name() }});
+            $("#slider_{{ this.get_name() }}").show();
             {%- endif %}
         }
         {% endmacro %}

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -179,13 +179,13 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
                 )  # noqa
 
         # Make set of timestamps.
-        timestamps = set()
+        timestamps_set = set()
         for feature in styledict.values():
-            timestamps.update(set(feature.keys()))
+            timestamps_set.update(set(feature.keys()))
         try:
-            timestamps = sorted(timestamps, key=int)
+            timestamps = sorted(timestamps_set, key=int)
         except (TypeError, ValueError):
-            timestamps = sorted(timestamps)
+            timestamps = sorted(timestamps_set)
 
         self.timestamps = timestamps
         self.styledict = styledict

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -7,7 +7,10 @@ from folium.map import Layer
 
 class TimeSliderChoropleth(JSCSSMixin, Layer):
     """
-    Creates a TimeSliderChoropleth plugin to append into a map with Map.add_child.
+    Create a choropleth with a timeslider for timestamped data.
+
+    Visualize timestamped data, allowing users to view the choropleth at
+    different timestamps using a slider.
 
     Parameters
     ----------

--- a/tests/plugins/test_time_slider_choropleth.py
+++ b/tests/plugins/test_time_slider_choropleth.py
@@ -81,9 +81,9 @@ def test_timedynamic_geo_json():
 
     # We verify that data has been inserted correctly
     expected_timestamps = sorted(dt_index, key=int)  # numeric sort
-    expected_timestamps = f"var timestamps = {expected_timestamps};"
+    expected_timestamps = f"let timestamps = {expected_timestamps};"
     expected_timestamps = expected_timestamps.split(";")[0].strip().replace("'", '"')
-    rendered_timestamps = rendered.split(";")[0].strip()
+    rendered_timestamps = rendered.strip(" \n{").split(";")[0].strip()
     assert expected_timestamps == rendered_timestamps
 
     expected_styledict = normalize(json.dumps(styledict, sort_keys=True))


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1744.

Allow multiple instances of `TimeSliderChoropleth` on a single map. 
- I used a code block to limit the scope of the the variables and functions used, except for the `GeoJson` object that will also be added to `LayerControl`.
- Give every CSS id a unique id.
- Show and hide the slider together with the layer.
- Restore the broken `highlight` functionality.