### PR TITLE
GeoJson bind popup/tooltip per feature

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1230,9 +1230,11 @@ class GeoJsonTooltip(GeoJsonDetail):
     _template = Template(
         """
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindTooltip("""
+    {{ this._parent.get_name() }}.eachLayer(function(layer) {
+        layer.bindTooltip("""
         + GeoJsonDetail.base_template
         + """,{{ this.tooltip_options | tojson | safe }});
+    });
                      {% endmacro %}
                      """
     )
@@ -1298,9 +1300,11 @@ class GeoJsonPopup(GeoJsonDetail):
     _template = Template(
         """
     {% macro script(this, kwargs) %}
-    {{ this._parent.get_name() }}.bindPopup("""
+    {{ this._parent.get_name() }}.eachLayer(function(layer) {
+        layer.bindPopup("""
         + GeoJsonDetail.base_template
         + """,{{ this.popup_options | tojson | safe }});
+    });
                      {% endmacro %}
                      """
     )


### PR DESCRIPTION
Change that's useful for https://github.com/python-visualization/folium/pull/1836.

When binding GeoJsonPopup/GeoJsonTooltip to the GeoJson, we currently do that to the full object. Which then 'distributes' the bindings to the underlying layers. See https://leafletjs.com/reference.html#featuregroup.

Instead, we want to bind the popup/tooltip to each underlying layer directly. That way we can check whether the popup of each layer is open or not.

I checked the example in our documentation and it functions correctly. Here's also a short snippet to test it with:

```
import folium
import geopandas
import requests


m = folium.Map(location=[35.3, -97.6], zoom_start=4)

data = requests.get(
    "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/us_states.json"
).json()
states = geopandas.GeoDataFrame.from_features(data, crs="EPSG:4326")

popup = folium.GeoJsonPopup(fields=["name"])
tooltip = folium.GeoJsonTooltip(fields=["name"])

folium.GeoJson(
    states,
    highlight_function=lambda x: {
        "fillOpacity": 0.4,
    },
    popup=popup,
    tooltip=tooltip,
).add_to(m)

m.show_in_browser()
```