### PR TITLE
Remove NASAGIBS Blue Marble example

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -90,14 +90,13 @@ class Map(JSCSSMixin, MacroElement):
         - "OpenStreetMap"
         - "CartoDB Positron"
         - "CartoDB Voyager"
-        - "NASAGIBS Blue Marble"
 
-    You can pass a custom tileset to Folium by passing a
+    You can also pass a custom tileset to Folium by passing a
     :class:`xyzservices.TileProvider` or a Leaflet-style
     URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
 
     You can find a list of free tile providers here:
-    ``http://leaflet-extras.github.io/leaflet-providers/preview/``.
+    http://leaflet-extras.github.io/leaflet-providers/preview/.
     Be sure to check their terms and conditions and to provide attribution
     with the `attr` keyword.
 

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -91,14 +91,12 @@ class Map(JSCSSMixin, MacroElement):
         - "CartoDB Positron"
         - "CartoDB Voyager"
 
-    You can also pass a custom tileset to Folium by passing a
-    :class:`xyzservices.TileProvider` or a Leaflet-style
-    URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
+    Explore more provider names available in ``xyzservices`` here:
+    https://leaflet-extras.github.io/leaflet-providers/preview/.
 
-    You can find a list of free tile providers here:
-    http://leaflet-extras.github.io/leaflet-providers/preview/.
-    Be sure to check their terms and conditions and to provide attribution
-    with the `attr` keyword.
+    You can also pass a custom tileset by passing a
+    :class:`xyzservices.TileProvider` or a Leaflet-style
+    URL to the tiles parameter: ``https://{s}.yourtiles.com/{z}/{x}/{y}.png``.
 
     Parameters
     ----------

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -34,14 +34,12 @@ class TileLayer(Layer):
             - "CartoDB Positron"
             - "CartoDB Voyager"
 
-        You can pass a custom tileset to Folium by passing a
-        :class:`xyzservices.TileProvider` or a Leaflet-style
-        URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
+        Explore more provider names available in ``xyzservices`` here:
+        https://leaflet-extras.github.io/leaflet-providers/preview/.
 
-        You can find a list of free tile providers here:
-        http://leaflet-extras.github.io/leaflet-providers/preview/.
-        Be sure to check their terms and conditions and to provide attribution
-        with the `attr` keyword.
+        You can also pass a custom tileset by passing a
+        :class:`xyzservices.TileProvider` or a Leaflet-style
+        URL to the tiles parameter: ``https://{s}.yourtiles.com/{z}/{x}/{y}.png``.
     min_zoom: int, default 0
         Minimum allowed zoom level for this tile layer.
     max_zoom: int, default 18

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -33,14 +33,13 @@ class TileLayer(Layer):
             - "OpenStreetMap"
             - "CartoDB Positron"
             - "CartoDB Voyager"
-            - "NASAGIBS Blue Marble"
 
         You can pass a custom tileset to Folium by passing a
         :class:`xyzservices.TileProvider` or a Leaflet-style
         URL to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
 
         You can find a list of free tile providers here:
-        ``http://leaflet-extras.github.io/leaflet-providers/preview/``.
+        http://leaflet-extras.github.io/leaflet-providers/preview/.
         Be sure to check their terms and conditions and to provide attribution
         with the `attr` keyword.
     min_zoom: int, default 0


### PR DESCRIPTION
https://github.com/python-visualization/folium/pull/1882 was very helpful in showing that the currently listed example tileset doesn't work anymore. But the proposed replacement is not suitable unfortunately. Simply solve this issue by removing the example. If users want more examples, they can visit the site we mention: http://leaflet-extras.github.io/leaflet-providers/preview/