### PR TITLE
use xyzservices instead of templates

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -82,15 +82,14 @@ class Map(JSCSSMixin, MacroElement):
     """Create a Map with Folium and Leaflet.js
 
     Generate a base map of given width and height with either default
-    tilesets or a custom tileset URL. The following tilesets are built-in
-    to Folium. Pass any of the following to the "tiles" keyword:
+    tilesets or a custom tileset URL. Folium has built-in all tilesets
+    available in the ``xyzservices`` package. For example, you can pass
+    any of the following to the "tiles" keyword:
 
         - "OpenStreetMap"
-        - "Mapbox Bright" (Limited levels of zoom for free tiles)
-        - "Mapbox Control Room" (Limited levels of zoom for free tiles)
-        - "Cloudmade" (Must pass API key)
-        - "Mapbox" (Must pass API key)
-        - "CartoDB" (positron and dark_matter)
+        - "CartoDB Positron"
+        - "CartoBD Voyager"
+        - "NASAGIBS Blue Marble"
 
     You can pass a custom tileset to Folium by passing a
     :class:`xyzservices.TileProvider` or a Leaflet-style

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Optional, Union
 
 import xyzservices
 from branca.element import Element, Figure
-from jinja2 import Environment, PackageLoader, Template
+from jinja2 import Template
 
 from folium.map import Layer
 from folium.utilities import (
@@ -16,8 +16,6 @@ from folium.utilities import (
     mercator_transform,
     parse_options,
 )
-
-ENV = Environment(loader=PackageLoader("folium", "templates"))
 
 
 class TileLayer(Layer):

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -128,8 +128,12 @@ class TileLayer(Layer):
                 name = tiles.name.replace(".", "").lower()
             tiles = tiles.build_url(fill_subdomain=False, scale_factor="{r}")  # type: ignore
 
-        self.tile_name = name if name is not None else "".join(tiles.lower().strip().split())
-        super().__init__(name=self.tile_name, overlay=overlay, control=control, show=show)
+        self.tile_name = (
+            name if name is not None else "".join(tiles.lower().strip().split())
+        )
+        super().__init__(
+            name=self.tile_name, overlay=overlay, control=control, show=show
+        )
         self._name = "TileLayer"
 
         self.tiles = tiles
@@ -146,7 +150,7 @@ class TileLayer(Layer):
             detect_retina=detect_retina,
             tms=tms,
             opacity=opacity,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -211,7 +215,7 @@ class WmsTileLayer(Layer):
         overlay: bool = True,
         control: bool = True,
         show: bool = True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self.url = url
@@ -223,7 +227,7 @@ class WmsTileLayer(Layer):
             transparent=transparent,
             version=version,
             attribution=attr,
-            **kwargs
+            **kwargs,
         )
         if cql_filter:
             # special parameter that shouldn't be camelized
@@ -301,7 +305,7 @@ class ImageOverlay(Layer):
         overlay: bool = True,
         control: bool = True,
         show: bool = True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "ImageOverlay"
@@ -398,7 +402,7 @@ class VideoOverlay(Layer):
         overlay: bool = True,
         control: bool = True,
         show: bool = True,
-        **kwargs: TypeJsonValue
+        **kwargs: TypeJsonValue,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "VideoOverlay"

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -109,7 +109,7 @@ class TileLayer(Layer):
         **kwargs,
     ):
         if isinstance(tiles, str):
-            if tiles == "OpenStreetMap":
+            if tiles.lower() == "openstreetmap":
                 tiles = "OpenStreetMap Mapnik"
                 if name is None:
                     name = "openstreetmap"

--- a/folium/templates/tiles/cartodbdark_matter/attr.txt
+++ b/folium/templates/tiles/cartodbdark_matter/attr.txt
@@ -1,1 +1,0 @@
-&copy; <a target="_blank" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a target="_blank" href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a target="_blank" href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cartodbdark_matter/tiles.txt
+++ b/folium/templates/tiles/cartodbdark_matter/tiles.txt
@@ -1,1 +1,0 @@
-https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png

--- a/folium/templates/tiles/cartodbpositron/attr.txt
+++ b/folium/templates/tiles/cartodbpositron/attr.txt
@@ -1,1 +1,0 @@
-&copy; <a target="_blank" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a target="_blank" href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a target="_blank" href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cartodbpositron/tiles.txt
+++ b/folium/templates/tiles/cartodbpositron/tiles.txt
@@ -1,1 +1,0 @@
-https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png

--- a/folium/templates/tiles/cartodbpositronnolabels/attr.txt
+++ b/folium/templates/tiles/cartodbpositronnolabels/attr.txt
@@ -1,1 +1,0 @@
-(c) <a target="_blank" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors (c) <a target="_blank" href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a target="_blank" href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cartodbpositronnolabels/tiles.txt
+++ b/folium/templates/tiles/cartodbpositronnolabels/tiles.txt
@@ -1,1 +1,0 @@
-https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png

--- a/folium/templates/tiles/cartodbpositrononlylabels/attr.txt
+++ b/folium/templates/tiles/cartodbpositrononlylabels/attr.txt
@@ -1,1 +1,0 @@
-(c) <a target="_blank" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors (c) <a target="_blank" href="http://cartodb.com/attributions">CartoDB</a>, CartoDB <a target="_blank" href ="http://cartodb.com/attributions">attributions</a>

--- a/folium/templates/tiles/cartodbpositrononlylabels/tiles.txt
+++ b/folium/templates/tiles/cartodbpositrononlylabels/tiles.txt
@@ -1,1 +1,0 @@
-https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png

--- a/folium/templates/tiles/openstreetmap/attr.txt
+++ b/folium/templates/tiles/openstreetmap/attr.txt
@@ -1,1 +1,0 @@
-Data by &copy; <a target="_blank" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_blank" href="http://www.openstreetmap.org/copyright">ODbL</a>.

--- a/folium/templates/tiles/openstreetmap/tiles.txt
+++ b/folium/templates/tiles/openstreetmap/tiles.txt
@@ -1,1 +1,0 @@
-https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,4 +36,3 @@ types-requests
 vega_datasets
 vincent
 wheel
-xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ branca>=0.6.0
 jinja2>=2.9
 numpy
 requests
+xyzservices

--- a/tests/plugins/test_minimap.py
+++ b/tests/plugins/test_minimap.py
@@ -25,4 +25,4 @@ def test_minimap():
 
     out = normalize(m._parent.render())
     # verify that tiles are being used
-    assert r"https://{s}.tile.openstreetmap.org" in out
+    assert r"https://tile.openstreetmap.org" in out

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -13,6 +13,7 @@ import jinja2
 import numpy as np
 import pandas as pd
 import pytest
+import xyzservices.providers as xyz
 from jinja2 import Environment, PackageLoader
 from jinja2.utils import htmlsafe_json_dumps
 
@@ -106,24 +107,17 @@ class TestFolium:
             },
         }
 
-    def test_builtin_tile(self):
+    @pytest.mark.parametrize("tiles,provider", [("OpenStreetMap", xyz.OpenStreetMap.Mapnik), ("CartoDB positron", xyz.CartoDB.Positron), ("CartoDB dark_matter", xyz.CartoDB.DarkMatter)])
+    def test_builtin_tile(self, tiles, provider):
         """Test custom maptiles."""
 
-        default_tiles = [
-            "OpenStreetMap",
-            "CartoDB positron",
-            "CartoDB dark_matter",
-        ]
-        for tiles in default_tiles:
-            m = folium.Map(location=[45.5236, -122.6750], tiles=tiles)
-            tiles = "".join(tiles.lower().strip().split())
-            url = "tiles/{}/tiles.txt".format
-            attr = "tiles/{}/attr.txt".format
-            url = ENV.get_template(url(tiles)).render()
-            attr = ENV.get_template(attr(tiles)).render()
+        m = folium.Map(location=[45.5236, -122.6750], tiles=tiles)
+        tiles = "".join(tiles.lower().strip().split())
+        url = provider.build_url(fill_subdomain=False, scale_factor="{r}")
+        attr = provider.html_attribution
 
-            assert m._children[tiles].tiles == url
-            assert htmlsafe_json_dumps(attr) in m._parent.render()
+        assert m._children[tiles.replace("_", "")].tiles == url
+        assert htmlsafe_json_dumps(attr) in m._parent.render()
 
         bounds = m.get_bounds()
         assert bounds == [[None, None], [None, None]], bounds

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -20,7 +20,6 @@ from jinja2.utils import htmlsafe_json_dumps
 import folium
 from folium import TileLayer
 from folium.features import Choropleth, GeoJson
-from folium.raster_layers import ENV
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
@@ -107,7 +106,14 @@ class TestFolium:
             },
         }
 
-    @pytest.mark.parametrize("tiles,provider", [("OpenStreetMap", xyz.OpenStreetMap.Mapnik), ("CartoDB positron", xyz.CartoDB.Positron), ("CartoDB dark_matter", xyz.CartoDB.DarkMatter)])
+    @pytest.mark.parametrize(
+        "tiles,provider",
+        [
+            ("OpenStreetMap", xyz.OpenStreetMap.Mapnik),
+            ("CartoDB positron", xyz.CartoDB.Positron),
+            ("CartoDB dark_matter", xyz.CartoDB.DarkMatter),
+        ],
+    )
     def test_builtin_tile(self, tiles, provider):
         """Test custom maptiles."""
 

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -3,8 +3,8 @@ Test raster_layers
 ------------------
 
 """
