### PR TITLE
fixed typos of examples in code

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -88,7 +88,7 @@ class Map(JSCSSMixin, MacroElement):
 
         - "OpenStreetMap"
         - "CartoDB Positron"
-        - "CartoBD Voyager"
+        - "CartoDB Voyager"
         - "NASAGIBS Blue Marble"
 
     You can pass a custom tileset to Folium by passing a

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -32,7 +32,7 @@ class TileLayer(Layer):
 
             - "OpenStreetMap"
             - "CartoDB Positron"
-            - "CartoBD Voyager"
+            - "CartoDB Voyager"
             - "NASAGIBS Blue Marble"
 
         You can pass a custom tileset to Folium by passing a


### PR DESCRIPTION
This PR fixes the typos of the example of tiles. The code cannot find  `CartoBD Voyager` in the `xyzservices.TileProvider`. It should be `CartoDB Voyager`. 
Reference: https://github.com/geopandas/xyzservices/blob/8c3f23830e9d0dd06406d3371610351aae77ed76/xyzservices/data/providers.json#L2075
