### PR TITLE
Make the map pickable natively

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -99,10 +99,6 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
             )
         )
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class Vega(JSCSSMixin, Element):
     """
@@ -169,10 +165,6 @@ class Vega(JSCSSMixin, Element):
         self.top = _parse_size(top)
         self.position = position
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
@@ -292,11 +284,6 @@ class VegaLite(Element):
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
-
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
@@ -694,11 +681,6 @@ class GeoJson(Layer):
         if isinstance(popup, (GeoJsonPopup, Popup)):
             self.add_child(popup)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
     def process_data(self, data: Any) -> dict:
         """Convert an unknown data input into a geojson dictionary."""
         if isinstance(data, dict):
@@ -1009,11 +991,6 @@ class TopoJson(JSCSSMixin, Layer):
         elif tooltip is not None:
             self.add_child(Tooltip(tooltip))
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
     def style_data(self) -> None:
         """Applies self.style_function to each feature of self.data."""
 
@@ -1279,11 +1256,6 @@ class GeoJsonTooltip(GeoJsonDetail):
         kwargs.update({"sticky": sticky, "class_name": class_name})
         self.tooltip_options = {camelize(key): kwargs[key] for key in kwargs.keys()}
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
 
 class GeoJsonPopup(GeoJsonDetail):
     """
@@ -1352,10 +1324,6 @@ class GeoJsonPopup(GeoJsonDetail):
         kwargs.update({"class_name": self.class_name})
         self.popup_options = {camelize(key): value for key, value in kwargs.items()}
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class Choropleth(FeatureGroup):
     """Apply a GeoJSON overlay to the map.
@@ -1720,11 +1688,6 @@ class DivIcon(MacroElement):
             class_name=class_name,
         )
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
 
 class LatLngPopup(MacroElement):
     """
@@ -1752,10 +1715,6 @@ class LatLngPopup(MacroElement):
         super().__init__()
         self._name = "LatLngPopup"
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class ClickForMarker(MacroElement):
     """
@@ -1803,11 +1762,6 @@ class ClickForMarker(MacroElement):
         else:
             self.popup = '"Latitude: " + lat + "<br>Longitude: " + lng '
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
 
 class ClickForLatLng(MacroElement):
     """
@@ -1845,10 +1799,6 @@ class ClickForLatLng(MacroElement):
         self.format_str = format_str or 'lat + "," + lng'
         self.alert = alert
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class CustomIcon(Icon):
     """
@@ -1913,11 +1863,6 @@ class CustomIcon(Icon):
             shadow_anchor=shadow_anchor,
             popup_anchor=popup_anchor,
         )
-
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 
 class ColorLine(FeatureGroup):

--- a/folium/features.py
+++ b/folium/features.py
@@ -62,9 +62,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
     https://humangeo.github.io/leaflet-dvf/
 
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.RegularPolygonMarker(
                 {{ this.location|tojson }},
@@ -72,7 +70,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     default_js = [
         (
@@ -101,6 +99,10 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
             )
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class Vega(JSCSSMixin, Element):
     """
@@ -132,7 +134,8 @@ class Vega(JSCSSMixin, Element):
 
     """
 
-    _template = Template("")
+    _template_str = ""
+    _template = Template(_template_str)
 
     default_js = [
         ("d3", "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"),
@@ -165,6 +168,11 @@ class Vega(JSCSSMixin, Element):
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
@@ -254,8 +262,8 @@ class VegaLite(Element):
         Ex: 'relative', 'absolute'
 
     """
-
-    _template = Template("")
+    _template_str = ""
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -284,6 +292,11 @@ class VegaLite(Element):
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
@@ -522,8 +535,7 @@ class GeoJson(Layer):
 
     """
 
-    _template = Template(
-        """
+    _template_str ="""
         {% macro script(this, kwargs) %}
         {%- if this.style %}
         function {{ this.get_name() }}_styler(feature) {
@@ -623,8 +635,8 @@ class GeoJson(Layer):
         {%- endif %}
 
         {% endmacro %}
-        """
-    )  # noqa
+        """ # noqa
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -681,6 +693,11 @@ class GeoJson(Layer):
             self.add_child(Tooltip(tooltip))
         if isinstance(popup, (GeoJsonPopup, Popup)):
             self.add_child(popup)
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def process_data(self, data: Any) -> dict:
         """Convert an unknown data input into a geojson dictionary."""
@@ -925,8 +942,7 @@ class TopoJson(JSCSSMixin, Layer):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }}_data = {{ this.data|tojson }};
             var {{ this.get_name() }} = L.geoJson(
@@ -945,7 +961,7 @@ class TopoJson(JSCSSMixin, Layer):
             });
         {% endmacro %}
         """