-import xyzservices
 import pytest
+import xyzservices
 from jinja2 import Template
 
 import folium
@@ -113,11 +113,12 @@ def test_image_overlay():
     bounds = m.get_bounds()
     assert bounds == [[0, -180], [90, 180]], bounds
 
-@pytest.mark.parametrize("tiles", ["CartoDB DarkMatter", xyzservices.providers.CartoDB.DarkMatter])
+
+@pytest.mark.parametrize(
+    "tiles", ["CartoDB DarkMatter", xyzservices.providers.CartoDB.DarkMatter]
+)
 def test_xyzservices(tiles):
-    m = folium.Map(
-        [48.0, 5.0], tiles=tiles, zoom_start=6
-    )
+    m = folium.Map([48.0, 5.0], tiles=tiles, zoom_start=6)
 
     folium.raster_layers.TileLayer(
         tiles=xyzservices.providers.CartoDB.Positron,

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -4,6 +4,7 @@ Test raster_layers
 
 """
 import xyzservices
+import pytest
 from jinja2 import Template
 
 import folium
@@ -112,10 +113,10 @@ def test_image_overlay():
     bounds = m.get_bounds()
     assert bounds == [[0, -180], [90, 180]], bounds
 
-
-def test_xyzservices():
+@pytest.mark.parametrize("tiles", ["CartoDB DarkMatter", xyzservices.providers.CartoDB.DarkMatter])
+def test_xyzservices(tiles):
     m = folium.Map(
-        [48.0, 5.0], tiles=xyzservices.providers.CartoDB.DarkMatter, zoom_start=6
+        [48.0, 5.0], tiles=tiles, zoom_start=6
     )
 
     folium.raster_layers.TileLayer(


### PR DESCRIPTION
This removes built-in tile management with the template files and adds `xyzservices` as a hard dependency that now manages all tiles. It is fully backwards compatible with all the benefits of a large library in `xyzservices` and flexibility of `query_name`, allowing custom characters and cases in the input. E.g. all of these will work

```py
"CartoDB Positron"
"cartodbpositron"
"cartodb-positron"
"carto db/positron"
"CARTO_DB_POSITRON"
"CartoDB.Positron"
```

