### PR TITLE
Add leaflet-realtime plugin

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -31,6 +31,12 @@ Other map features
 .. automodule:: folium.features
 
 
+Utilities
+---------------------
+
+.. autoclass:: folium.utilities.JsCode
+
+
 Plugins
 --------------------
 .. automodule:: folium.plugins

--- a/docs/user_guide/plugins.rst
+++ b/docs/user_guide/plugins.rst
@@ -23,6 +23,7 @@ Plugins
   plugins/pattern
   plugins/polyline_offset
   plugins/polyline_textpath_and_antpath
+  plugins/realtime
   plugins/scroll_zoom_toggler
   plugins/search
   plugins/semi_circle

--- a/docs/user_guide/plugins/realtime.md
+++ b/docs/user_guide/plugins/realtime.md
@@ -24,15 +24,19 @@ source :
   * a dict that is passed to javascript's `fetch` function
     for fetching the data
   * a folium.utilities.JsCode object in case you need more freedom.
+
 start : bool, default True
   Should automatic updates be enabled when layer is added
   on the map and stopped when layer is removed from the map
+
 interval : int, default 60000
   Automatic update interval, in milliseconds
+
 get_feature_id : folium.utilities.JsCode
   A function with a geojson `feature` as parameter
   default returns `feature.properties.id`
   Function to get an identifier uniquely identify a feature over time
+
 update_feature : folium.utilities.JsCode
   A function with a geojson `feature` as parameter
   Used to update an existing feature's layer;
@@ -40,6 +44,7 @@ update_feature : folium.utilities.JsCode
   and replaced with a new, updated layer.
   Allows to create more complex transitions,
   for example, when a feature is updated
+
 remove_missing : bool, default False
   Should missing features between updates been automatically
           removed from the layer

--- a/docs/user_guide/plugins/realtime.md
+++ b/docs/user_guide/plugins/realtime.md
@@ -23,7 +23,7 @@ In this example we use a static geojson, whereas normally you would have a
 url that actually updates in real time.
 
 ```{code-cell} ipython3
-from folium.utilities import JsCode
+from folium import JsCode
 m = folium.Map(location=[40.73, -73.94], zoom_start=12)
 rt = folium.plugins.Realtime(
     "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson",
@@ -44,12 +44,11 @@ International Space Station using a public API.
 
 ```{code-cell} ipython3
 import folium
-from folium.utilities import JsCode
 from folium.plugins import Realtime
 
 m = folium.Map()
 
