### PR TITLE
Fixes styling on tag filter button

### DIFF
--- a/folium/plugins/tag_filter_button.py
+++ b/folium/plugins/tag_filter_button.py
@@ -30,6 +30,18 @@ class TagFilterButton(JSCSSMixin, MacroElement):
 
     _template = Template(
         """
+        {% macro header(this,kwargs) %}
+            <style>
+                .easy-button-button {
+                  display: block !important;
+                }
+
+                .tag-filter-tags-container {
+                  left: 30px;
+                }
+            </style>
+        {% endmacro %}
+
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.control.tagFilterButton(
                 {{ this.options|tojson }}


### PR DESCRIPTION
The original example from tagfilterbutton had some extra lines of styling in the css, that were not present in the supplied css file.

As a workaround, I copied those lines into the Folium template.

Closes #1867 