### PR TITLE
Github Actions: only on push to main

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,6 +1,10 @@
 name: Code Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run:

--- a/.github/workflows/test_latest_branca.yml
+++ b/.github/workflows/test_latest_branca.yml
@@ -1,6 +1,10 @@
 name: Code Tests with Latest branca
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run:

--- a/.github/workflows/test_mypy.yml
+++ b/.github/workflows/test_mypy.yml
@@ -1,6 +1,10 @@
 name: Mypy type hint checks
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run:

--- a/.github/workflows/test_selenium.yml
+++ b/.github/workflows/test_selenium.yml
@@ -1,6 +1,10 @@
 name: Selenium Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run:


### PR DESCRIPTION
Run our CI only on pushes to the main branch, not to any branch. This makes sure CI doesn't start on branches of forks, which is a waste, since we run CI on our pull requests anyway. Branches on forks are meant to be merged into the main repo through a PR, so running CI on the branch is not necessary.