-    )  # noqa
+    _template = Template(_template_str)
 
     default_js = [
         (
@@ -992,6 +1008,11 @@ class TopoJson(JSCSSMixin, Layer):
             self.add_child(tooltip)
         elif tooltip is not None:
             self.add_child(Tooltip(tooltip))
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def style_data(self) -> None:
         """Applies self.style_function to each feature of self.data."""
@@ -1225,15 +1246,15 @@ class GeoJsonTooltip(GeoJsonDetail):
     >>> GeoJsonTooltip(fields=("CNTY_NM",), labels=False, sticky=False)
     """
 
-    _template = Template(
-        """
+    _template_str = "".join(["""
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindTooltip("""
-        + GeoJsonDetail.base_template
-        + """,{{ this.tooltip_options | tojson | safe }});
+    {{ this._parent.get_name() }}.bindTooltip(""",
+        GeoJsonDetail.base_template,
+        """,{{ this.tooltip_options | tojson | safe }});
                      {% endmacro %}
                      """
-    )
+    ])
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -1257,6 +1278,11 @@ class GeoJsonTooltip(GeoJsonDetail):
         self._name = "GeoJsonTooltip"
         kwargs.update({"sticky": sticky, "class_name": class_name})
         self.tooltip_options = {camelize(key): kwargs[key] for key in kwargs.keys()}
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 
 class GeoJsonPopup(GeoJsonDetail):
@@ -1293,15 +1319,16 @@ class GeoJsonPopup(GeoJsonDetail):
                                 ).add_to(gjson)
     """
 
-    _template = Template(
+    _template_str = "".join([
         """
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindPopup("""
-        + GeoJsonDetail.base_template
-        + """,{{ this.popup_options | tojson | safe }});
+    {{ this._parent.get_name() }}.bindPopup(""",
+        GeoJsonDetail.base_template,
+        """,{{ this.popup_options | tojson | safe }});
                      {% endmacro %}
                      """
-    )
+    ])
+    _template_ = Template(_template_str)
 
     def __init__(
         self,
@@ -1325,6 +1352,10 @@ class GeoJsonPopup(GeoJsonDetail):
         kwargs.update({"class_name": self.class_name})
         self.popup_options = {camelize(key): value for key, value in kwargs.items()}
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class Choropleth(FeatureGroup):
     """Apply a GeoJSON overlay to the map.
