### PR TITLE
#1751 issue: add Filter polyline

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -601,6 +601,9 @@ class GeoJson(Layer):
             {% if this.style %}
                 style: {{ this.get_name() }}_styler,
             {%- endif %}
+            {% if this.tags %}
+                "tags":{{this.tags}},
+            {%- endif %}
             {%- if this.marker %}
                 pointToLayer: {{ this.get_name() }}_pointToLayer
             {%- endif %}
@@ -636,6 +639,7 @@ class GeoJson(Layer):
         popup: Optional["GeoJsonPopup"] = None,
         zoom_on_click: bool = False,
         marker: Union[Circle, CircleMarker, Marker, None] = None,
+        tags: List = None,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "GeoJson"
@@ -647,6 +651,7 @@ class GeoJson(Layer):
         self.style = style_function is not None
         self.highlight = highlight_function is not None
         self.zoom_on_click = zoom_on_click
+        self.tags= tags 
         if marker:
             if not isinstance(marker, (Circle, CircleMarker, Marker)):
                 raise TypeError(

--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -65,5 +65,6 @@ class AntPath(JSCSSMixin, BaseMultiLocation):
                 "opacity": kwargs.pop("opacity", 0.5),
                 "color": kwargs.pop("color", "#0000FF"),
                 "pulseColor": kwargs.pop("pulse_color", "#FFFFFF"),
+                "tags":kwargs.pop("tags",None),
             }
         )

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -186,6 +186,11 @@ class PolyLine(BaseMultiLocation):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "PolyLine"
         self.options = path_options(line=True, **kwargs)
+        self.options.update(
+            {
+                "tags":kwargs.pop("tags",None),
+            }
+        )
 
 
 class Polygon(BaseMultiLocation):


### PR DESCRIPTION
 To filter a PolyLine, you'll need to define what you mean by "filter." Here are a few common methods for filtering Polylines:

Filter by length: You can filter Polylines based on their length. For example, you might want to keep only Polylines that are longer than a certain threshold, or you might want to remove Polylines that are shorter than a certain threshold.

Filter by proximity: You can filter Polylines based on their proximity to other features or locations. For example, you might want to keep only Polylines that are within a certain distance of a particular point or feature.