### PR TITLE
docs: mark logo as dark mode safe

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ Folium
 
 .. image:: _static/folium_logo.png
    :height: 100px
+   :class: dark-light
 
 
 Python data, leaflet.js maps


### PR DESCRIPTION
Tiny tweak to fix something that bothered me: the transparent png logo in our docs has a white background when using dark mode. Turns out the theme we use does this on purpose and expects us to mark images that are safe for dark mode: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/light-dark.html#images-and-content-that-work-in-both-themes. Do that here by adding the 'dark-light' class.

** Before **

![afbeelding](https://github.com/python-visualization/folium/assets/33519926/2cbce8a3-dfc4-42e2-8ad3-134a4a5cc2c7)

** After **

![afbeelding](https://github.com/python-visualization/folium/assets/33519926/00cf1584-9afd-475b-a925-563da4cf0627)
