### PR TITLE
Bump jquery from 2.0.0 to 3.7.1

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -137,7 +137,7 @@ class Vega(JSCSSMixin, Element):
     default_js = [
         ("d3", "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"),
         ("vega", "https://cdnjs.cloudflare.com/ajax/libs/vega/1.4.3/vega.min.js"),
-        ("jquery", "https://code.jquery.com/jquery-2.1.0.min.js"),
+        ("jquery", "https://code.jquery.com/jquery-3.7.1.min.js"),
     ]
 
     def __init__(

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -24,7 +24,7 @@ from folium.utilities import (
 
 _default_js = [
     ("leaflet", "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"),
-    ("jquery", "https://code.jquery.com/jquery-1.12.4.min.js"),
+    ("jquery", "https://code.jquery.com/jquery-3.7.1.min.js"),
     (
         "bootstrap",
         "https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js",

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -146,8 +146,8 @@ class TimestampedGeoJson(JSCSSMixin, MacroElement):
 
     default_js = [
         (
-            "jquery2.0.0",
-            "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js",
+            "jquery3.7.1",
+            "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js",
         ),
         (
             "jqueryui1.10.2",

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -91,8 +91,8 @@ class TimestampedWmsTileLayers(JSCSSMixin, MacroElement):
 
     default_js = [
         (
-            "jquery2.0.0",
-            "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js",
+            "jquery3.7.1",
+            "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js",
         ),
         (
             "jqueryui1.10.2",

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -102,7 +102,7 @@ def test_timestamped_geo_json():
 
     # Verify the imports.
     assert (
-        '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>'
+        '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>'
         in out
     )
     assert (


### PR DESCRIPTION
This PR fixes https://github.com/python-visualization/folium/issues/1787 and is inspired by https://github.com/python-visualization/folium/pull/1793/files previous one.

I have tested the following and all seems to work on my side : 
- [x]  Popup
- [x]  TimeSliderChoropleth
- [x]  GeoJson with a url as data
- [x]  Map.keep_in_front()
- [x]  TimestampedGeoJson
- [x]  TimestampedWmsTileLayers

No change has been needed apart from the version change. 