### PR TITLE
Possibility for markers to link to other markers #1563

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -467,7 +467,7 @@ class Popup(Element):
             **kwargs,
         )
         self.linked_marker = linked_marker
-        self.linked_marker_name =linked_marker_name
+        self.linked_marker_name = linked_marker_name
 
     def render(self, **kwargs) -> None:
         """Renders the HTML representation of the element."""

--- a/folium/map.py
+++ b/folium/map.py
@@ -488,7 +488,7 @@ class Popup(Element):
             linking_script = f"""
                 var linkElement = document.createElement('a');
                 linkElement.href = '#';
-                linkElement.innerHTML = '{'Open ' + self.linked_marker_name if self.linked_marker_name else 'Open Another Popup'}';
+                linkElement.innerHTML = '{'Open ' + self.linked_marker_name if self.linked_marker_name else 'Open another popup'}';
                 linkElement.addEventListener('click', function() {{
                     {self._parent.get_name()}.closePopup();
                     {self.linked_marker.get_name()}.openPopup();


### PR DESCRIPTION
This implementation introduces a feature allowing markers to be linked, specifically through their popups. This functionality also ensures an easy navigation between their popups.

Changes Made: 
 1. When creating a marker with a popup, users can now specify a linked marker using "linked_marker" and assign a name with "linked_marker_name".
 2. A clickable link is added to the popup. When clicked:
 - The current popup closes.
 - The linked marker gets centered, and its popup opens.
 3. If you have only specified the linked marker, it has a standard name. However, if you specified the name, the link is named after the given name.
 
**Related Issue:** #1563