### PR TITLE
highlight_color for vector classes

### DIFF
--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -133,6 +133,7 @@ class BaseMultiLocation(MacroElement):
         locations: TypeMultiLine,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
+        **kwargs: TypePathOptions
     ):
         super().__init__()
         self.locations = validate_multi_locations(locations)
@@ -142,6 +143,7 @@ class BaseMultiLocation(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
+        self.options = path_options(line=True, **kwargs)
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""
@@ -181,14 +183,34 @@ class PolyLine(BaseMultiLocation):
                 {{ this.locations|tojson }},
                 {{ this.options|tojson }}
             ).addTo({{this._parent.get_name()}});
+            {% if this.options.highlight_color %}
+            {{ this.get_name() }}.options.original_color = {{ this.options.color|tojson }};
+
+            function highlightLayer(e) {
+                if (e.target.getTooltip()) {
+                    e.target.setStyle({ color:  e.target.options.highlight_color });
+                }
+            }
+
+            function resetHighlight(e) {
+                e.target.setStyle({ color:  e.target.options.original_color });
+            }
+
+            {{ this.get_name() }}.on({
+                mouseover: highlightLayer,
+                mouseout: resetHighlight
+            });
+            {% endif %}
         {% endmacro %}
         """
     )
 
-    def __init__(self, locations, popup=None, tooltip=None, **kwargs):
+    def __init__(self, locations, popup=None, tooltip=None, highlight_color=None, **kwargs):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "PolyLine"
         self.options = path_options(line=True, **kwargs)
+        if highlight_color is not None:
+            self.options['highlight_color'] = highlight_color
 
 
 class Polygon(BaseMultiLocation):
@@ -220,6 +242,24 @@ class Polygon(BaseMultiLocation):
                 {{ this.locations|tojson }},
                 {{ this.options|tojson }}
             ).addTo({{this._parent.get_name()}});
+            {% if this.options.highlight_color %}
+            {{ this.get_name() }}.options.original_color = {{ this.options.color|tojson }};
+
+            function highlightLayer(e) {
+                if (e.target.getTooltip()) {
+                    e.target.setStyle({ color:  e.target.options.highlight_color });
+                }
+            }
+
+            function resetHighlight(e) {
+                e.target.setStyle({ color:  e.target.options.original_color });
+            }
+
+            {{ this.get_name() }}.on({
+                mouseover: highlightLayer,
+                mouseout: resetHighlight
+            });
+            {% endif %}
         {% endmacro %}
         """
     )
@@ -229,12 +269,15 @@ class Polygon(BaseMultiLocation):
         locations: TypeMultiLine,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
+        highlight_color: Optional[str] = None,
         **kwargs: TypePathOptions
     ):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "Polygon"
         self.options = path_options(line=True, radius=None, **kwargs)
-
+        if highlight_color is not None:
+            self.options['highlight_color'] = highlight_color
+        
 
 class Rectangle(MacroElement):
     """Draw rectangle overlays on a map.
@@ -262,6 +305,24 @@ class Rectangle(MacroElement):
                 {{ this.locations|tojson }},
                 {{ this.options|tojson }}
             ).addTo({{this._parent.get_name()}});
+            {% if this.options.highlight_color %}
+            {{ this.get_name() }}.options.original_color = {{ this.options.color|tojson }};
+
+            function highlightLayer(e) {
+                if (e.target.getTooltip()) {
+                    e.target.setStyle({ color:  e.target.options.highlight_color });
+                }
+            }
+
+            function resetHighlight(e) {
+                e.target.setStyle({ color:  e.target.options.original_color });
+            }
+
+            {{ this.get_name() }}.on({
+                mouseover: highlightLayer,
+                mouseout: resetHighlight
+            });
+            {% endif %}
         {% endmacro %}
         """
     )
@@ -271,6 +332,7 @@ class Rectangle(MacroElement):
         bounds: TypeLine,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
+        highlight_color: Optional[str] = None,
         **kwargs: TypePathOptions
     ):
         super().__init__()
@@ -284,6 +346,8 @@ class Rectangle(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
+        if highlight_color is not None:
+            self.options['highlight_color'] = highlight_color
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""
@@ -322,6 +386,24 @@ class Circle(Marker):
                 {{ this.location|tojson }},
                 {{ this.options|tojson }}
             ).addTo({{ this._parent.get_name() }});
