### PR TITLE
GHA: disable env caching

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -22,7 +22,6 @@ jobs:
           python=${{ matrix.python-version }}
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_code_notebooks.yml
+++ b/.github/workflows/test_code_notebooks.yml
@@ -17,7 +17,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_latest_branca.yml
+++ b/.github/workflows/test_latest_branca.yml
@@ -17,7 +17,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_mypy.yml
+++ b/.github/workflows/test_mypy.yml
@@ -17,7 +17,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_selenium.yml
+++ b/.github/workflows/test_selenium.yml
@@ -17,7 +17,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}

--- a/.github/workflows/test_style_notebooks.yml
+++ b/.github/workflows/test_style_notebooks.yml
@@ -17,7 +17,6 @@ jobs:
           python=3
           --file requirements.txt
           --file requirements-dev.txt
-        cache-environment: true
 
     - name: Install folium from source
       shell: bash -l {0}


### PR DESCRIPTION
Adding environment caching in Github Actions was a mistake, because it doesn't use the content of requirements.txt in its caching key, so updating the requirements won't take effect in the test environment. Disable caching. For more info see https://github.com/mamba-org/setup-micromamba#caching.