### PR TITLE
changed NASAGIBS Blue Marble to NASAGIBS BlueMarble3413 in examples

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -89,7 +89,7 @@ class Map(JSCSSMixin, MacroElement):
         - "OpenStreetMap"
         - "CartoDB Positron"
         - "CartoBD Voyager"
-        - "NASAGIBS Blue Marble"
+        - "NASAGIBS BlueMarble3413"
 
     You can pass a custom tileset to Folium by passing a
     :class:`xyzservices.TileProvider` or a Leaflet-style

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -33,7 +33,7 @@ class TileLayer(Layer):
             - "OpenStreetMap"
             - "CartoDB Positron"
             - "CartoBD Voyager"
-            - "NASAGIBS Blue Marble"
+            - "NASAGIBS BlueMarble3413"
 
         You can pass a custom tileset to Folium by passing a
         :class:`xyzservices.TileProvider` or a Leaflet-style


### PR DESCRIPTION
 `NASAGIBS Blue Marble` was removed from xyzservices provider list as the endpoint doesn't work. (https://github.com/geopandas/xyzservices/pull/158) I suggest the example in Folium to be replaced with either `"BlueMarble3413` or `"BlueMarble3031`. 
 However, at the moment, the URL that's in their json file of these two tiles isn't working and throws 400 error.  
 Or, maybe this example can be thrown out as it would be very confusing. 
