### PR TITLE
Geojson: allow null geometry objects

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1120,7 +1120,8 @@ class GeoJsonDetail(MacroElement):
         geom_collections = [
             feature.get("properties") if feature.get("properties") is not None else key
             for key, feature in enumerate(self._parent.data["features"])
-            if feature["geometry"]["type"] == "GeometryCollection"
+            if feature["geometry"]
+            and feature["geometry"]["type"] == "GeometryCollection"
         ]
         if any(geom_collections):
             warnings.warn(

--- a/folium/features.py
+++ b/folium/features.py
@@ -1137,7 +1137,11 @@ class GeoJsonDetail(MacroElement):
         """Renders the HTML representation of the element."""
         figure = self.get_root()
         if isinstance(self._parent, GeoJson):
-            keys = tuple(self._parent.data["features"][0]["properties"].keys())
+            keys = tuple(
+                self._parent.data["features"][0]["properties"].keys()
+                if self._parent.data["features"]
+                else []
+            )
             self.warn_for_geometry_collections()
         elif isinstance(self._parent, TopoJson):
             obj_name = self._parent.object_path.split(".")[-1]

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -276,10 +276,18 @@ def iter_coords(obj: Any) -> Iterator[Tuple[float, ...]]:
     if isinstance(obj, (tuple, list)):
         coords = obj
     elif "features" in obj:
-        coords = [geom["geometry"]["coordinates"] for geom in obj["features"]]
+        coords = [
+            geom["geometry"]["coordinates"]
+            for geom in obj["features"]
+            if geom["geometry"]
+        ]
     elif "geometry" in obj:
-        coords = obj["geometry"]["coordinates"]
-    elif "geometries" in obj and "coordinates" in obj["geometries"][0]:
+        coords = obj["geometry"]["coordinates"] if obj["geometry"] else []
+    elif (
+        "geometries" in obj
+        and obj["geometries"][0]
+        and "coordinates" in obj["geometries"][0]
+    ):
         coords = obj["geometries"][0]["coordinates"]
     else:
         coords = obj.get("coordinates", obj)


### PR DESCRIPTION
GeoJson objects can have `null` `geometry` members according to the standard. However, if we pass a `null` value to folium, this will cause an error in `m.get_bounds()`. 

See https://datatracker.ietf.org/doc/html/rfc7946#section-3.2

A Feature object has a member with the name "geometry".  The value of the geometry member SHALL be either a Geometry object as defined above or . . . a JSON null value.