### PR TITLE
Drop Bootstrap 3 but keep glyphicons

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -45,7 +45,7 @@ _default_css = [
     # glyphicons came from Bootstrap 3 and are used for Awesome Markers
     (
         "glyphicons_css",
-        "https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css",
+        "https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css",
     ),
     (
         "awesome_markers_font_css",


### PR DESCRIPTION
In https://github.com/python-visualization/folium/pull/1650 we transitioned from Bootstrap 3 to 5. We also had to keep Bootstrap 3 for the Glyphicon icons in the AwesomeMarkers.

Turns out there's also a hosted css file with only the css necessary for the glyphicons, not the entirety of Bootstrap 3. See https://stackoverflow.com/a/18225474/4082914 under "If you want to use the Glyphicons separately". Use that file instead.
 
Closes https://github.com/python-visualization/folium/issues/1908.