### PR TITLE
fix __geo_interface__ styling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: examples/data/|.*\.css|.*\.json|.*\.geojson|.*\.html
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast
@@ -15,12 +15,12 @@ repos:
       files: requirements-dev.txt
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.4
+  rev: v0.4.1
   hooks:
     - id: ruff
 
 - repo: https://github.com/psf/black
-  rev: 24.3.0
+  rev: 24.4.0
   hooks:
   - id: black
     language_version: python3

--- a/docs/user_guide/geojson/geojson.md
+++ b/docs/user_guide/geojson/geojson.md
@@ -237,6 +237,23 @@ colormap.add_to(m)
 m
 ```
 
+>
+> **Caveat**
+>
+> When using `style_function` in a loop you may encounter Python's 'Late Binding Closure' gotcha!
+> See https://docs.python-guide.org/writing/gotchas/#late-binding-closures for more info.
+> There are a few ways around it from using a GeoPandas object instead,
+> to "hacking" your `style_function` to force early closure, like:
+> ```python
+> for geom, my_style in zip(geoms, my_styles):
+>     style = my_style
+>     style_function = lambda x, style=style: style
+>     folium.GeoJson(
+>         data=geom,
+>         style_function=style_function,
+>     ).add_to(m)
+> ```
+
 ### Highlight function
 
 The `GeoJson` class provides a `highlight_function` argument, which works similarly

--- a/folium/features.py
+++ b/folium/features.py
@@ -643,6 +643,10 @@ class GeoJson(Layer):
                 .done({{ this.get_name() }}_add);
         {%- endif %}
 
+        {%- if not this.style %}
+        {{this.get_name()}}.setStyle(function(feature) {return feature.properties.style;});
+        {%- endif %}
+
         {% endmacro %}
         """
     )  # noqa


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/1932.

- [X] Fixes the geopandas (or any `__geo_interface__` object) styling regression.
- [x] Amend the docs with a CAVEAT regarding Late Binding Closures when using `style_function` in a loop.