+            {% if this.options.highlight_color %}
+            {{ this.get_name() }}.options.original_color = {{ this.options.color|tojson }};
+
+            function highlightLayer(e) {
+                if (e.target.getTooltip()) {
+                    e.target.setStyle({ color:  e.target.options.highlight_color });
+                }
+            }
+
+            function resetHighlight(e) {
+                e.target.setStyle({ color:  e.target.options.original_color });
+            }
+
+            {{ this.get_name() }}.on({
+                mouseover: highlightLayer,
+                mouseout: resetHighlight
+            });
+            {% endif %}
         {% endmacro %}
         """
     )
@@ -332,11 +414,14 @@ class Circle(Marker):
         radius: float = 50,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
+        highlight_color: Optional[str] = None,
         **kwargs: TypePathOptions
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "circle"
         self.options = path_options(line=False, radius=radius, **kwargs)
+        if highlight_color is not None:
+            self.options['highlight_color'] = highlight_color
 
 
 class CircleMarker(Marker):
@@ -368,6 +453,24 @@ class CircleMarker(Marker):
                 {{ this.location|tojson }},
                 {{ this.options|tojson }}
             ).addTo({{ this._parent.get_name() }});
+            {% if this.options.highlight_color %}
+            {{ this.get_name() }}.options.original_color = {{ this.options.color|tojson }};
+
+            function highlightLayer(e) {
+                if (e.target.getTooltip()) {
+                    e.target.setStyle({ color:  e.target.options.highlight_color });
+                }
+            }
+
+            function resetHighlight(e) {
+                e.target.setStyle({ color:  e.target.options.original_color });
+            }
+
+            {{ this.get_name() }}.on({
+                mouseover: highlightLayer,
+                mouseout: resetHighlight
+            });
+            {% endif %}
         {% endmacro %}
         """
     )
@@ -378,8 +481,11 @@ class CircleMarker(Marker):
         radius: float = 10,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
+        highlight_color: Optional[str] = None,
         **kwargs: TypePathOptions
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "CircleMarker"
         self.options = path_options(line=False, radius=radius, **kwargs)
+        if highlight_color is not None:
+            self.options['highlight_color'] = highlight_color

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -205,12 +205,14 @@ class PolyLine(BaseMultiLocation):
         """
     )
 
-    def __init__(self, locations, popup=None, tooltip=None, highlight_color=None, **kwargs):
+    def __init__(
+        self, locations, popup=None, tooltip=None, highlight_color=None, **kwargs
+    ):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "PolyLine"
         self.options = path_options(line=True, **kwargs)
         if highlight_color is not None:
-            self.options['highlight_color'] = highlight_color
+            self.options["highlight_color"] = highlight_color
 
 
 class Polygon(BaseMultiLocation):
@@ -276,8 +278,8 @@ class Polygon(BaseMultiLocation):
         self._name = "Polygon"
         self.options = path_options(line=True, radius=None, **kwargs)
         if highlight_color is not None:
-            self.options['highlight_color'] = highlight_color
-        
+            self.options["highlight_color"] = highlight_color
+
 
 class Rectangle(MacroElement):
     """Draw rectangle overlays on a map.
@@ -347,7 +349,7 @@ class Rectangle(MacroElement):
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
         if highlight_color is not None:
-            self.options['highlight_color'] = highlight_color
+            self.options["highlight_color"] = highlight_color
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""
@@ -421,7 +423,7 @@ class Circle(Marker):
         self._name = "circle"
         self.options = path_options(line=False, radius=radius, **kwargs)
         if highlight_color is not None:
-            self.options['highlight_color'] = highlight_color
+            self.options["highlight_color"] = highlight_color
 
 
 class CircleMarker(Marker):
@@ -488,4 +490,4 @@ class CircleMarker(Marker):
         self._name = "CircleMarker"
         self.options = path_options(line=False, radius=radius, **kwargs)
         if highlight_color is not None:
-            self.options['highlight_color'] = highlight_color
+            self.options["highlight_color"] = highlight_color

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -143,7 +143,6 @@ class BaseMultiLocation(MacroElement):
             self.add_child(
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
-        self.options = path_options(line=True, **kwargs)
 
     def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Compute the bounds of the object itself."""


### PR DESCRIPTION
The implementation introduces the possibility to highlight polylines, polygons, rectangles, circles, and circle markers if a tooltip is shown.
Changes Made:
 - Users can now specify the "highlight_color" when creating a vector layer.
 - When a user hovers over the vector layer and a tooltip is displayed, the vector layer then sets its color to the highlight color.
 
Related Issue: #1763