### PR TITLE
repair max_zoom and max_native_zoom

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -112,10 +112,12 @@ class Map(JSCSSMixin, MacroElement):
         pass a custom URL, pass a TileLayer object,
         or pass `None` to create a map without tiles.
         For more advanced tile layer options, use the `TileLayer` class.
-    min_zoom: int, default 0
+    min_zoom: int, optional, default 0
         Minimum allowed zoom level for the tile layer that is created.
-    max_zoom: int, default 18
+        Filled by xyzservices by default.
+    max_zoom: int, optional, default 18
         Maximum allowed zoom level for the tile layer that is created.
+        Filled by xyzservices by default.
     zoom_start: int, default 10
         Initial zoom level for the map.
     attr: string, default None
@@ -244,8 +246,8 @@ class Map(JSCSSMixin, MacroElement):
         position: str = "relative",
         tiles: Union[str, TileLayer, None] = "OpenStreetMap",
         attr: Optional[str] = None,
-        min_zoom: int = 0,
-        max_zoom: int = 18,
+        min_zoom: Optional[int] = None,
+        max_zoom: Optional[int] = None,
         zoom_start: int = 10,
         min_lat: int = -90,
         max_lat: int = 90,


### PR DESCRIPTION
Fix https://github.com/python-visualization/folium/issues/1859

When we introduced xyzservices, we changed the way we handle the `max_zoom` and `max_native_zoom` arguments of `TileLayer` (and `Map`). In this PR, restore how it worked before that change, but keep using the values from xyzservices.

To do that, make `min_zoom` and `max_zoom` optional arguments with default values None. That way, when a user doesn't provide them, we can use the value from xyzservices.

When a user does provide explicit values for e.g. `max_zoom`, honor that value and don't overwrite it from xyzservices. This allows zooming past the highest native zoom level.

Fill the `max_native_zoom` option from xyzservices, unless a user provides an explicit value.

I opted to keep the defaults of 0 and 18, because those are the defaults set by Leaflet as well. This way, we make them explicit to our users.