### PR TITLE
Add ability to set font size in plot

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -153,6 +153,9 @@ class Map(JSCSSMixin, MacroElement):
         rare environments) even if they're supported.
     zoom_control : bool, default True
         Display zoom controls on the map.
+    font_size : int or float or string (default: '1rem')
+        The font size to use for Leaflet, can either be a number of a
+        string ending in 'rem'
     **kwargs
         Additional keyword arguments are passed to Leaflets Map class:
         https://leafletjs.com/reference.html#map
@@ -236,7 +239,6 @@ class Map(JSCSSMixin, MacroElement):
         height: Union[str, float] = "100%",
         left: Union[str, float] = "0%",
         top: Union[str, float] = "0%",
-        font_size: str = "1rem",
         position: str = "relative",
         tiles: Union[str, TileLayer, None] = "OpenStreetMap",
         attr: Optional[str] = None,
@@ -255,6 +257,7 @@ class Map(JSCSSMixin, MacroElement):
         disable_3d: bool = False,
         png_enabled: bool = False,
         zoom_control: bool = True,
+        font_size: str = "1rem",
         **kwargs: TypeJsonValue,
     ):
         super().__init__()

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -17,6 +17,7 @@ from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
     _parse_size,
+    parse_font_size,
     parse_options,
     temp_html_filepath,
     validate_location,
@@ -186,7 +187,7 @@ class Map(JSCSSMixin, MacroElement):
                     left: {{this.left[0]}}{{this.left[1]}};
                     top: {{this.top[0]}}{{this.top[1]}};
                 }
-                .leaflet-container { font-size: 1rem; }
+                .leaflet-container { font-size: {{this.font_size}}; }
             </style>
         {% endmacro %}
 
@@ -235,6 +236,7 @@ class Map(JSCSSMixin, MacroElement):
         height: Union[str, float] = "100%",
         left: Union[str, float] = "0%",
         top: Union[str, float] = "0%",
+        font_size: str = "1rem",
         position: str = "relative",
         tiles: Union[str, TileLayer, None] = "OpenStreetMap",
         attr: Optional[str] = None,
@@ -276,6 +278,7 @@ class Map(JSCSSMixin, MacroElement):
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
+        self.font_size = parse_font_size(font_size)
 
         max_bounds_array = (
             [[min_lat, min_lon], [max_lat, max_lon]] if max_bounds else None

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -155,7 +155,7 @@ class Map(JSCSSMixin, MacroElement):
         Display zoom controls on the map.
     font_size : int or float or string (default: '1rem')
         The font size to use for Leaflet, can either be a number or a
-        string ending in 'rem'
+        string ending in 'rem', 'em', or 'px'.
     **kwargs
         Additional keyword arguments are passed to Leaflets Map class:
         https://leafletjs.com/reference.html#map

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -154,7 +154,7 @@ class Map(JSCSSMixin, MacroElement):
     zoom_control : bool, default True
         Display zoom controls on the map.
     font_size : int or float or string (default: '1rem')
-        The font size to use for Leaflet, can either be a number of a
+        The font size to use for Leaflet, can either be a number or a
         string ending in 'rem'
     **kwargs
         Additional keyword arguments are passed to Leaflets Map class:

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -425,3 +425,13 @@ class JsCode:
 
     def __init__(self, js_code: str):
         self.js_code = js_code
+
+
+def parse_font_size(value:Union[str, int, float]) ->str:
+    """Parse a font size value."""
+    if isinstance(value, (int, float)):
+        return f"{value}rem"
+
+    if 'rem' not in value:
+        raise ValueError("The font size must be expressed in rem.")
+    return value

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -428,10 +428,11 @@ class JsCode:
 
 
 def parse_font_size(value: Union[str, int, float]) -> str:
-    """Parse a font size value."""
+    """Parse a font size value, if number set as px"""
     if isinstance(value, (int, float)):
-        return f"{value}rem"
+        return f"{value}px"
 
-    if "rem" not in value:
-        raise ValueError("The font size must be expressed in rem.")
+    if (value[-3:] != 'rem') and (value[-2:] not in ['em','px']):
+        raise ValueError("The font size must be expressed in rem, em, or px.")
     return value
+

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -427,11 +427,11 @@ class JsCode:
         self.js_code = js_code
 
 
-def parse_font_size(value:Union[str, int, float]) ->str:
+def parse_font_size(value: Union[str, int, float]) -> str:
     """Parse a font size value."""
     if isinstance(value, (int, float)):
         return f"{value}rem"
 
-    if 'rem' not in value:
+    if "rem" not in value:
         raise ValueError("The font size must be expressed in rem.")
     return value

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -432,7 +432,6 @@ def parse_font_size(value: Union[str, int, float]) -> str:
     if isinstance(value, (int, float)):
         return f"{value}px"
 
-    if (value[-3:] != 'rem') and (value[-2:] not in ['em','px']):
+    if (value[-3:] != "rem") and (value[-2:] not in ["em", "px"]):
         raise ValueError("The font size must be expressed in rem, em, or px.")
     return value
-

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -75,7 +75,7 @@ class TestFolium:
             max_zoom=20,
             zoom_start=4,
             max_bounds=True,
-            font_size=1.5,
+            font_size="1.5rem",
             attr=attr,
         )
         self.env = Environment(loader=PackageLoader("folium", "templates"))

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -75,6 +75,7 @@ class TestFolium:
             max_zoom=20,
             zoom_start=4,
             max_bounds=True,