@@ -1663,14 +1694,13 @@ class DivIcon(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.divIcon({{ this.options|tojson }});
             {{this._parent.get_name()}}.setIcon({{this.get_name()}});
         {% endmacro %}
         """
-    )  # noqa
+    _template_ = Template(_template_str)
 
     def __init__(
         self,
@@ -1690,6 +1720,11 @@ class DivIcon(MacroElement):
             class_name=class_name,
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
+
 
 class LatLngPopup(MacroElement):
     """
@@ -1698,8 +1733,7 @@ class LatLngPopup(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
             {% macro script(this, kwargs) %}
                 var {{this.get_name()}} = L.popup();
                 function latLngPop(e) {
@@ -1712,12 +1746,16 @@ class LatLngPopup(MacroElement):
                 {{this._parent.get_name()}}.on('click', latLngPop);
             {% endmacro %}
             """
-    )  # noqa
+    _template_ = Template(_template_str)
 
     def __init__(self):
         super().__init__()
         self._name = "LatLngPopup"
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class ClickForMarker(MacroElement):
     """
@@ -1739,8 +1777,7 @@ class ClickForMarker(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
             {% macro script(this, kwargs) %}
                 function newMarker(e){
                     var new_mark = L.marker().setLatLng(e.latlng).addTo({{this._parent.get_name()}});
@@ -1753,7 +1790,7 @@ class ClickForMarker(MacroElement):
                 {{this._parent.get_name()}}.on('click', newMarker);
             {% endmacro %}
             """
-    )  # noqa
+    _template = Template(_template_str)
 
     def __init__(self, popup: Union[IFrame, Html, str, None] = None):
         super().__init__()
@@ -1765,6 +1802,11 @@ class ClickForMarker(MacroElement):
             self.popup = "`" + escape_backticks(popup) + "`"
         else:
             self.popup = '"Latitude: " + lat + "<br>Longitude: " + lng '
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 
 class ClickForLatLng(MacroElement):
@@ -1783,8 +1825,7 @@ class ClickForLatLng(MacroElement):
         Whether there should be an alert when something has been copied to clipboard.
     """
 
-    _template = Template(
-        """
+    _template_str = """
             {% macro script(this, kwargs) %}
                 function getLatLng(e){
                     var lat = e.latlng.lat.toFixed(6),
@@ -1796,7 +1837,7 @@ class ClickForLatLng(MacroElement):
                 {{this._parent.get_name()}}.on('click', getLatLng);
             {% endmacro %}
             """
-    )  # noqa
+    _template = Template(_template_str)
 
     def __init__(self, format_str: Optional[str] = None, alert: bool = True):
         super().__init__()
@@ -1804,6 +1845,10 @@ class ClickForLatLng(MacroElement):
         self.format_str = format_str or 'lat + "," + lng'
         self.alert = alert
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class CustomIcon(Icon):
     """
@@ -1839,14 +1884,13 @@ class CustomIcon(Icon):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
         var {{ this.get_name() }} = L.icon({{ this.options|tojson }});
         {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
-    )  # noqa
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -1869,6 +1913,11 @@ class CustomIcon(Icon):
             shadow_anchor=shadow_anchor,
             popup_anchor=popup_anchor,
         )
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 
 class ColorLine(FeatureGroup):

--- a/folium/features.py
+++ b/folium/features.py
@@ -62,7 +62,9 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
     https://humangeo.github.io/leaflet-dvf/
 
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.RegularPolygonMarker(
                 {{ this.location|tojson }},
@@ -70,7 +72,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     default_js = [
         (
@@ -130,8 +132,7 @@ class Vega(JSCSSMixin, Element):
 
     """
 
-    _template_str = ""
-    _template = Template(_template_str)
+    _template = Template("")
 
     default_js = [
         ("d3", "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"),
@@ -164,7 +165,6 @@ class Vega(JSCSSMixin, Element):
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
-
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
@@ -254,8 +254,8 @@ class VegaLite(Element):
         Ex: 'relative', 'absolute'
 
     """
-    _template_str = ""
-    _template = Template(_template_str)
+
+    _template = Template("")
 
     def __init__(
         self,
@@ -522,7 +522,8 @@ class GeoJson(Layer):
 
     """
 
-    _template_str ="""
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
         {%- if this.style %}
         function {{ this.get_name() }}_styler(feature) {
@@ -622,8 +623,8 @@ class GeoJson(Layer):
         {%- endif %}
 
         {% endmacro %}
-        """ # noqa
-    _template = Template(_template_str)
+        """
+    )  # noqa
 
     def __init__(
         self,
@@ -924,7 +925,8 @@ class TopoJson(JSCSSMixin, Layer):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }}_data = {{ this.data|tojson }};
             var {{ this.get_name() }} = L.geoJson(
@@ -943,7 +945,7 @@ class TopoJson(JSCSSMixin, Layer):
             });
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )  # noqa
 
     default_js = [
         (
@@ -1223,15 +1225,15 @@ class GeoJsonTooltip(GeoJsonDetail):
     >>> GeoJsonTooltip(fields=("CNTY_NM",), labels=False, sticky=False)
     """
 
-    _template_str = "".join(["""
+    _template = Template(
+        """
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindTooltip(""",
-        GeoJsonDetail.base_template,
-        """,{{ this.tooltip_options | tojson | safe }});
+    {{ this._parent.get_name() }}.bindTooltip("""
+        + GeoJsonDetail.base_template
+        + """,{{ this.tooltip_options | tojson | safe }});
                      {% endmacro %}
                      """
-    ])
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -1291,16 +1293,15 @@ class GeoJsonPopup(GeoJsonDetail):
                                 ).add_to(gjson)
     """
 
-    _template_str = "".join([
+    _template = Template(
         """
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindPopup(""",
-        GeoJsonDetail.base_template,
-        """,{{ this.popup_options | tojson | safe }});
+    {{ this._parent.get_name() }}.bindPopup("""
+        + GeoJsonDetail.base_template
+        + """,{{ this.popup_options | tojson | safe }});
                      {% endmacro %}
                      """
-    ])
-    _template_ = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -1662,13 +1663,14 @@ class DivIcon(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.divIcon({{ this.options|tojson }});
             {{this._parent.get_name()}}.setIcon({{this.get_name()}});
         {% endmacro %}
         """
-    _template_ = Template(_template_str)
+    )  # noqa
 
     def __init__(
         self,
@@ -1696,7 +1698,8 @@ class LatLngPopup(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
             {% macro script(this, kwargs) %}
                 var {{this.get_name()}} = L.popup();
                 function latLngPop(e) {
@@ -1709,7 +1712,7 @@ class LatLngPopup(MacroElement):
                 {{this._parent.get_name()}}.on('click', latLngPop);
             {% endmacro %}
             """
-    _template_ = Template(_template_str)
+    )  # noqa
 
     def __init__(self):
         super().__init__()
@@ -1736,7 +1739,8 @@ class ClickForMarker(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
             {% macro script(this, kwargs) %}
                 function newMarker(e){
                     var new_mark = L.marker().setLatLng(e.latlng).addTo({{this._parent.get_name()}});
@@ -1749,7 +1753,7 @@ class ClickForMarker(MacroElement):
                 {{this._parent.get_name()}}.on('click', newMarker);
             {% endmacro %}
             """
-    _template = Template(_template_str)
+    )  # noqa
 
     def __init__(self, popup: Union[IFrame, Html, str, None] = None):
         super().__init__()
@@ -1779,7 +1783,8 @@ class ClickForLatLng(MacroElement):
         Whether there should be an alert when something has been copied to clipboard.
     """
 
-    _template_str = """
+    _template = Template(
+        """
             {% macro script(this, kwargs) %}
                 function getLatLng(e){
                     var lat = e.latlng.lat.toFixed(6),
@@ -1791,7 +1796,7 @@ class ClickForLatLng(MacroElement):
                 {{this._parent.get_name()}}.on('click', getLatLng);
             {% endmacro %}
             """
-    _template = Template(_template_str)
+    )  # noqa
 
     def __init__(self, format_str: Optional[str] = None, alert: bool = True):
         super().__init__()
@@ -1834,13 +1839,14 @@ class CustomIcon(Icon):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
         var {{ this.get_name() }} = L.icon({{ this.options|tojson }});
         {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )  # noqa
 
     def __init__(
         self,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -2,6 +2,7 @@
 Make beautiful, interactive maps with Python and Leaflet.js
 
 """
+
 import time
 import webbrowser
 from typing import Any, List, Optional, Sequence, Union
@@ -64,13 +65,14 @@ _default_css = [
 
 
 class GlobalSwitches(Element):
-    _template_str = """
+    _template = Template(
+        """
         <script>
             L_NO_TOUCH = {{ this.no_touch |tojson}};
             L_DISABLE_3D = {{ this.disable_3d|tojson }};
         </script>
     """
-    _template = Template(_template_str)
+    )
 
     def __init__(self, no_touch=False, disable_3d=False):
         super().__init__()
@@ -176,7 +178,8 @@ class Map(JSCSSMixin, MacroElement):
 
     """  # noqa
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro header(this, kwargs) %}
             <meta name="viewport" content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
@@ -224,7 +227,7 @@ class Map(JSCSSMixin, MacroElement):
 
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     # use the module variables for backwards compatibility
     default_js = _default_js
@@ -258,7 +261,6 @@ class Map(JSCSSMixin, MacroElement):
         **kwargs: TypeJsonValue,
     ):
         super().__init__()
-
         self._name = "Map"
         self._env = ENV
 
@@ -299,38 +301,14 @@ class Map(JSCSSMixin, MacroElement):
         self.global_switches = GlobalSwitches(no_touch, disable_3d)
 
         self.objects_to_stay_in_front: List[Layer] = []
-  
-        if len(self._children) > 0: # Add already prepared childrens
-            for key, child in self._children.items(): # add the missing ones (key is a safety)
-                self.add_child(child, name = key) 
-        else: # Initialize the tiles
-            if isinstance(tiles, TileLayer):
-                self.add_child(tiles)
-            elif tiles:
-                tile_layer = TileLayer(
-                    tiles=tiles, attr=attr, min_zoom=min_zoom, max_zoom=max_zoom
-                )
-                self.add_child(tile_layer, name=tile_layer.tile_name)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self.zoom_start = state["options"]["zoom"]
-        self.zoom_control = state["options"]["zoomControl"]
-        self.prefer_canvas = state["options"]["preferCanvas"]
-        max_bounds_array = state["options"].get("maxBounds")
-        if max_bounds_array is None:
-            self.max_bounds = False
-            self.min_lat = -90
-            self.max_lat = 90
-            self.min_lon = -180
-            self.max_lon = 180
-        else: # max_bounds_array = [[min_lat, min_lon], [max_lat, max_lon]]
-            self.max_bounds = True
-            self.min_lat = max_bounds_array[0][0] 
-            self.max_lat = max_bounds_array[1][0]
-            self.min_lon = max_bounds_array[0][1]
-            self.max_lon = max_bounds_array[1][1]
+        if isinstance(tiles, TileLayer):
+            self.add_child(tiles)
+        elif tiles:
+            tile_layer = TileLayer(
+                tiles=tiles, attr=attr, min_zoom=min_zoom, max_zoom=max_zoom
+            )
+            self.add_child(tile_layer, name=tile_layer.tile_name)
 
     def _repr_html_(self, **kwargs) -> str:
         """Displays the HTML Map in a Jupyter notebook."""

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -345,12 +345,17 @@ class Map(JSCSSMixin, MacroElement):
                 self.add_child(child, name = key) 
         else: # Initialize the tiles
             if isinstance(tiles, TileLayer):
-                self.add_child(tiles, index = 0)
+                self.add_child(tiles)
             elif tiles:
                 tile_layer = TileLayer(
-                    tiles=tiles, attr=attr, min_zoom=min_zoom, max_zoom=max_zoom, index = 0
+                    tiles=tiles, attr=attr, min_zoom=min_zoom, max_zoom=max_zoom
                 )
                 self.add_child(tile_layer, name=tile_layer.tile_name)
+
+    def set_parent_for_children(self) -> None:
+        for _, child in self._children.items():
+            child._parent = self
+        return None
 
     def _repr_html_(self, **kwargs) -> str:
         """Displays the HTML Map in a Jupyter notebook."""
@@ -516,7 +521,7 @@ class Map(JSCSSMixin, MacroElement):
         for obj in args:
             self.objects_to_stay_in_front.append(obj)
 
-def map_reduce(map_instance):
+def map_pickler(map_instance):
     return (Map, (
         map_instance.location,
         map_instance.width,
@@ -544,4 +549,4 @@ def map_reduce(map_instance):
         map_instance._children,
     ))
 
-copyreg.pickle(Map, map_reduce)
+copyreg.pickle(Map, map_pickler)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -78,10 +78,6 @@ class GlobalSwitches(Element):
         self.no_touch = no_touch
         self.disable_3d = disable_3d
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class Map(JSCSSMixin, MacroElement):
     """Create a Map with Folium and Leaflet.js
@@ -316,16 +312,6 @@ class Map(JSCSSMixin, MacroElement):
                 )
                 self.add_child(tile_layer, name=tile_layer.tile_name)
 
-    def __getstate__(self):
-        """Modify object state when pickling the object.
-        jinja2 Environment cannot be pickled, so set
-        the ._env attribute to None. This will be added back
-        when unpickling (see __setstate__)
-        """
-        state = super().__getstate__()
-        state["_png_image"] = None
-        return state
-
     def __setstate__(self, state: dict):
         """Re-add ._env attribute when unpickling"""
         super().__setstate__(state)
@@ -345,9 +331,6 @@ class Map(JSCSSMixin, MacroElement):
             self.max_lat = max_bounds_array[1][0]
             self.min_lon = max_bounds_array[0][1]
             self.max_lon = max_bounds_array[1][1]
-
-        self._template = Template(self._template_str)
-
 
     def _repr_html_(self, **kwargs) -> str:
         """Displays the HTML Map in a Jupyter notebook."""

--- a/folium/map.py
+++ b/folium/map.py
@@ -117,10 +117,6 @@ class FeatureGroup(Layer):
         self.tile_name = name if name is not None else self.get_name()
         self.options = parse_options(**kwargs)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class LayerControl(MacroElement):
     """
@@ -199,11 +195,6 @@ class LayerControl(MacroElement):
         self.draggable = draggable
         self.base_layers: OrderedDict[str, str] = OrderedDict()
         self.overlays: OrderedDict[str, str] = OrderedDict()
-
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def reset(self) -> None:
         self.base_layers = OrderedDict()
@@ -312,10 +303,6 @@ class Icon(MacroElement):
             **kwargs,
         )
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class Marker(MacroElement):
     """
@@ -385,11 +372,6 @@ class Marker(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
-
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> List[List[float]]:
         """Computes the bounds of the object itself.
@@ -486,11 +468,6 @@ class Popup(Element):
             **kwargs,
         )
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
         for name, child in self._children.items():
@@ -571,11 +548,6 @@ class Tooltip(MacroElement):
             # noqa outside of type checking.
             self.style = style
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
-
     def parse_options(
         self,
         kwargs: Dict[str, TypeJsonValue],
@@ -642,11 +614,6 @@ class FitBounds(MacroElement):
             padding_bottom_right=padding_bottom_right,
             padding=padding,
         )
-
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
         
 
 class FitOverlays(MacroElement):
@@ -697,10 +664,6 @@ class FitOverlays(MacroElement):
         self.fit_on_map_load = fit_on_map_load
         self.options = parse_options(padding=(padding, padding), max_zoom=max_zoom)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class CustomPane(MacroElement):
     """
@@ -748,8 +711,3 @@ class CustomPane(MacroElement):
         self.name = name
         self.z_index = z_index
         self.pointer_events = pointer_events
-
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)

--- a/folium/map.py
+++ b/folium/map.py
@@ -95,16 +95,14 @@ class FeatureGroup(Layer):
         https://leafletjs.com/reference.html#featuregroup
 
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.featureGroup(
                 {{ this.options|tojson }}
             );
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -119,6 +117,10 @@ class FeatureGroup(Layer):
         self.tile_name = name if name is not None else self.get_name()
         self.options = parse_options(**kwargs)
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class LayerControl(MacroElement):
     """
@@ -153,8 +155,7 @@ class LayerControl(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this,kwargs) %}
             var {{ this.get_name() }}_layers = {
                 base_layers : {
@@ -180,7 +181,7 @@ class LayerControl(MacroElement):
 
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -198,6 +199,11 @@ class LayerControl(MacroElement):
         self.draggable = draggable
         self.base_layers: OrderedDict[str, str] = OrderedDict()
         self.overlays: OrderedDict[str, str] = OrderedDict()
+
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def reset(self) -> None:
         self.base_layers = OrderedDict()
@@ -250,8 +256,7 @@ class Icon(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.AwesomeMarkers.icon(
                 {{ this.options|tojson }}
@@ -259,7 +264,7 @@ class Icon(MacroElement):
             {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
     color_options = {
         "red",
         "darkred",
@@ -307,6 +312,10 @@ class Icon(MacroElement):
             **kwargs,
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class Marker(MacroElement):
     """
@@ -342,8 +351,7 @@ class Marker(MacroElement):
     ... )
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.marker(
                 {{ this.location|tojson }},
@@ -351,7 +359,7 @@ class Marker(MacroElement):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -377,6 +385,11 @@ class Marker(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
+
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> List[List[float]]:
         """Computes the bounds of the object itself.
@@ -413,8 +426,7 @@ class Popup(Element):
         True only loads the Popup content when clicking on the Marker.
     """
 
-    _template = Template(
-        """
+    _template_str = """
         var {{this.get_name()}} = L.popup({{ this.options|tojson }});
 
         {% for name, element in this.html._children.items() %}
@@ -434,8 +446,8 @@ class Popup(Element):
         {% for name, element in this.script._children.items() %}
             {{element.render()}}
         {% endfor %}
-    """
-    )  # noqa
+    """ # noqa 
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -474,6 +486,11 @@ class Popup(Element):
             **kwargs,
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
+
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""
         for name, child in self._children.items():
@@ -509,9 +526,7 @@ class Tooltip(MacroElement):
         available here: https://leafletjs.com/reference.html#tooltip
 
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             {{ this._parent.get_name() }}.bindTooltip(
                 `<div{% if this.style %} style={{ this.style|tojson }}{% endif %}>
@@ -521,7 +536,7 @@ class Tooltip(MacroElement):
             );
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
     valid_options: Dict[str, Tuple[Type, ...]] = {
         "pane": (str,),
         "offset": (tuple,),
@@ -555,6 +570,11 @@ class Tooltip(MacroElement):
             ), "Pass a valid inline HTML style property string to style."
             # noqa outside of type checking.
             self.style = style
+
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def parse_options(
         self,
@@ -595,8 +615,7 @@ class FitBounds(MacroElement):
         Maximum zoom to be used.
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             {{ this._parent.get_name() }}.fitBounds(
                 {{ this.bounds|tojson }},
@@ -604,7 +623,7 @@ class FitBounds(MacroElement):
             );
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -624,6 +643,11 @@ class FitBounds(MacroElement):
             padding=padding,
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
+        
 
 class FitOverlays(MacroElement):
     """Fit the bounds of the maps to the enabled overlays.
@@ -639,9 +663,7 @@ class FitOverlays(MacroElement):
     fit_on_map_load: bool, default True
         Apply the fit when initially loading the map.
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
         function customFlyToBounds() {
             let bounds = L.latLngBounds([]);
@@ -660,8 +682,8 @@ class FitOverlays(MacroElement):
         {%- endif %}
         {% endmacro %}
     """
-    )
-
+    _template = Template(_template_str)
+        
     def __init__(
         self,
         padding: int = 0,
@@ -675,6 +697,10 @@ class FitOverlays(MacroElement):
         self.fit_on_map_load = fit_on_map_load
         self.options = parse_options(padding=(padding, padding), max_zoom=max_zoom)
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class CustomPane(MacroElement):
     """
@@ -699,9 +725,7 @@ class CustomPane(MacroElement):
         cursor. Setting to False will prevent interfering with
         pointer events associated with lower layers.
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = {{ this._parent.get_name() }}.createPane(
                 {{ this.name|tojson }});
@@ -710,9 +734,9 @@ class CustomPane(MacroElement):
                 {{ this.get_name() }}.style.pointerEvents = 'none';
             {% endif %}
         {% endmacro %}
-        """
-    )
-
+        """ 
+    _template = Template(_template_str)
+        
     def __init__(
         self,
         name: str,
@@ -724,3 +748,8 @@ class CustomPane(MacroElement):
         self.name = name
         self.z_index = z_index
         self.pointer_events = pointer_events
+
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)

--- a/folium/map.py
+++ b/folium/map.py
@@ -95,14 +95,16 @@ class FeatureGroup(Layer):
         https://leafletjs.com/reference.html#featuregroup
 
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.featureGroup(
                 {{ this.options|tojson }}
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -151,7 +153,8 @@ class LayerControl(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this,kwargs) %}
             var {{ this.get_name() }}_layers = {
                 base_layers : {
@@ -177,7 +180,7 @@ class LayerControl(MacroElement):
 
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -247,7 +250,8 @@ class Icon(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.AwesomeMarkers.icon(
                 {{ this.options|tojson }}
@@ -255,7 +259,7 @@ class Icon(MacroElement):
             {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
     color_options = {
         "red",
         "darkred",
@@ -338,7 +342,8 @@ class Marker(MacroElement):
     ... )
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.marker(
                 {{ this.location|tojson }},
@@ -346,7 +351,7 @@ class Marker(MacroElement):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -408,7 +413,8 @@ class Popup(Element):
         True only loads the Popup content when clicking on the Marker.
     """
 
-    _template_str = """
+    _template = Template(
+        """
         var {{this.get_name()}} = L.popup({{ this.options|tojson }});
 
         {% for name, element in this.html._children.items() %}
@@ -428,8 +434,8 @@ class Popup(Element):
         {% for name, element in this.script._children.items() %}
             {{element.render()}}
         {% endfor %}
-    """ # noqa 
-    _template = Template(_template_str)
+    """
+    )  # noqa
 
     def __init__(
         self,
@@ -503,7 +509,9 @@ class Tooltip(MacroElement):
         available here: https://leafletjs.com/reference.html#tooltip
 
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             {{ this._parent.get_name() }}.bindTooltip(
                 `<div{% if this.style %} style={{ this.style|tojson }}{% endif %}>
@@ -513,7 +521,7 @@ class Tooltip(MacroElement):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
     valid_options: Dict[str, Tuple[Type, ...]] = {
         "pane": (str,),
         "offset": (tuple,),
@@ -587,7 +595,8 @@ class FitBounds(MacroElement):
         Maximum zoom to be used.
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             {{ this._parent.get_name() }}.fitBounds(
                 {{ this.bounds|tojson }},
@@ -595,7 +604,7 @@ class FitBounds(MacroElement):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -614,7 +623,7 @@ class FitBounds(MacroElement):
             padding_bottom_right=padding_bottom_right,
             padding=padding,
         )
-        
+
 
 class FitOverlays(MacroElement):
     """Fit the bounds of the maps to the enabled overlays.
@@ -630,7 +639,9 @@ class FitOverlays(MacroElement):
     fit_on_map_load: bool, default True
         Apply the fit when initially loading the map.
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
         function customFlyToBounds() {
             let bounds = L.latLngBounds([]);
@@ -649,8 +660,8 @@ class FitOverlays(MacroElement):
         {%- endif %}
         {% endmacro %}
     """
-    _template = Template(_template_str)
-        
+    )
+
     def __init__(
         self,
         padding: int = 0,
@@ -688,7 +699,9 @@ class CustomPane(MacroElement):
         cursor. Setting to False will prevent interfering with
         pointer events associated with lower layers.
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = {{ this._parent.get_name() }}.createPane(
                 {{ this.name|tojson }});
@@ -697,9 +710,9 @@ class CustomPane(MacroElement):
                 {{ this.get_name() }}.style.pointerEvents = 'none';
             {% endif %}
         {% endmacro %}
-        """ 
-    _template = Template(_template_str)
-        
+        """
+    )
+
     def __init__(
         self,
         name: str,

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -158,10 +158,6 @@ class TileLayer(Layer):
             **kwargs
         )
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class WmsTileLayer(Layer):
     """
@@ -241,10 +237,6 @@ class WmsTileLayer(Layer):
             # special parameter that shouldn't be camelized
             self.options["cql_filter"] = cql_filter
 
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class ImageOverlay(Layer):
     """
@@ -329,11 +321,6 @@ class ImageOverlay(Layer):
             )
 
         self.url = image_to_url(image, origin=origin, colormap=colormap)
-
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         super().render()
@@ -425,11 +412,6 @@ class VideoOverlay(Layer):
 
         self.bounds = bounds
         self.options = parse_options(autoplay=autoplay, loop=loop, **kwargs)
-
-    def __setstate__(self, state: dict):
-        """Re-add ._template attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> TypeBounds:
         """

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -78,7 +78,8 @@ class TileLayer(Layer):
         object.
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.tileLayer(
                 {{ this.tiles|tojson }},
@@ -86,7 +87,7 @@ class TileLayer(Layer):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -196,7 +197,8 @@ class WmsTileLayer(Layer):
     See https://leafletjs.com/reference.html#tilelayer-wms
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.tileLayer.wms(
                 {{ this.url|tojson }},
@@ -204,8 +206,8 @@ class WmsTileLayer(Layer):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
-    
+    )  # noqa
+
     def __init__(
         self,
         url: str,
@@ -285,7 +287,8 @@ class ImageOverlay(Layer):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.imageOverlay(
                 {{ this.url|tojson }},
@@ -294,8 +297,8 @@ class ImageOverlay(Layer):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
-    
+    )
+
     def __init__(
         self,
         image: Any,
@@ -383,7 +386,8 @@ class VideoOverlay(Layer):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.videoOverlay(
                 {{ this.video_url|tojson }},
@@ -392,8 +396,8 @@ class VideoOverlay(Layer):
             );
         {% endmacro %}
         """
-    _template = Template(_template_str)
-    
+    )
+
     def __init__(
         self,
         video_url: str,

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -78,8 +78,7 @@ class TileLayer(Layer):
         object.
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.tileLayer(
                 {{ this.tiles|tojson }},
@@ -87,7 +86,7 @@ class TileLayer(Layer):
             );
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -159,6 +158,10 @@ class TileLayer(Layer):
             **kwargs
         )
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class WmsTileLayer(Layer):
     """
@@ -197,8 +200,7 @@ class WmsTileLayer(Layer):
     See https://leafletjs.com/reference.html#tilelayer-wms
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.tileLayer.wms(
                 {{ this.url|tojson }},
@@ -206,8 +208,8 @@ class WmsTileLayer(Layer):
             );
         {% endmacro %}
         """
-    )  # noqa
-
+    _template = Template(_template_str)
+    
     def __init__(
         self,
         url: str,
@@ -239,6 +241,10 @@ class WmsTileLayer(Layer):
             # special parameter that shouldn't be camelized
             self.options["cql_filter"] = cql_filter
 
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class ImageOverlay(Layer):
     """
@@ -287,8 +293,7 @@ class ImageOverlay(Layer):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.imageOverlay(
                 {{ this.url|tojson }},
@@ -297,8 +302,8 @@ class ImageOverlay(Layer):
             );
         {% endmacro %}
         """
-    )
-
+    _template = Template(_template_str)
+    
     def __init__(
         self,
         image: Any,
@@ -324,6 +329,11 @@ class ImageOverlay(Layer):
             )
 
         self.url = image_to_url(image, origin=origin, colormap=colormap)
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def render(self, **kwargs) -> None:
         super().render()
@@ -386,8 +396,7 @@ class VideoOverlay(Layer):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.videoOverlay(
                 {{ this.video_url|tojson }},
@@ -396,8 +405,8 @@ class VideoOverlay(Layer):
             );
         {% endmacro %}
         """
-    )
-
+    _template = Template(_template_str)
+    
     def __init__(
         self,
         video_url: str,
@@ -416,6 +425,11 @@ class VideoOverlay(Layer):
 
         self.bounds = bounds
         self.options = parse_options(autoplay=autoplay, loop=loop, **kwargs)
+
+    def __setstate__(self, state: dict):
+        """Re-add ._template attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> TypeBounds:
         """

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -188,10 +188,6 @@ class PolyLine(BaseMultiLocation):
         self._name = "PolyLine"
         self.options = path_options(line=True, **kwargs)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class Polygon(BaseMultiLocation):
     """Draw polygon overlays on a map.
@@ -236,10 +232,6 @@ class Polygon(BaseMultiLocation):
         self._name = "Polygon"
         self.options = path_options(line=True, radius=None, **kwargs)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
         
 class Rectangle(MacroElement):
     """Draw rectangle overlays on a map.
@@ -288,11 +280,6 @@ class Rectangle(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
-            
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""
@@ -347,10 +334,6 @@ class Circle(Marker):
         self._name = "circle"
         self.options = path_options(line=False, radius=radius, **kwargs)
 
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)
 
 class CircleMarker(Marker):
     """
@@ -394,8 +377,3 @@ class CircleMarker(Marker):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "CircleMarker"
         self.options = path_options(line=False, radius=radius, **kwargs)
-
-    def __setstate__(self, state: dict):
-        """Re-add ._env attribute when unpickling"""
-        super().__setstate__(state)
-        self._template = Template(self._template_str)

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -173,7 +173,9 @@ class PolyLine(BaseMultiLocation):
         https://leafletjs.com/reference.html#polyline
 
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.polyline(
                 {{ this.locations|tojson }},
@@ -181,7 +183,7 @@ class PolyLine(BaseMultiLocation):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super().__init__(locations, popup=popup, tooltip=tooltip)
@@ -210,8 +212,9 @@ class Polygon(BaseMultiLocation):
         https://leafletjs.com/reference.html#polygon
 
     """
-    
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.polygon(
                 {{ this.locations|tojson }},
@@ -219,7 +222,7 @@ class Polygon(BaseMultiLocation):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -232,7 +235,7 @@ class Polygon(BaseMultiLocation):
         self._name = "Polygon"
         self.options = path_options(line=True, radius=None, **kwargs)
 
-        
+
 class Rectangle(MacroElement):
     """Draw rectangle overlays on a map.
 
@@ -252,7 +255,8 @@ class Rectangle(MacroElement):
 
     """
 
-    _template_str = """
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{this.get_name()}} = L.rectangle(
                 {{ this.locations|tojson }},
@@ -260,7 +264,7 @@ class Rectangle(MacroElement):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,
@@ -310,7 +314,8 @@ class Circle(Marker):
         https://leafletjs.com/reference.html#circle
 
     """
-    _template_str = (
+
+    _template = Template(
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.circle(
@@ -320,7 +325,6 @@ class Circle(Marker):
         {% endmacro %}
         """
     )
-    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -356,7 +360,9 @@ class CircleMarker(Marker):
         https://leafletjs.com/reference.html#circlemarker
 
     """
-    _template_str = """
+
+    _template = Template(
+        """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.circleMarker(
                 {{ this.location|tojson }},
@@ -364,7 +370,7 @@ class CircleMarker(Marker):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    _template = Template(_template_str)
+    )
 
     def __init__(
         self,

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -173,9 +173,7 @@ class PolyLine(BaseMultiLocation):
         https://leafletjs.com/reference.html#polyline
 
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.polyline(
                 {{ this.locations|tojson }},
@@ -183,13 +181,17 @@ class PolyLine(BaseMultiLocation):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(self, locations, popup=None, tooltip=None, **kwargs):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "PolyLine"
         self.options = path_options(line=True, **kwargs)
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class Polygon(BaseMultiLocation):
     """Draw polygon overlays on a map.
@@ -212,9 +214,8 @@ class Polygon(BaseMultiLocation):
         https://leafletjs.com/reference.html#polygon
 
     """
-
-    _template = Template(
-        """
+    
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.polygon(
                 {{ this.locations|tojson }},
@@ -222,7 +223,7 @@ class Polygon(BaseMultiLocation):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -235,7 +236,11 @@ class Polygon(BaseMultiLocation):
         self._name = "Polygon"
         self.options = path_options(line=True, radius=None, **kwargs)
 
-
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
+        
 class Rectangle(MacroElement):
     """Draw rectangle overlays on a map.
 
@@ -255,8 +260,7 @@ class Rectangle(MacroElement):
 
     """
 
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{this.get_name()}} = L.rectangle(
                 {{ this.locations|tojson }},
@@ -264,7 +268,7 @@ class Rectangle(MacroElement):
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -284,6 +288,11 @@ class Rectangle(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
+            
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""
@@ -314,8 +323,7 @@ class Circle(Marker):
         https://leafletjs.com/reference.html#circle
 
     """
-
-    _template = Template(
+    _template_str = (
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.circle(
@@ -325,6 +333,7 @@ class Circle(Marker):
         {% endmacro %}
         """
     )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -338,6 +347,10 @@ class Circle(Marker):
         self._name = "circle"
         self.options = path_options(line=False, radius=radius, **kwargs)
 
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)
 
 class CircleMarker(Marker):
     """
@@ -360,9 +373,7 @@ class CircleMarker(Marker):
         https://leafletjs.com/reference.html#circlemarker
 
     """
-
-    _template = Template(
-        """
+    _template_str = """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.circleMarker(
                 {{ this.location|tojson }},
@@ -370,7 +381,7 @@ class CircleMarker(Marker):
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
-    )
+    _template = Template(_template_str)
 
     def __init__(
         self,
@@ -383,3 +394,8 @@ class CircleMarker(Marker):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "CircleMarker"
         self.options = path_options(line=False, radius=radius, **kwargs)
+
+    def __setstate__(self, state: dict):
+        """Re-add ._env attribute when unpickling"""
+        super().__setstate__(state)
+        self._template = Template(self._template_str)


### PR DESCRIPTION
This PR needs a modification in branca (https://github.com/python-visualization/branca/pull/142).
For the sake of testing in the WIP version, i repeated the modification here.

For now, the Map can be pickled and unpickled, but it is not rendered properly when I try to cope with children. If I use :

`  
with open(f"{folder}/map_w_children_pickle.pkl",'rb') as f:  
    map_unpickled = pickle.load(f)  
`  

I need to add :

`
for key in map_unpickled._children.keys():  
    map_unpickled._children[key]._parent = map_unpickled 
`

So everything is fine.
For some reason, adding these lines to the end of the __init__() does not work. 

Linked issue : https://github.com/python-visualization/folium/issues/1813