### PR TITLE
realtime plugin: allow str for JsCode arg

### DIFF
--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 
 from branca.element import MacroElement
 from jinja2 import Template

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -27,11 +27,11 @@ class Realtime(JSCSSMixin, MacroElement):
         on the map and stopped when layer is removed from the map
     interval: int, default 60000
         Automatic update interval, in milliseconds
-    get_feature_id: JsCode, optional
+    get_feature_id: str or JsCode, optional
         A JS function with a geojson `feature` as parameter
         default returns `feature.properties.id`
         Function to get an identifier to uniquely identify a feature over time
-    update_feature: JsCode, optional
+    update_feature: str or JsCode, optional
         A JS function with a geojson `feature` as parameter
         Used to update an existing feature's layer;
         by default, points (markers) are updated, other layers are discarded
@@ -44,7 +44,8 @@ class Realtime(JSCSSMixin, MacroElement):
 
 
     Other keyword arguments are passed to the GeoJson layer, so you can pass
-    `style`, `point_to_layer` and/or `on_each_feature`.
+    `style`, `point_to_layer` and/or `on_each_feature`. Make sure to wrap
+    Javascript functions in the JsCode class.
 
     Examples
     --------
@@ -95,8 +96,8 @@ class Realtime(JSCSSMixin, MacroElement):
         source: Union[str, dict, JsCode],
         start: bool = True,
         interval: int = 60000,
-        get_feature_id: Optional[JsCode] = None,
-        update_feature: Optional[JsCode] = None,
+        get_feature_id: Union[JsCode, str, None] = None,
+        update_feature: Union[JsCode, str, None] = None,
         remove_missing: bool = False,
         **kwargs
     ):
@@ -107,16 +108,16 @@ class Realtime(JSCSSMixin, MacroElement):
         kwargs["start"] = start
         kwargs["interval"] = interval
         if get_feature_id is not None:
-            kwargs["get_feature_id"] = get_feature_id
+            kwargs["get_feature_id"] = JsCode(get_feature_id)
         if update_feature is not None:
-            kwargs["update_feature"] = update_feature
+            kwargs["update_feature"] = JsCode(update_feature)
         kwargs["remove_missing"] = remove_missing
 
         # extract JsCode objects
         self.functions = {}
         for key, value in list(kwargs.items()):
             if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value.js_code
+                self.functions[camelize(key)] = value
                 kwargs.pop(key)
 
         self.options = parse_options(**kwargs)

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -117,7 +117,7 @@ class Realtime(JSCSSMixin, MacroElement):
         self.functions = {}
         for key, value in list(kwargs.items()):
             if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value
+                self.functions[camelize(key)] = value.js_code
                 kwargs.pop(key)
 
         self.options = parse_options(**kwargs)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -420,6 +420,11 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
     return figure
 
 
-class JsCode(str):
+class JsCode:
     """Wrapper around Javascript code."""
-    pass
+
+    def __init__(self, js_code: Union[str, 'JsCode']):
+        if isinstance(js_code, JsCode):
+            self.js_code: str = js_code.js_code
+        else:
+            self.js_code = js_code

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -420,8 +420,6 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
     return figure
 
 
-class JsCode:
+class JsCode(str):
     """Wrapper around Javascript code."""
-
-    def __init__(self, js_code: str):
-        self.js_code = js_code
+    pass

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -423,7 +423,7 @@ def get_and_assert_figure_root(obj: Element) -> Figure:
 class JsCode:
     """Wrapper around Javascript code."""
 
-    def __init__(self, js_code: Union[str, 'JsCode']):
+    def __init__(self, js_code: Union[str, "JsCode"]):
         if isinstance(js_code, JsCode):
             self.js_code: str = js_code.js_code
         else:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -220,13 +220,13 @@ def test_javascript_identifier_path_to_array_notation(text, result):
 
 
 def test_js_code_init_str():
-    js_code = JsCode('hi')
+    js_code = JsCode("hi")
     assert isinstance(js_code, JsCode)
     assert isinstance(js_code.js_code, str)
 
 
 def test_js_code_init_js_code():
-    js_code = JsCode('hi')
+    js_code = JsCode("hi")
     js_code_2 = JsCode(js_code)
     assert isinstance(js_code_2, JsCode)
     assert isinstance(js_code_2.js_code, str)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,6 +4,7 @@ import pytest
 
 from folium import FeatureGroup, Map, Marker, Popup
 from folium.utilities import (
+    JsCode,
     _is_url,
     camelize,
     deep_copy,
@@ -216,3 +217,16 @@ def test_escape_double_quotes(text, result):
 )
 def test_javascript_identifier_path_to_array_notation(text, result):
     assert javascript_identifier_path_to_array_notation(text) == result
+
+
+def test_js_code_init_str():
+    js_code = JsCode('hi')
+    assert isinstance(js_code, JsCode)
+    assert isinstance(js_code.js_code, str)
+
+
+def test_js_code_init_js_code():
+    js_code = JsCode('hi')
+    js_code_2 = JsCode(js_code)
+    assert isinstance(js_code_2, JsCode)
+    assert isinstance(js_code_2.js_code, str)


### PR DESCRIPTION
Idea split off from https://github.com/python-visualization/folium/pull/1856.

For defined keyword arguments that expect a Javascript function, allow not only the new `JsCode` class, but also str. Adapt `JsCode` to allow both `str` and `JsCode` arguments for easier instantiation.

This means that users can use these keyword arguments without having to deal with `JsCode`. And `JsCode` is only necessary for undefined keyword arguments that are Javascript functions.

Upside of this is that users have less classes to worry about when using this plugin. Downside is it may be confusing that using a string doesn't work for undefined keyword arguments that are Javascript functions. But since that's a more advanced move, I hope those users can read and understand the docstring.