+            font_size=1.5,
             attr=attr,
         )
         self.env = Environment(loader=PackageLoader("folium", "templates"))
@@ -94,6 +95,7 @@ class TestFolium:
         assert self.m.top == (0, "%")
         assert self.m.global_switches.no_touch is False
         assert self.m.global_switches.disable_3d is False
+        assert self.m.font_size == "1.5rem"
         assert self.m.to_dict() == {
             "name": "Map",
             "id": self.m._id,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -219,7 +219,6 @@ def test_escape_double_quotes(text, result):
 def test_javascript_identifier_path_to_array_notation(text, result):
     assert javascript_identifier_path_to_array_notation(text) == result
 
-    
 def test_js_code_init_str():
     js_code = JsCode("hi")
     assert isinstance(js_code, JsCode)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -235,6 +235,7 @@ def test_parse_font_size_valid(value, expected):
 invalid_values = ["1", "1unit"]
 expected_errors = "The font size must be expressed in rem, em, or px."
 
+
 @pytest.mark.parametrize("value,error_message", zip(invalid_values, expected_errors))
 def test_parse_font_size_invalid(value, error_message):
     with pytest.raises(ValueError, match=error_message):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -15,6 +15,7 @@ from folium.utilities import (
     validate_location,
     validate_locations,
     validate_multi_locations,
+    parse_font_size
 )
 
 
@@ -216,3 +217,26 @@ def test_escape_double_quotes(text, result):
 )
 def test_javascript_identifier_path_to_array_notation(text, result):
     assert javascript_identifier_path_to_array_notation(text) == result
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (10, "10rem"),
+        (12.5, "12.5rem"),
+        ("1rem", "1rem"),
+    ],
+)
+def test_parse_font_size_valid(value, expected):
+    assert parse_font_size(value) == expected
+
+invalid_values = [
+    "10px",
+    "1"
+]
+expected_errors = ["The font size must be expressed in rem.", "The font size must be expressed in rem."]
+
+@pytest.mark.parametrize("value,error_message", zip(invalid_values, expected_errors))
+def test_parse_font_size_invalid(value, error_message):
+    with pytest.raises(ValueError, match=error_message):
+        parse_font_size(value)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,11 +11,11 @@ from folium.utilities import (
     get_obj_in_upper_tree,
     if_pandas_df_convert_to_numpy,
     javascript_identifier_path_to_array_notation,
+    parse_font_size,
     parse_options,
     validate_location,
     validate_locations,
     validate_multi_locations,
-    parse_font_size,
 )
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -219,6 +219,7 @@ def test_escape_double_quotes(text, result):
 def test_javascript_identifier_path_to_array_notation(text, result):
     assert javascript_identifier_path_to_array_notation(text) == result
 
+
 def test_js_code_init_str():
     js_code = JsCode("hi")
     assert isinstance(js_code, JsCode)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -15,7 +15,7 @@ from folium.utilities import (
     validate_location,
     validate_locations,
     validate_multi_locations,
-    parse_font_size
+    parse_font_size,
 )
 
 
@@ -230,11 +230,13 @@ def test_javascript_identifier_path_to_array_notation(text, result):
 def test_parse_font_size_valid(value, expected):
     assert parse_font_size(value) == expected
 
-invalid_values = [
-    "10px",
-    "1"
+
+invalid_values = ["10px", "1"]
+expected_errors = [
+    "The font size must be expressed in rem.",
+    "The font size must be expressed in rem.",
 ]
-expected_errors = ["The font size must be expressed in rem.", "The font size must be expressed in rem."]
+
 
 @pytest.mark.parametrize("value,error_message", zip(invalid_values, expected_errors))
 def test_parse_font_size_invalid(value, error_message):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -222,21 +222,18 @@ def test_javascript_identifier_path_to_array_notation(text, result):
 @pytest.mark.parametrize(
     "value,expected",
     [
-        (10, "10rem"),
-        (12.5, "12.5rem"),
+        (10, "10px"),
+        (12.5, "12.5px"),
         ("1rem", "1rem"),
+        ("1em", "1em"),
     ],
 )
 def test_parse_font_size_valid(value, expected):
     assert parse_font_size(value) == expected
 
 
-invalid_values = ["10px", "1"]
-expected_errors = [
-    "The font size must be expressed in rem.",
-    "The font size must be expressed in rem.",
-]
-
+invalid_values = ["1", "1unit"]
+expected_errors = "The font size must be expressed in rem, em, or px."
 
 @pytest.mark.parametrize("value,error_message", zip(invalid_values, expected_errors))
 def test_parse_font_size_invalid(value, error_message):


### PR DESCRIPTION
This PR permits you to set the leaflet font size. This is helpful to make plots more legible in certain circumstances. 