### PR TITLE
Geocoder plugin: support other built-in providers

### DIFF
--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -1,10 +1,10 @@
+from typing import Optional
+
 from branca.element import MacroElement
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
-
-from typing import Optional
 
 
 class Geocoder(JSCSSMixin, MacroElement):

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -19,6 +19,8 @@ class Geocoder(JSCSSMixin, MacroElement):
         Choose from 'topleft', 'topright', 'bottomleft' or 'bottomright'.
     add_marker: bool, default True
         If True, adds a marker on the found location.
+    geocode_zoom: int, default 11
+        Set zoom level used for displaying the geocode result, note that this only has an effect when add_marker is set to False. Set this to None to preserve the current map zoom level.
     geocode_provider: str, default 'nominatim'
         Defaults to "nominatim", see https://github.com/perliedman/leaflet-control-geocoder/tree/2.4.0/src/geocoders for other built-in providers.
     geocode_provider_options: dict, default {}
@@ -45,7 +47,8 @@ class Geocoder(JSCSSMixin, MacroElement):
             L.Control.geocoder(
                 geocoderOpts_{{ this.get_name() }}
             ).on('markgeocode', function(e) {
-                {{ this._parent.get_name() }}.setView(e.geocode.center, 11);
+                var zoom = geocoderOpts_{{ this.get_name() }}['geocodeZoom'] || {{ this._parent.get_name() }}.getZoom();
+                {{ this._parent.get_name() }}.setView(e.geocode.center, zoom);
             }).addTo({{ this._parent.get_name() }});
 
         {% endmacro %}
@@ -70,6 +73,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         collapsed: bool = False,
         position: str = "topright",
         add_marker: bool = True,
+        geocode_zoom: int | None = 11,
         geocode_provider: str = "nominatim",
         geocode_provider_options: dict = {},
         **kwargs
@@ -80,6 +84,7 @@ class Geocoder(JSCSSMixin, MacroElement):
             collapsed=collapsed,
             position=position,
             default_mark_geocode=add_marker,
+            geocode_zoom=geocode_zoom,
             geocode_provider=geocode_provider,
             geocode_provider_options=geocode_provider_options,
             **kwargs

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -4,6 +4,8 @@ from jinja2 import Template
 from folium.elements import JSCSSMixin
 from folium.utilities import parse_options
 
