### PR TITLE
Remove _env instance attributes

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -262,7 +262,6 @@ class Map(JSCSSMixin, MacroElement):
     ):
         super().__init__()
         self._name = "Map"
-        self._env = ENV
 
         self._png_image: Optional[bytes] = None
         self.png_enabled = png_enabled

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -22,7 +22,6 @@ from folium.utilities import (
     validate_location,
 )
 
-
 _default_js = [
     ("leaflet", "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"),
     ("jquery", "https://code.jquery.com/jquery-1.12.4.min.js"),

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -22,8 +22,6 @@ from folium.utilities import (
     validate_location,
 )
 
-ENV = Environment(loader=PackageLoader("folium", "templates"))
-
 
 _default_js = [
     ("leaflet", "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"),

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -8,7 +8,7 @@ import webbrowser
 from typing import Any, List, Optional, Sequence, Union
 
 from branca.element import Element, Figure, MacroElement
-from jinja2 import Environment, PackageLoader, Template
+from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import FitBounds, Layer

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -122,7 +122,6 @@ class TileLayer(Layer):
             name=self.tile_name, overlay=overlay, control=control, show=show
         )
         self._name = "TileLayer"
-        self._env = ENV
 
         tiles_flat = "".join(tiles.lower().strip().split())
         if tiles_flat in {"cloudmade", "mapbox", "mapboxbright", "mapboxcontrolroom"}:
@@ -133,14 +132,14 @@ class TileLayer(Layer):
                 "argument. See the documentation of the `TileLayer` class."
             )
         templates = list(
-            self._env.list_templates(filter_func=lambda x: x.startswith("tiles/"))
+            ENV.list_templates(filter_func=lambda x: x.startswith("tiles/"))
         )
         tile_template = "tiles/" + tiles_flat + "/tiles.txt"
         attr_template = "tiles/" + tiles_flat + "/attr.txt"
 
         if tile_template in templates and attr_template in templates:
-            self.tiles = self._env.get_template(tile_template).render()
-            attr = self._env.get_template(attr_template).render()
+            self.tiles = ENV.get_template(tile_template).render()
+            attr = ENV.get_template(attr_template).render()
         else:
             self.tiles = tiles
             if not attr:

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -19,6 +19,7 @@ from jinja2.utils import htmlsafe_json_dumps
 import folium
 from folium import TileLayer
 from folium.features import Choropleth, GeoJson
+from folium.folium import ENV
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
@@ -120,8 +121,8 @@ class TestFolium:
             tiles = "".join(tiles.lower().strip().split())
             url = "tiles/{}/tiles.txt".format
             attr = "tiles/{}/attr.txt".format
-            url = m._env.get_template(url(tiles)).render()
-            attr = m._env.get_template(attr(tiles)).render()
+            url = ENV.get_template(url(tiles)).render()
+            attr = ENV.get_template(attr(tiles)).render()
 
             assert m._children[tiles].tiles == url
             assert htmlsafe_json_dumps(attr) in m._parent.render()

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -19,7 +19,7 @@ from jinja2.utils import htmlsafe_json_dumps
 import folium
 from folium import TileLayer
 from folium.features import Choropleth, GeoJson
-from folium.folium import ENV
+from folium.raster_layers import ENV
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
See comment on https://github.com/python-visualization/folium/issues/1813#issuecomment-1761750279.

Storing the Jinja2 Environment on class instances doesn't make sense to me. It doesn't bring any benefit. It takes up space in our code and in the class instances. And we have to explicitly remove it when pickling objects.

Remove the `_env` class instance attributes from Folium. Use the `ENV` module variable instead.

When we stop using the tile layer templates, we can get rid of this fully. But this PR already removes `ENV` from the `folium` module.

We can do the same on Branca.