### PR TITLE
Process JS code separately [draft]

### DIFF
--- a/docs/user_guide/plugins/mouse_position.md
+++ b/docs/user_guide/plugins/mouse_position.md
@@ -20,7 +20,7 @@ m
 ```{code-cell} ipython3
 m = folium.Map()
 
-formatter = "function(num) {return L.Util.formatNum(num, 3) + ' &deg; ';};"
+formatter = "function(num) {return L.Util.formatNum(num, 3) + ' &deg; '}"
 
 MousePosition(
     position="topright",

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -1,7 +1,8 @@
 from typing import List, Tuple
 
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
-from jinja2 import Template
+
+from folium.template import Template
 
 
 class JSCSSMixin(Element):

--- a/folium/features.py
+++ b/folium/features.py
@@ -14,11 +14,11 @@ import requests
 from branca.colormap import ColorMap, LinearColormap, StepColormap
 from branca.element import Element, Figure, Html, IFrame, JavascriptLink, MacroElement
 from branca.utilities import color_brewer
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import FeatureGroup, Icon, Layer, Marker, Popup, Tooltip
+from folium.template import Template
 from folium.utilities import (
     TypeJsonValue,
     TypeLine,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -8,11 +8,11 @@ import webbrowser
 from typing import Any, List, Optional, Sequence, Union
 
 from branca.element import Element, Figure, MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import FitBounds, Layer
 from folium.raster_layers import TileLayer
+from folium.template import Template
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,

--- a/folium/map.py
+++ b/folium/map.py
@@ -109,7 +109,7 @@ class FeatureGroup(Layer):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "FeatureGroup"
         self.tile_name = name if name is not None else self.get_name()
-        self.options = kwargs
+        self.options = parse_options(**kwargs)
 
 
 class LayerControl(MacroElement):

--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -1,6 +1,5 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.vector_layers import BaseMultiLocation, path_options
 
 

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Marker
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -1,7 +1,7 @@
 from branca.element import Element, Figure, MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class Draw(JSCSSMixin, MacroElement):

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -1,9 +1,9 @@
 from branca.element import Figure, MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import LayerControl
+from folium.template import Template
 from folium.utilities import deep_copy
 
 

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -1,6 +1,5 @@
-from jinja2 import Template
-
 from folium.plugins.marker_cluster import MarkerCluster
+from folium.template import Template
 from folium.utilities import if_pandas_df_convert_to_numpy, validate_location
 
 

--- a/folium/plugins/feature_group_sub_group.py
+++ b/folium/plugins/feature_group_sub_group.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 
 
 class FeatureGroupSubGroup(JSCSSMixin, Layer):

--- a/folium/plugins/float_image.py
+++ b/folium/plugins/float_image.py
@@ -1,5 +1,6 @@
 from branca.element import MacroElement
-from jinja2 import Template
+
+from folium.template import Template
 
 
 class FloatImage(MacroElement):

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/groupedlayercontrol.py
+++ b/folium/plugins/groupedlayercontrol.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -1,10 +1,10 @@
 import warnings
 
 import numpy as np
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import (
     if_pandas_df_convert_to_numpy,
     none_max,

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -1,8 +1,8 @@
 from branca.element import Element, Figure
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import none_max, none_min
 
 

--- a/folium/plugins/locate_control.py
+++ b/folium/plugins/locate_control.py
@@ -4,9 +4,9 @@ Based on leaflet plugin: https://github.com/domoritz/leaflet-locatecontrol
 """
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer, Marker
+from folium.template import Template
 from folium.utilities import parse_options, validate_locations
 
 

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -1,8 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.raster_layers import TileLayer
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -1,8 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
+from folium.utilities import JsCode, TypeJsFunctionArg
 
 
 class MousePosition(JSCSSMixin, MacroElement):
@@ -27,14 +27,14 @@ class MousePosition(JSCSSMixin, MacroElement):
         longitude and latitude decimal degree values.
     prefix : str, default ''
         A string to be prepended to the coordinates.
-    lat_formatter : str, default None
+    lat_formatter : str or JsCode, optional
         Custom Javascript function to format the latitude value.
-    lng_formatter : str, default None
+    lng_formatter : str or JsCode, optional
         Custom Javascript function to format the longitude value.
 
     Examples
     --------
-    >>> fmtr = "function(num) {return L.Util.formatNum(num, 3) + ' º ';};"
+    >>> fmtr = "function(num) {return L.Util.formatNum(num, 3) + ' º '}"
     >>> MousePosition(
     ...     position="topright",
     ...     separator=" | ",
@@ -49,12 +49,8 @@ class MousePosition(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.Control.MousePosition(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
-            {{ this.get_name() }}.options["latFormatter"] =
-                {{ this.lat_formatter }};
-            {{ this.get_name() }}.options["lngFormatter"] =
-                {{ this.lng_formatter }};
             {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
         {% endmacro %}
     """
@@ -81,21 +77,21 @@ class MousePosition(JSCSSMixin, MacroElement):
         lng_first=False,
         num_digits=5,
         prefix="",
-        lat_formatter=None,
-        lng_formatter=None,
+        lat_formatter: TypeJsFunctionArg = None,
+        lng_formatter: TypeJsFunctionArg = None,
         **kwargs
     ):
         super().__init__()
         self._name = "MousePosition"
 
-        self.options = parse_options(
+        self.options = dict(
             position=position,
             separator=separator,
             empty_string=empty_string,
             lng_first=lng_first,
             num_digits=num_digits,
             prefix=prefix,
+            lat_formatter=JsCode.optional_create(lat_formatter),
+            lng_formatter=JsCode.optional_create(lng_formatter),
             **kwargs
         )
-        self.lat_formatter = lat_formatter or "undefined"
-        self.lng_formatter = lng_formatter or "undefined"

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -1,8 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
+from folium.template import Template
 from folium.utilities import get_obj_in_upper_tree, parse_options
 
 

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import MacroElement
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,10 +1,10 @@
-from typing import Optional, Union
+from typing import Union
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import JsCode, camelize, parse_options
+from folium.template import Template
+from folium.utilities import JsCode, TypeJsFunctionArg
 
 
 class Realtime(JSCSSMixin, MacroElement):
@@ -27,11 +27,11 @@ class Realtime(JSCSSMixin, MacroElement):
         on the map and stopped when layer is removed from the map
     interval: int, default 60000
         Automatic update interval, in milliseconds
-    get_feature_id: JsCode, optional
+    get_feature_id: str or JsCode, optional
         A JS function with a geojson `feature` as parameter
         default returns `feature.properties.id`
         Function to get an identifier to uniquely identify a feature over time
-    update_feature: JsCode, optional
+    update_feature: str or JsCode, optional
         A JS function with a geojson `feature` as parameter
         Used to update an existing feature's layer;
         by default, points (markers) are updated, other layers are discarded
@@ -44,7 +44,8 @@ class Realtime(JSCSSMixin, MacroElement):
 
 
     Other keyword arguments are passed to the GeoJson layer, so you can pass
-    `style`, `point_to_layer` and/or `on_each_feature`.
+    `style`, `point_to_layer` and/or `on_each_feature`. Make sure to wrap
+    Javascript functions in the JsCode class.
 
     Examples
     --------
@@ -52,7 +53,7 @@ class Realtime(JSCSSMixin, MacroElement):
     >>> m = folium.Map(location=[40.73, -73.94], zoom_start=12)
     >>> rt = Realtime(
     ...     "https://raw.githubusercontent.com/python-visualization/folium-example-data/main/subway_stations.geojson",
-    ...     get_feature_id=JsCode("(f) => { return f.properties.objectid; }"),
+    ...     get_feature_id="(f) => { return f.properties.objectid; }",
     ...     point_to_layer=JsCode(
     ...         "(f, latlng) => { return L.circleMarker(latlng, {radius: 8, fillOpacity: 0.2})}"
     ...     ),
@@ -64,18 +65,9 @@ class Realtime(JSCSSMixin, MacroElement):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-            var {{ this.get_name() }}_options = {{ this.options|tojson }};
-            {% for key, value in this.functions.items() %}
-            {{ this.get_name() }}_options["{{key}}"] = {{ value }};
-            {% endfor %}
-
             var {{ this.get_name() }} = new L.realtime(
-            {% if this.src is string or this.src is mapping -%}
-                {{ this.src|tojson }},
-            {% else -%}
-                {{ this.src.js_code }},
-            {% endif -%}
-                {{ this.get_name() }}_options
+                {{ this.src|tojavascript }},
+                {{ this.options|tojavascript }}
             );
             {{ this._parent.get_name() }}.addLayer(
                 {{ this.get_name() }}._container);
@@ -95,28 +87,19 @@ class Realtime(JSCSSMixin, MacroElement):
         source: Union[str, dict, JsCode],
         start: bool = True,
         interval: int = 60000,
-        get_feature_id: Optional[JsCode] = None,
-        update_feature: Optional[JsCode] = None,
+        get_feature_id: TypeJsFunctionArg = None,
+        update_feature: TypeJsFunctionArg = None,
         remove_missing: bool = False,
         **kwargs
     ):
         super().__init__()
         self._name = "Realtime"
         self.src = source
-
-        kwargs["start"] = start
-        kwargs["interval"] = interval
-        if get_feature_id is not None:
-            kwargs["get_feature_id"] = get_feature_id
-        if update_feature is not None:
-            kwargs["update_feature"] = update_feature
-        kwargs["remove_missing"] = remove_missing
-
-        # extract JsCode objects
-        self.functions = {}
-        for key, value in list(kwargs.items()):
-            if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value.js_code
-                kwargs.pop(key)
-
-        self.options = parse_options(**kwargs)
+        self.options = dict(
+            start=start,
+            interval=interval,
+            get_feature_id=JsCode.optional_create(get_feature_id),
+            update_feature=JsCode.optional_create(update_feature),
+            remove_missing=remove_missing,
+            **kwargs
+        )

--- a/folium/plugins/scroll_zoom_toggler.py
+++ b/folium/plugins/scroll_zoom_toggler.py
@@ -1,5 +1,6 @@
 from branca.element import MacroElement
-from jinja2 import Template
+
+from folium.template import Template
 
 
 class ScrollZoomToggler(MacroElement):

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -1,10 +1,10 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium import Map
 from folium.elements import JSCSSMixin
 from folium.features import FeatureGroup, GeoJson, TopoJson
 from folium.plugins import MarkerCluster
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/semicircle.py
+++ b/folium/plugins/semicircle.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Marker
+from folium.template import Template
 from folium.utilities import parse_options
 from folium.vector_layers import path_options
 

--- a/folium/plugins/side_by_side.py
+++ b/folium/plugins/side_by_side.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class SideBySideLayers(JSCSSMixin, MacroElement):

--- a/folium/plugins/tag_filter_button.py
+++ b/folium/plugins/tag_filter_button.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/terminator.py
+++ b/folium/plugins/terminator.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class Terminator(JSCSSMixin, MacroElement):

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -1,8 +1,7 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import GeoJson
 from folium.map import Layer
+from folium.template import Template
 
 
 class TimeSliderChoropleth(JSCSSMixin, Layer):

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -1,10 +1,10 @@
 import json
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
+from folium.template import Template
 from folium.utilities import get_bounds, parse_options
 
 

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -1,8 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.raster_layers import WmsTileLayer
+from folium.template import Template
 from folium.utilities import parse_options
 
 

--- a/folium/plugins/vectorgrid_protobuf.py
+++ b/folium/plugins/vectorgrid_protobuf.py
@@ -1,9 +1,8 @@
 from typing import Optional, Union
 
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 
 
 class VectorGridProtobuf(JSCSSMixin, Layer):

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -6,9 +6,9 @@ from typing import Any, Callable, Optional, Union
 
 import xyzservices
 from branca.element import Element, Figure
-from jinja2 import Template
 
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,

--- a/folium/template.py
+++ b/folium/template.py
@@ -1,0 +1,46 @@
+import json
+from typing import Union
+
+import jinja2
+
+from folium.utilities import JsCode, TypeJsonValueNoNone, camelize
+
+
+def tojavascript(obj: Union[str, JsCode, dict]) -> str:
+    if isinstance(obj, (str, JsCode)):
+        return obj
+    elif isinstance(obj, dict):
+        out = ["{\n"]
+        for key, value in obj.items():
+            if value is None:
+                continue
+            out.append(f'  "{camelize(key)}": ')
+            if isinstance(value, JsCode):
+                out.append(value)
+            else:
+                out.append(_to_escaped_json(value))
+            out.append(",\n")
+        out.append("}")
+        return "".join(out)
+    else:
+        raise TypeError(f"Unsupported type: {type(obj)}")
+
+
+def _to_escaped_json(obj: TypeJsonValueNoNone) -> str:
+    return (
+        json.dumps(obj)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("'", "\\u0027")
+    )
+
+
+class Environment(jinja2.Environment):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filters["tojavascript"] = tojavascript
+
+
+class Template(jinja2.Template):
+    environment_class = Environment

--- a/folium/template.py
+++ b/folium/template.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import jinja2
 
-from folium.utilities import JsCode, TypeJsonValueNoNone, camelize
+from folium.utilities import JsCode, camelize
 
 
 def tojavascript(obj: Union[str, JsCode, dict]) -> str:
@@ -18,22 +18,18 @@ def tojavascript(obj: Union[str, JsCode, dict]) -> str:
             if isinstance(value, JsCode):
                 out.append(value)
             else:
-                out.append(_to_escaped_json(value))
+                out.append(
+                    json.dumps(obj)
+                    .replace("<", "\\u003c")
+                    .replace(">", "\\u003e")
+                    .replace("&", "\\u0026")
+                    .replace("'", "\\u0027")
+                )
             out.append(",\n")
         out.append("}")
         return "".join(out)
     else:
         raise TypeError(f"Unsupported type: {type(obj)}")
-
-
-def _to_escaped_json(obj: TypeJsonValueNoNone) -> str:
-    return (
-        json.dumps(obj)
-        .replace("<", "\\u003c")
-        .replace(">", "\\u003e")
-        .replace("&", "\\u0026")
-        .replace("'", "\\u0027")
-    )
 
 
 class Environment(jinja2.Environment):

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -412,8 +412,19 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
     return figure
 
 
-class JsCode:
+class JsCode(str):
     """Wrapper around Javascript code."""
 
-    def __init__(self, js_code: str):
-        self.js_code = js_code
+    @staticmethod
+    def optional_create(value: "TypeJsFunctionArg") -> Optional["JsCode"]:
+        """Return a JsCode object if value is not None."""
+        if value is None:
+            return None
+        elif value is JsCode:
+            return value
+        else:
+            assert isinstance(value, str)
+            return JsCode(value)
+
+
+TypeJsFunctionArg = Union[None, str, JsCode]

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -420,7 +420,7 @@ class JsCode(str):
         """Return a JsCode object if value is not None."""
         if value is None:
             return None
-        elif value is JsCode:
+        elif isinstance(value, JsCode):
             return value
         else:
             assert isinstance(value, str)

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -5,9 +5,9 @@ Wraps leaflet Polyline, Polygon, Rectangle, Circle, and CircleMarker
 from typing import List, Optional, Sequence, Union
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.map import Marker, Popup, Tooltip
+from folium.template import Template
 from folium.utilities import (
     TypeLine,
     TypeMultiLine,


### PR DESCRIPTION
Testing out how we can use the concept of the new `JsCode` class, which was added in https://github.com/python-visualization/folium/pull/1848. Idea is that we no longer have to manually put Javascript code in templates. 

Problem before was that a Javascript-function-as-Python-string would get transformed into a Javascript string. Because of that we had to put those functions into the template manually.

Now we have a `JsCode` class that we can use to mark strings as Javascript code. When putting stuff in templates, we can check for that class and prevent adding string quotes.

I looked into using a custom JSON encoder with the `json` module, but that turns out to be awkward, because what we're producing is not actually valid JSON.

So I've opted to make a custom filter like the `tojson` filter we use a lot, but now allowing for Javascript code. To register this filter I had to subclass `Template`.

Using it means:
- Importing the `Template` class from `folium.template`
- Wrapping any arguments that are JS functions with `JsCode.optional_create()`
- Stop using `parse_options`.
- Using `{{ options|tojavascript }}` filter in the template.

I've now applied this new workflow on the `LayerControl`, `MousePosition` and `Realtime` classes.

Some smaller included changes:
- Make `JsCode` a subclass of `str`, that makes it easier to put it in a template without additional needed code.
- Arguments that are JS functions can be either string or `JsCode`, I figured that's more user-friendly then requiring `JsCode`.
- The `MousePosition` example with the custom formatter no longer works with the trailing `;` character, so that's a breaking change.

If this seems like a good change I'll add tests as well.

Question is whether the added complexity of the new code weighs up to the more straightforward way in working with Javascript code.