### PR TITLE
 GeoJson: documentation for popup_keep_highlighted argument 

### DIFF
--- a/docs/user_guide/geojson/geojson.md
+++ b/docs/user_guide/geojson/geojson.md
@@ -257,3 +257,27 @@ folium.GeoJson(
 
 m
 ```
+
+#### Keep highlighted while popup is open
+
+The `GeoJson` class provides a `popup_keep_highlighted` boolean argument. \
+Whenever a GeoJson layer is associated with a popup and a highlight function is defined, this argument allows you to decide if the highlighting should remain active while the popup is open.
+
+```{code-cell} ipython3
+m = folium.Map([43, -100], zoom_start=4)
+
+popup = folium.GeoJsonPopup(fields=["name"])
+
+folium.GeoJson(
+    geo_json_data,
+    highlight_function=lambda feature: {
+        "fillColor": (
+            "green" if "e" in feature["properties"]["name"].lower() else "#ffff00"
+        ),
+    },
+    popup=popup,
+    popup_keep_highlighted=True,
+).add_to(m)
+
+m
+```

--- a/docs/user_guide/geojson/geojson.md
+++ b/docs/user_guide/geojson/geojson.md
@@ -260,8 +260,10 @@ m
 
 #### Keep highlighted while popup is open
 
-The `GeoJson` class provides a `popup_keep_highlighted` boolean argument. \
-Whenever a GeoJson layer is associated with a popup and a highlight function is defined, this argument allows you to decide if the highlighting should remain active while the popup is open.
+The `GeoJson` class provides a `popup_keep_highlighted` boolean argument.
+Whenever a GeoJson layer is associated with a popup and a highlight function
+is defined, this argument allows you to decide if the highlighting should remain
+active while the popup is open.
 
 ```{code-cell} ipython3
 m = folium.Map([43, -100], zoom_start=4)


### PR DESCRIPTION
Related to #1836 
I added a small description along with an example, as a small section in the **Highlight function** paragraph.
I had some problems with building the documentation on my own.
However, I tested the example on my own and it is working correctly, so I believe there shouldn't be any problem.
Beware that, as I'm writing this, the popup_keep_highlighted feature has not yet been officially released.