-source = JsCode("""
+source = folium.JsCode("""
     function(responseHandler, errorHandler) {
         var url = 'https://api.wheretheiss.at/v1/satellites/25544';
 
@@ -94,7 +93,7 @@ means that you can also pass parameters which you would typically pass to an
 
 ```{code-cell} ipython3
 import folium
-from folium.utilities import JsCode
+from folium import JsCode
 from folium.plugins import Realtime
 
 m = folium.Map(location=[40.73, -73.94], zoom_start=12)

--- a/docs/user_guide/plugins/realtime.md
+++ b/docs/user_guide/plugins/realtime.md
@@ -17,6 +17,10 @@ This plugin functions much like an `L.GeoJson` layer, for
 which the geojson data is periodically polled from a url.
 
 
+## Simple example
+
+In this example we use a static geojson, whereas normally you would have a
+url that actually updates in real time.
 
 ```{code-cell} ipython3
 from folium.utilities import JsCode
@@ -30,9 +34,12 @@ rt.add_to(m)
 m
 ```
 
+
+## Javascript function as source
+
 For more complicated scenarios, such as when the underlying data source does not return geojson, you can
 write a javascript function for the `source` parameter. In this example we track the location of the
-International Space Station.
+International Space Station using a public API.
 
 
 ```{code-cell} ipython3
@@ -43,39 +50,42 @@ from folium.plugins import Realtime
 m = folium.Map()
 
 source = JsCode("""
-function(responseHandler, errorHandler) {
-    var url = 'https://api.wheretheiss.at/v1/satellites/25544';
+    function(responseHandler, errorHandler) {
+        var url = 'https://api.wheretheiss.at/v1/satellites/25544';
 
-    fetch(url)
-    .then((response) => {
-        return response.json().then((data) => {
-            var { id, longitude, latitude } = data;
+        fetch(url)
+        .then((response) => {
+            return response.json().then((data) => {
+                var { id, longitude, latitude } = data;
 
-            return {
-                'type': 'FeatureCollection',
-                'features': [{
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'Point',
-                        'coordinates': [longitude, latitude]
-                    },
-                    'properties': {
-                        'id': id
-                    }
-                }]
-            };
+                return {
+                    'type': 'FeatureCollection',
+                    'features': [{
+                        'type': 'Feature',
+                        'geometry': {
+                            'type': 'Point',
+                            'coordinates': [longitude, latitude]
+                        },
+                        'properties': {
+                            'id': id
+                        }
+                    }]
+                };
+            })
         })
-    })
-    .then(responseHandler)
-    .catch(errorHandler);
-}
+        .then(responseHandler)
+        .catch(errorHandler);
+    }
 """)
 
-rt = Realtime(source,
-              interval=10000)
+rt = Realtime(source, interval=10000)
 rt.add_to(m)
+
 m
 ```
+
+
+## Customizing the layer
 
 The leaflet-realtime plugin typically uses an `L.GeoJson` layer to show the data. This
 means that you can also pass parameters which you would typically pass to an
@@ -90,10 +100,12 @@ from folium.plugins import Realtime
 m = folium.Map(location=[40.73, -73.94], zoom_start=12)
 source = "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson"
 
-rt = Realtime(source,
-              get_feature_id=JsCode("(f) => { return f.properties.objectid }"),
-              point_to_layer=JsCode("(f, latlng) => { return L.circleMarker(latlng, {radius: 8, fillOpacity: 0.2})}"),
-              interval=10000)
-rt.add_to(m)
+Realtime(
+    source,
+    get_feature_id=JsCode("(f) => { return f.properties.objectid }"),
+    point_to_layer=JsCode("(f, latlng) => { return L.circleMarker(latlng, {radius: 8, fillOpacity: 0.2})}"),
+    interval=10000,
+).add_to(m)
+
 m
 ```

--- a/docs/user_guide/plugins/realtime.md
+++ b/docs/user_guide/plugins/realtime.md
@@ -1,0 +1,129 @@
+```{code-cell} ipython3
+---
+nbsphinx: hidden
+---
+import folium
+import folium.plugins
+```
+
+# Realtime plugin
+
+Put realtime data on a Leaflet map: live tracking GPS units,
+sensor data or just about anything.
+
+Based on: https://github.com/perliedman/leaflet-realtime
+
+This plugin functions much like an `L.GeoJson` layer, for
+which the geojson data is periodically polled from a url.
+
+Parameters
+----------
+source :
+  The source can be one of:
+  * a string with the URL to get data from
+  * a dict that is passed to javascript's `fetch` function
+    for fetching the data
+  * a folium.utilities.JsCode object in case you need more freedom.
+start : bool, default True
+  Should automatic updates be enabled when layer is added
+  on the map and stopped when layer is removed from the map
+interval : int, default 60000
+  Automatic update interval, in milliseconds
+get_feature_id : folium.utilities.JsCode
+  A function with a geojson `feature` as parameter
+  default returns `feature.properties.id`
+  Function to get an identifier uniquely identify a feature over time
+update_feature : folium.utilities.JsCode
+  A function with a geojson `feature` as parameter
+  Used to update an existing feature's layer;
+  by default, points (markers) are updated, other layers are discarded
+  and replaced with a new, updated layer.
+  Allows to create more complex transitions,
+  for example, when a feature is updated
+remove_missing : bool, default False
+  Should missing features between updates been automatically
+          removed from the layer
+
+Other parameters are passed to the `L.GeoJson` object, so you can pass
+      `style`, `point_to_layer` and/or `on_each_feature`.
+
+
+```{code-cell} ipython3
+from folium.utilities import JsCode
+m = folium.Map(location=[40.73, -73.94], zoom_start=12)
+rt = folium.plugins.Realtime(
+    "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson",
+    get_feature_id=JsCode("(f) => { return f.properties.objectid; }"),
+    interval=10000,
+)
+rt.add_to(m)
+m
+```
+
+For more complicated scenarios, such as when the underlying data source does not return geojson, you can
+write a javascript function for the `source` parameter. In this example we track the location of the
+International Space Station.
+
+
+```{code-cell} ipython3
+import folium
+from folium.utilities import JsCode
+from folium.plugins import Realtime
+
+m = folium.Map()
+
+source = JsCode("""
+function(responseHandler, errorHandler) {
+    var url = 'https://api.wheretheiss.at/v1/satellites/25544';
+
+    fetch(url)
+    .then((response) => {
+        return response.json().then((data) => {
+            var { id, longitude, latitude } = data;
+
+            return {
+                'type': 'FeatureCollection',
+                'features': [{
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [longitude, latitude]
+                    },
+                    'properties': {
+                        'id': id
+                    }
+                }]
+            };
+        })
+    })
+    .then(responseHandler)
+    .catch(errorHandler);
+}
+""")
+
+rt = Realtime(source,
+              interval=10000)
+rt.add_to(m)
+m
+```
+
+The leaflet-realtime plugin typically uses an `L.GeoJson` layer to show the data. This
+means that you can also pass parameters which you would typically pass to an
+`L.GeoJson` layer. With this knowledge we can change the first example to display
+`L.CircleMarker` objects.
+
+```{code-cell} ipython3
+import folium
+from folium.utilities import JsCode
+from folium.plugins import Realtime
+
+m = folium.Map(location=[40.73, -73.94], zoom_start=12)
+source = "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson"
+
+rt = Realtime(source,
+              get_feature_id=JsCode("(f) => { return f.properties.objectid }"),
+              point_to_layer=JsCode("(f, latlng) => { return L.circleMarker(latlng, {radius: 8, fillOpacity: 0.2})}"),
+              interval=10000)
+rt.add_to(m)
+m
+```

--- a/docs/user_guide/plugins/realtime.md
+++ b/docs/user_guide/plugins/realtime.md
@@ -16,41 +16,6 @@ Based on: https://github.com/perliedman/leaflet-realtime
 This plugin functions much like an `L.GeoJson` layer, for
 which the geojson data is periodically polled from a url.
 
-Parameters
-----------
-source :
-  The source can be one of:
-  * a string with the URL to get data from
-  * a dict that is passed to javascript's `fetch` function
-    for fetching the data
-  * a folium.utilities.JsCode object in case you need more freedom.
-
-start : bool, default True
-  Should automatic updates be enabled when layer is added
-  on the map and stopped when layer is removed from the map
-
-interval : int, default 60000
-  Automatic update interval, in milliseconds
-
-get_feature_id : folium.utilities.JsCode
-  A function with a geojson `feature` as parameter
-  default returns `feature.properties.id`
-  Function to get an identifier uniquely identify a feature over time
-
-update_feature : folium.utilities.JsCode
-  A function with a geojson `feature` as parameter
-  Used to update an existing feature's layer;
-  by default, points (markers) are updated, other layers are discarded
-  and replaced with a new, updated layer.
-  Allows to create more complex transitions,
-  for example, when a feature is updated
-
-remove_missing : bool, default False
-  Should missing features between updates been automatically
-          removed from the layer
-
-Other parameters are passed to the `L.GeoJson` object, so you can pass
-      `style`, `point_to_layer` and/or `on_each_feature`.
 
 
 ```{code-cell} ipython3

--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -40,6 +40,7 @@ from folium.map import (
     Tooltip,
 )
 from folium.raster_layers import TileLayer, WmsTileLayer
+from folium.utilities import JsCode
 from folium.vector_layers import Circle, CircleMarker, Polygon, PolyLine, Rectangle
 
 try:
@@ -79,6 +80,7 @@ __all__ = [
     "IFrame",
     "Icon",
     "JavascriptLink",
+    "JsCode",
     "LatLngPopup",
     "LayerControl",
     "LinearColormap",

--- a/folium/plugins/__init__.py
+++ b/folium/plugins/__init__.py
@@ -21,6 +21,7 @@ from folium.plugins.mouse_position import MousePosition
 from folium.plugins.pattern import CirclePattern, StripePattern
 from folium.plugins.polyline_offset import PolyLineOffset
 from folium.plugins.polyline_text_path import PolyLineTextPath
+from folium.plugins.realtime import Realtime
 from folium.plugins.scroll_zoom_toggler import ScrollZoomToggler
 from folium.plugins.search import Search
 from folium.plugins.semicircle import SemiCircle
@@ -54,6 +55,7 @@ __all__ = [
     "MousePosition",
     "PolyLineTextPath",
     "PolyLineOffset",
+    "Realtime",
     "ScrollZoomToggler",
     "Search",
     "SemiCircle",

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -82,7 +82,7 @@ class Realtime(JSCSSMixin, MacroElement):
     default_js = [
         (
             "Leaflet_Realtime_js",
-            "https://cdnjs.cloudflare.com/ajax/libs/leaflet-realtime/2.2.0/leaflet-realtime.js",  # NoQA
+            "https://cdnjs.cloudflare.com/ajax/libs/leaflet-realtime/2.2.0/leaflet-realtime.js",
         )
     ]
 

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,0 +1,88 @@
+from branca.element import MacroElement
+from jinja2 import Template
+
+from folium.elements import JSCSSMixin
+from folium.utilities import parse_options, JsCode
+
+
+class Realtime(JSCSSMixin, MacroElement):
+    """Put realtime data on a Leaflet map: live tracking GPS units,
+    sensor data or just about anything.
+
+    Based on: https://github.com/perliedman/leaflet-realtime
+
+    Parameters
+    ----------
+    start : bool, default True
+        Should automatic updates be enabled when layer is added
+        on the map and stopped when layer is removed from the map
+    interval : int, default 60000
+        Automatic update interval, in milliseconds
+    getFeatureId : function, default returns `feature.properties.id`
+        Function to get an identifier uniquely identify a feature over time
+    updateFeature : function
+        Used to update an existing feature's layer;
+        by default, points (markers) are updated, other layers are discarded
+        and replaced with a new, updated layer.
+        Allows to create more complex transitions,
+        for example, when a feature is updated
+    removeMissing : bool, default False
+        Should missing features between updates been automatically
+        removed from the layer
+
+    Other parameters are passed to the GeoJson layer, so you can pass
+        `style`, `pointToLayer` and/or `onEachFeature`.
+
+    Examples
+    --------
+    >>> from folium.utilities import JsCode
+    >>> m = folium.Map()
+    >>> rt = Realtime("https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_geography_regions_elevation_points.geojson",
+    ...                getFeatureId=JsCode("function(f) { return f.properties.name; }"),
+    ...                interval=10000)
+    >>> rt.add_to(m)
+    """
+
+    _template = Template(
+        """
+        {% macro script(this, kwargs) %}
+            var options = {{this.options|tojson}};
+            {% for key, value in this.functions.items() %}
+            options["{{key}}"] = {{ value }};
+            {% endfor %}
+            var {{ this.get_name() }} = new L.realtime(
+                {{ this.src|tojson }},
+                options
+            );
+            {{ this._parent.get_name() }}.addLayer(
+                {{ this.get_name() }}._container);
+        {% endmacro %}
+    """
+    )
+
+    default_js = [
+        (
+            "Leaflet_Realtime_js",
+            "https://cdnjs.cloudflare.com/ajax/libs/leaflet-realtime/2.2.0/leaflet-realtime.js",  # NoQA
+        )
+    ]
+
+    def __init__(self, src, **kwargs):
+        super().__init__()
+        self._name = "Realtime"
+        self.src = src
+
+        # extract JsCode objects
+        self.functions = {}
+        for key, value in kwargs.items():
+            if isinstance(value, JsCode):
+                self.functions[key] = value.js_code
+
+        # and remove them from kwargs
+        for key in self.functions:
+            kwargs.pop(key)
+
+        # the container is special, as we
+        # do not allow it to be set (yet)
+        # from python
+        self.options = parse_options(container=None, **kwargs)

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -2,7 +2,7 @@ from branca.element import MacroElement
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options, JsCode
+from folium.utilities import JsCode, parse_options
 
 
 class Realtime(JSCSSMixin, MacroElement):
@@ -37,9 +37,11 @@ class Realtime(JSCSSMixin, MacroElement):
     --------
     >>> from folium.utilities import JsCode
     >>> m = folium.Map()
-    >>> rt = Realtime("https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_geography_regions_elevation_points.geojson",
-    ...                getFeatureId=JsCode("function(f) { return f.properties.name; }"),
-    ...                interval=10000)
+    >>> rt = Realtime(
+    ...     "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_geography_regions_elevation_points.geojson",
+    ...     getFeatureId=JsCode("function(f) { return f.properties.name; }"),
+    ...     interval=10000,
+    ... )
     >>> rt.add_to(m)
     """
 

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -21,7 +21,7 @@ class Realtime(JSCSSMixin, MacroElement):
         * a string with the URL to get data from
         * a dict that is passed to javascript's `fetch` function
           for fetching the data
-        * a `folium.utilities.JsCode` object in case you need more freedom.
+        * a `folium.JsCode` object in case you need more freedom.
     start: bool, default True
         Should automatic updates be enabled when layer is added
         on the map and stopped when layer is removed from the map
@@ -48,7 +48,7 @@ class Realtime(JSCSSMixin, MacroElement):
 
     Examples
     --------
-    >>> from folium.utilities import JsCode
+    >>> from folium import JsCode
     >>> m = folium.Map(location=[40.73, -73.94], zoom_start=12)
     >>> rt = Realtime(
     ...     "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson",

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 from branca.element import MacroElement
 from jinja2 import Template
 
@@ -13,34 +15,36 @@ class Realtime(JSCSSMixin, MacroElement):
 
     Parameters
     ----------
-    source :
+    source: str, dict, JsCode
         The source can be one of:
+
         * a string with the URL to get data from
         * a dict that is passed to javascript's `fetch` function
           for fetching the data
-        * a folium.utilities.JsCode object in case you need more freedom.
-    start : bool, default True
+        * a `folium.utilities.JsCode` object in case you need more freedom.
+    start: bool, default True
         Should automatic updates be enabled when layer is added
         on the map and stopped when layer is removed from the map
-    interval : int, default 60000
+    interval: int, default 60000
         Automatic update interval, in milliseconds
-    get_feature_id : folium.utilities.JsCode
-        A function with a geojson `feature` as parameter
+    get_feature_id: JsCode, optional
+        A JS function with a geojson `feature` as parameter
         default returns `feature.properties.id`
-        Function to get an identifier uniquely identify a feature over time
-    update_feature : folium.utilities.JsCode
-        A function with a geojson `feature` as parameter
+        Function to get an identifier to uniquely identify a feature over time
+    update_feature: JsCode, optional
+        A JS function with a geojson `feature` as parameter
         Used to update an existing feature's layer;
         by default, points (markers) are updated, other layers are discarded
         and replaced with a new, updated layer.
         Allows to create more complex transitions,
         for example, when a feature is updated
-    remove_missing : bool, default False
+    remove_missing: bool, default False
         Should missing features between updates been automatically
         removed from the layer
 
-    Other parameters are passed to the GeoJson layer, so you can pass
-        `style`, `point_to_layer` and/or `on_each_feature`.
+
+    Other keyword arguments are passed to the GeoJson layer, so you can pass
+    `style`, `point_to_layer` and/or `on_each_feature`.
 
     Examples
     --------
@@ -88,28 +92,25 @@ class Realtime(JSCSSMixin, MacroElement):
 
     def __init__(
         self,
-        source,
-        start=None,
-        interval=None,
-        get_feature_id=None,
-        update_feature=None,
-        remove_missing=None,
+        source: Union[str, dict, JsCode],
+        start: bool = True,
+        interval: int = 60000,
+        get_feature_id: Optional[JsCode] = None,
+        update_feature: Optional[JsCode] = None,
+        remove_missing: bool = False,
         **kwargs
     ):
         super().__init__()
         self._name = "Realtime"
         self.src = source
 
-        if start is not None:
-            kwargs["start"] = start
-        if interval is not None:
-            kwargs["interval"] = interval
+        kwargs["start"] = start
+        kwargs["interval"] = interval
         if get_feature_id is not None:
             kwargs["get_feature_id"] = get_feature_id
         if update_feature is not None:
             kwargs["update_feature"] = update_feature
-        if remove_missing is not None:
-            kwargs["remove_missing"] = remove_missing
+        kwargs["remove_missing"] = remove_missing
 
         # extract JsCode objects
         self.functions = {}

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -60,9 +60,9 @@ class Realtime(JSCSSMixin, MacroElement):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-            var options = {{this.options|tojson}};
+            var {{ this.get_name() }}_options = {{ this.options|tojson }};
             {% for key, value in this.functions.items() %}
-            options["{{key}}"] = {{ value }};
+            {{ this.get_name() }}_options["{{key}}"] = {{ value }};
             {% endfor %}
 
             var {{ this.get_name() }} = new L.realtime(
@@ -71,7 +71,7 @@ class Realtime(JSCSSMixin, MacroElement):
             {% else -%}
                 {{ this.src.js_code }},
             {% endif -%}
-                options
+                {{ this.get_name() }}_options
             );
             {{ this._parent.get_name() }}.addLayer(
                 {{ this.get_name() }}._container);

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -412,13 +412,8 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
     return figure
 
 
-# See:
-# https://github.com/andfanilo/streamlit-echarts/blob/master/streamlit_echarts/frontend/src/utils.js
-# Thanks andfanilo
 class JsCode:
+    """Wrapper around Javascript code."""
+
     def __init__(self, js_code: str):
-        """Wrapper around a js function
-        Args:
-            js_code (str): javascript function code as str
-        """
         self.js_code = js_code

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -410,3 +410,15 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
         figure, Figure
     ), "You cannot render this Element if it is not in a Figure."
     return figure
+
+
+# See:
+# https://github.com/andfanilo/streamlit-echarts/blob/master/streamlit_echarts/frontend/src/utils.js
+# Thanks andfanilo
+class JsCode:
+    def __init__(self, js_code: str):
+        """Wrapper around a js function
+        Args:
+            js_code (str): javascript function code as str
+        """
+        self.js_code = js_code


### PR DESCRIPTION
Based on: https://github.com/perliedman/leaflet-realtime

A current limitation of folium is that it is not possible to perform dynamic updates to an existing map (see e.g. #848, #1581, #1233). A way to overcome that limitation is to use the leaflet-realtime plugin. This plugin allows polling for a url that provides geojson data. 

I saw several suggestions in the past to implement this plugin in folium (see #735 and #127), so I decided to give it a go.

I did not test the full plugin functionality yet; just the basic `url` lookup of a static geojson datasource.  Most notably, the `container` parameter is not implemented. I am unsure what the best way would be to implement this. Should it refer to a folium object or should it refer to a javascript object?

If there is any interest in this plugin, I can add more tests and implement the `container` parameter. 

I also added a `JsCode` utility wrapper around strings. The idea was stolen from several streamlit plugins, that use a similar class to pass javascript functions from python to javascript. I mainly used it because I was too lazy to implement all the function parameters from `L.realtime` and `L.geojson` in the template. 
