### PR TITLE
remove test for unused Branca get_templates()

### DIFF
--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -7,9 +7,7 @@ Folium Tests
 import json
 import os
 
-import branca.element
 import geopandas as gpd
-import jinja2
 import numpy as np
 import pandas as pd
 import pytest
@@ -42,13 +40,6 @@ def setup_data():
     # Perform an inner join, pad NA's with data from nearest county.
     merged = pd.merge(df, county_df, on="FIPS_Code", how="inner")
     return merged.fillna(method="pad")
-
-
-def test_get_templates():
-    """Test template getting."""
-
-    env = branca.utilities.get_templates()
-    assert isinstance(env, jinja2.environment.Environment)
 
 
 def test_location_args():


### PR DESCRIPTION
Some cleanup. For some reason we have a test in Folium for Branca's `get_templates()` function. That function is not used anymore inside of Branca, but even if it did, it doesn't make sense to have a test for it in Folium. So remove it. We can then remove the function it from Branca as well.