+from typing import Optional
+
 
 class Geocoder(JSCSSMixin, MacroElement):
     """A simple geocoder for Leaflet that by default uses OSM/Nominatim.
@@ -19,7 +21,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         Choose from 'topleft', 'topright', 'bottomleft' or 'bottomright'.
     add_marker: bool, default True
         If True, adds a marker on the found location.
-    geocode_zoom: int, default 11
+    geocode_zoom: int, default 11, optional
         Set zoom level used for displaying the geocode result, note that this only has an effect when add_marker is set to False. Set this to None to preserve the current map zoom level.
     geocode_provider: str, default 'nominatim'
         Defaults to "nominatim", see https://github.com/perliedman/leaflet-control-geocoder/tree/2.4.0/src/geocoders for other built-in providers.
@@ -73,7 +75,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         collapsed: bool = False,
         position: str = "topright",
         add_marker: bool = True,
-        geocode_zoom: int | None = 11,
+        geocode_zoom: Optional[int] = 11,
         geocode_provider: str = "nominatim",
         geocode_provider_options: dict = {},
         **kwargs

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -21,11 +21,11 @@ class Geocoder(JSCSSMixin, MacroElement):
         Choose from 'topleft', 'topright', 'bottomleft' or 'bottomright'.
     add_marker: bool, default True
         If True, adds a marker on the found location.
-    geocode_zoom: int, default 11, optional
+    zoom: int, default 11, optional
         Set zoom level used for displaying the geocode result, note that this only has an effect when add_marker is set to False. Set this to None to preserve the current map zoom level.
-    geocode_provider: str, default 'nominatim'
+    provider: str, default 'nominatim'
         Defaults to "nominatim", see https://github.com/perliedman/leaflet-control-geocoder/tree/2.4.0/src/geocoders for other built-in providers.
-    geocode_provider_options: dict, default {}
+    provider_options: dict, default {}
         For use with specific providers that may require api keys or other parameters.
 
     For all options see https://github.com/perliedman/leaflet-control-geocoder
@@ -39,17 +39,17 @@ class Geocoder(JSCSSMixin, MacroElement):
             var geocoderOpts_{{ this.get_name() }} = {{ this.options|tojson }};
 
             // note: geocoder name should start with lowercase
-            var geocoderName_{{ this.get_name() }} = geocoderOpts_{{ this.get_name() }}["geocodeProvider"];
+            var geocoderName_{{ this.get_name() }} = geocoderOpts_{{ this.get_name() }}["provider"];
 
             var customGeocoder_{{ this.get_name() }} = L.Control.Geocoder[ geocoderName_{{ this.get_name() }} ](
-                geocoderOpts_{{ this.get_name() }}['geocodeProviderOptions']
+                geocoderOpts_{{ this.get_name() }}['providerOptions']
             );
             geocoderOpts_{{ this.get_name() }}["geocoder"] = customGeocoder_{{ this.get_name() }};
 
             L.Control.geocoder(
                 geocoderOpts_{{ this.get_name() }}
             ).on('markgeocode', function(e) {
-                var zoom = geocoderOpts_{{ this.get_name() }}['geocodeZoom'] || {{ this._parent.get_name() }}.getZoom();
+                var zoom = geocoderOpts_{{ this.get_name() }}['zoom'] || {{ this._parent.get_name() }}.getZoom();
                 {{ this._parent.get_name() }}.setView(e.geocode.center, zoom);
             }).addTo({{ this._parent.get_name() }});
 
@@ -75,9 +75,9 @@ class Geocoder(JSCSSMixin, MacroElement):
         collapsed: bool = False,
         position: str = "topright",
         add_marker: bool = True,
-        geocode_zoom: Optional[int] = 11,
-        geocode_provider: str = "nominatim",
-        geocode_provider_options: dict = {},
+        zoom: Optional[int] = 11,
+        provider: str = "nominatim",
+        provider_options: dict = {},
         **kwargs
     ):
         super().__init__()
@@ -86,8 +86,8 @@ class Geocoder(JSCSSMixin, MacroElement):
             collapsed=collapsed,
             position=position,
             default_mark_geocode=add_marker,
-            geocode_zoom=geocode_zoom,
-            geocode_provider=geocode_provider,
-            geocode_provider_options=geocode_provider_options,
+            zoom=zoom,
+            provider=provider,
+            provider_options=provider_options,
             **kwargs
         )


### PR DESCRIPTION
tested with Nominatim, Photon, Google:
```Python
from branca.element import MacroElement
from jinja2 import Template

from folium.elements import JSCSSMixin
from folium.utilities import parse_options

import folium

class EnhancedGeocoder(JSCSSMixin, MacroElement):
    """A simple geocoder for Leaflet that by default uses OSM/Nominatim.

    Please respect the Nominatim usage policy:
    https://operations.osmfoundation.org/policies/nominatim/
    Parameters
    ----------
    collapsed: bool, default False
        If True, collapses the search box unless hovered/clicked.
    position: str, default 'topright'
        Choose from 'topleft', 'topright', 'bottomleft' or 'bottomright'.
    add_marker: bool, default True
        If True, adds a marker on the found location.
    geocode_zoom: int, default 11
        Set zoom level used for displaying the geocode result, note that this only has an effect when add_marker is set to False. Set this to None to preserve the current map zoom level.
    geocode_provider: str, default 'nominatim'
        Defaults to "nominatim", see https://github.com/perliedman/leaflet-control-geocoder/tree/2.4.0/src/geocoders for other built-in providers.
    geocode_provider_options: dict, default {}
        For use with specific providers that may require api keys or other parameters.

    For all options see https://github.com/perliedman/leaflet-control-geocoder

    """

    _template = Template(
        """
        {% macro script(this, kwargs) %}

            var geocoderOpts_{{ this.get_name() }} = {{ this.options|tojson }};

            // note: geocoder name should start with lowercase
            var geocoderName_{{ this.get_name() }} = geocoderOpts_{{ this.get_name() }}["geocodeProvider"];

            var customGeocoder_{{ this.get_name() }} = L.Control.Geocoder[ geocoderName_{{ this.get_name() }} ](
                geocoderOpts_{{ this.get_name() }}['geocodeProviderOptions']
            );
            geocoderOpts_{{ this.get_name() }}["geocoder"] = customGeocoder_{{ this.get_name() }};

            L.Control.geocoder(
                geocoderOpts_{{ this.get_name() }}
            ).on('markgeocode', function(e) {
                var zoom = geocoderOpts_{{ this.get_name() }}['geocodeZoom'] || {{ this._parent.get_name() }}.getZoom();
                {{ this._parent.get_name() }}.setView(e.geocode.center, zoom);
            }).addTo({{ this._parent.get_name() }});

        {% endmacro %}
    """
    )

    default_js = [
        (
            "Control.Geocoder.js",
            "https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js",
        )
    ]
    default_css = [
        (
            "Control.Geocoder.css",
            "https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css",
        )
    ]

    def __init__(
        self,
        collapsed: bool = False,
        position: str = "topright",
        add_marker: bool = True,
        geocode_zoom: int | None = 11,
        geocode_provider: str = "nominatim",
        geocode_provider_options: dict = {},
        **kwargs
    ):
        super().__init__()
        self._name = "Geocoder"
        self.options = parse_options(
            collapsed=collapsed,
            position=position,
            default_mark_geocode=add_marker,
            geocode_zoom=geocode_zoom,
            geocode_provider=geocode_provider,
            geocode_provider_options=geocode_provider_options,
            **kwargs
        )

google_key = "placeholder"
gc2_default = EnhancedGeocoder() # nominatim
#gc2_photon = EnhancedGeocoder(geocode_provider="photon")
#gc2_google = EnhancedGeocoder(geocode_provider="google",
#                           geocode_provider_options={"apiKey": google_key})


m2 = folium.Map(location=[43.7798, 11.24148], zoom_start=13, tiles="cartodb positron")

gc2_default.add_to(m2)
#gc2_photon.add_to(m2)
#gc2_google.add_to(m2)

folium.LayerControl().add_to(m2)
m2
```