### PR TITLE
Add Evented base class

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -35,7 +35,7 @@ Utilities
 ---------------------
 
 .. autoclass:: folium.utilities.JsCode
-.. autoclass:: folium.elements.EventTargetMixin
+.. autoclass:: folium.elements.EventHandler
 
 
 Plugins

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -35,6 +35,7 @@ Utilities
 ---------------------
 
 .. autoclass:: folium.utilities.JsCode
+.. autoclass:: folium.elements.EventTargetMixin
 
 
 Plugins

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -55,9 +55,9 @@ class EventTargetMixin(Element):
     --------
     >>> import folium
     >>> from folium.utilities import JsCode
-
+    >>>
     >>> m = folium.Map()
-
+    >>>
     >>> geo_json_data = {
     ...     "type": "FeatureCollection",
     ...     "features": [
@@ -79,8 +79,9 @@ class EventTargetMixin(Element):
     ...         }
     ...     ],
     ... }
-
+    >>>
     >>> g = folium.GeoJson(geo_json_data).add_to(m)
+    >>>
     >>> highlight = JsCode(
     ...     """
     ...    function highlight(e) {
@@ -89,6 +90,7 @@ class EventTargetMixin(Element):
     ... }
     ... """
     ... )
+    >>>
     >>> reset = JsCode(
     ...     """
     ... function reset(e) {
@@ -96,6 +98,7 @@ class EventTargetMixin(Element):
     ... }
     ... """
     ... )
+    >>>
     >>> g.on(mouseover=highlight, mouseout=reset)
     '''
 

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -50,6 +50,8 @@ class JSCSSMixin(Element):
 
 class EventHandler(MacroElement):
     '''
+    Add javascript event handlers.
+
     Examples
     --------
     >>> import folium

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -48,9 +48,8 @@ class JSCSSMixin(Element):
             default_list.append((name, url))
 
 
-class EventTargetMixin(Element):
-    '''Add Event Handlers to an element.
-
+class EventHandler(MacroElement):
+    '''
     Examples
     --------
     >>> import folium
@@ -85,34 +84,23 @@ class EventTargetMixin(Element):
     >>> highlight = JsCode(
     ...     """
     ...    function highlight(e) {
-    ...    e.target.original_color = e.layer.options.color;
-    ...    e.target.setStyle({ color: "green" });
-    ... }
+    ...        e.target.original_color = e.layer.options.color;
+    ...        e.target.setStyle({ color: "green" });
+    ...    }
     ... """
     ... )
     >>>
     >>> reset = JsCode(
     ...     """
-    ... function reset(e) {
-    ...    e.target.setStyle({ color: e.target.original_color });
-    ... }
+    ...    function reset(e) {
+    ...       e.target.setStyle({ color: e.target.original_color });
+    ...    }
     ... """
     ... )
     >>>
-    >>> g.on(mouseover=highlight, mouseout=reset)
+    >>> g.add_child(EventHandler("mouseover", highlight))
+    >>> g.add_child(EventHandler("mouseout", reset))
     '''
-
-    def on(self, **kwargs: JsCode):
-        for event, handler in kwargs.items():
-            self.add_child(EventHandler(event, handler))
-        return self
-
-    def render(self, **kwargs) -> None:
-        super().render(**kwargs)
-
-
-class EventHandler(MacroElement):
-    """Render Event Handlers."""
 
     _template = Template(
         """

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -3,6 +3,8 @@ from typing import List, Tuple
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
 from jinja2 import Template
 
+from folium.utilities import JsCode
+
 
 class JSCSSMixin(Element):
     """Render links to external Javascript and CSS resources."""
@@ -44,6 +46,87 @@ class JSCSSMixin(Element):
                 break
         else:
             default_list.append((name, url))
+
+
+class EventTargetMixin(Element):
+    '''Add Event Handlers to an element.
+
+    Examples
+    --------
+    >>> import folium
+    >>> from folium.utilities import JsCode
+
+    >>> m = folium.Map()
+
+    >>> geo_json_data = {
+    ...     "type": "FeatureCollection",
+    ...     "features": [
+    ...         {
+    ...             "type": "Feature",
+    ...             "geometry": {
+    ...                 "type": "Polygon",
+    ...                 "coordinates": [
+    ...                     [
+    ...                         [100.0, 0.0],
+    ...                         [101.0, 0.0],
+    ...                         [101.0, 1.0],
+    ...                         [100.0, 1.0],
+    ...                         [100.0, 0.0],
+    ...                     ]
+    ...                 ],
+    ...             },
+    ...             "properties": {"prop1": {"title": "Somewhere on Sumatra"}},
+    ...         }
+    ...     ],
+    ... }
+
+    >>> g = folium.GeoJson(geo_json_data).add_to(m)
+    >>> highlight = JsCode(
+    ...     """
+    ...    function highlight(e) {
+    ...    e.target.original_color = e.layer.options.color;
+    ...    e.target.setStyle({ color: "green" });
+    ... }
+    ... """
+    ... )
+    >>> reset = JsCode(
+    ...     """
+    ... function reset(e) {
+    ...    e.target.setStyle({ color: e.target.original_color });
+    ... }
+    ... """
+    ... )
+    >>> g.on(mouseover=highlight, mouseout=reset)
+    '''
+
+    def on(self, **kwargs: JsCode):
+        for event, handler in kwargs.items():
+            self.add_child(EventHandler(event, handler))
+        return self
+
+    def render(self, **kwargs) -> None:
+        super().render(**kwargs)
+
+
+class EventHandler(MacroElement):
+    """Render Event Handlers."""
+
+    _template = Template(
+        """
+        {% macro script(this, kwargs) %}
+            {{ this._parent.get_name()}}.on(
+                {{ this.event|tojson}},
+                {{ this.handler.js_code }}
+            );
+        {% endmacro %}
+        """
+    )
+
+    def __init__(self, event: str, handler: JsCode):
+        super().__init__()
+        self._name = "EventHandler"
+        self.event = event
+        self.handler = handler
 
 
 class ElementAddToElement(MacroElement):

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -7,11 +7,11 @@ import time
 import webbrowser
 from typing import Any, List, Optional, Sequence, Union
 
-from branca.element import Element, Figure, MacroElement
+from branca.element import Element, Figure
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.map import FitBounds, Layer
+from folium.map import Evented, FitBounds, Layer
 from folium.raster_layers import TileLayer
 from folium.utilities import (
     TypeBounds,
@@ -79,7 +79,7 @@ class GlobalSwitches(Element):
         self.disable_3d = disable_3d
 
 
-class Map(JSCSSMixin, MacroElement):
+class Map(JSCSSMixin, Evented):
     """Create a Map with Folium and Leaflet.js
 
     Generate a base map of given width and height with either default

--- a/folium/map.py
+++ b/folium/map.py
@@ -32,7 +32,7 @@ class Evented(MacroElement):
     method using python keyword arguments.
     """
 
-    def on(self, **event_map):
+    def on(self, **event_map: JsCode):
         for event_type, handler in event_map.items():
             self.add_child(EventHandler(event_type, handler))
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -32,9 +32,6 @@ class Evented(MacroElement):
     method using python keyword arguments.
     """
 
-    def __init__(self):
-        super().__init__()
-
     def on(self, **event_map):
         for event_type, handler in event_map.items():
             self.add_child(EventHandler(event_type, handler))

--- a/folium/map.py
+++ b/folium/map.py
@@ -12,6 +12,7 @@ from jinja2 import Template
 
 from folium.elements import ElementAddToElement, EventHandler
 from folium.utilities import (
+    JsCode,
     TypeBounds,
     TypeJsonValue,
     camelize,

--- a/folium/map.py
+++ b/folium/map.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
 from branca.element import Element, Figure, Html, MacroElement
 from jinja2 import Template
 
-from folium.elements import ElementAddToElement
+from folium.elements import ElementAddToElement, EventHandler
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
@@ -21,7 +21,26 @@ from folium.utilities import (
 )
 
 
-class Layer(MacroElement):
+class Evented(MacroElement):
+    """The base class for Layer and Map
+
+    Adds the `on` method for event handling capabilities.
+
+    See https://leafletjs.com/reference.html#evented for
+    more in depth documentation. Please note that we have
+    only added the `on(<Object> eventMap)` variant of this
+    method using python keyword arguments.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def on(self, **event_map):
+        for event_type, handler in event_map.items():
+            self.add_child(EventHandler(event_type, handler))
+
+
+class Layer(Evented):
     """An abstract class for everything that is a Layer on the map.
     It will be used to define whether an object will be included in
     LayerControls.

--- a/folium/map.py
+++ b/folium/map.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
 from branca.element import Element, Figure, Html, MacroElement
 from jinja2 import Template
 
-from folium.elements import ElementAddToElement
+from folium.elements import ElementAddToElement, EventTargetMixin
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
@@ -21,7 +21,7 @@ from folium.utilities import (
 )
 
 
-class Layer(MacroElement):
+class Layer(EventTargetMixin, MacroElement):
     """An abstract class for everything that is a Layer on the map.
     It will be used to define whether an object will be included in
     LayerControls.

--- a/folium/map.py
+++ b/folium/map.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
 from branca.element import Element, Figure, Html, MacroElement
 from jinja2 import Template
 
-from folium.elements import ElementAddToElement, EventTargetMixin
+from folium.elements import ElementAddToElement
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
@@ -21,7 +21,7 @@ from folium.utilities import (
 )
 
 
-class Layer(EventTargetMixin, MacroElement):
+class Layer(MacroElement):
     """An abstract class for everything that is a Layer on the map.
     It will be used to define whether an object will be included in
     LayerControls.

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,6 +1,5 @@
 from typing import Optional, Union
 
-from branca.element import MacroElement
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
@@ -8,7 +7,7 @@ from folium.map import Layer
 from folium.utilities import JsCode, camelize, parse_options
 
 
-class Realtime(JSCSSMixin, MacroElement):
+class Realtime(JSCSSMixin, Layer):
     """Put realtime data on a Leaflet map: live tracking GPS units,
     sensor data or just about anything.
 

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 
+from branca.element import MacroElement
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
@@ -7,7 +8,7 @@ from folium.map import Layer
 from folium.utilities import JsCode, camelize, parse_options
 
 
-class Realtime(JSCSSMixin, Layer):
+class Realtime(JSCSSMixin, MacroElement):
     """Put realtime data on a Leaflet map: live tracking GPS units,
     sensor data or just about anything.
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,6 +13,7 @@ from branca.element import Element
 
 import folium
 from folium import Choropleth, ClickForMarker, GeoJson, Map, Popup
+from folium.utilities import JsCode
 
 
 @pytest.fixture
@@ -281,6 +282,23 @@ def test_geojson_empty_features_with_styling():
     data = {"type": "FeatureCollection", "features": []}
     GeoJson(data, style_function=lambda x: {}).add_to(m)
     m.get_root().render()
+
+
+def test_geojson_event_handler():
+    """Test that event handlers are properly generated"""
+    m = Map()
+    data = {"type": "FeatureCollection", "features": []}
+    geojson = GeoJson(data, style_function=lambda x: {}).add_to(m)
+    fn = JsCode(
+        """
+        function f(e) {
+            console.log("only for testing")
+        }
+    """
+    )
+    geojson.on(mouseover=fn)
+    rendered = m.get_root().render()
+    assert fn.js_code in rendered
 
 
 def test_geometry_collection_get_bounds():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,6 +13,7 @@ from branca.element import Element
 
 import folium
 from folium import Choropleth, ClickForMarker, GeoJson, Map, Popup
+from folium.elements import EventHandler
 from folium.utilities import JsCode
 
 
@@ -296,7 +297,7 @@ def test_geojson_event_handler():
         }
     """
     )
-    geojson.on(mouseover=fn)
+    geojson.add_child(EventHandler("mouseover", fn))
     rendered = m.get_root().render()
     assert fn.js_code in rendered
 


### PR DESCRIPTION
In Leaflet `Evented` is the parent class of `Layer` and `Map`. 

It adds the `on` method, which can be used to add event handlers for the two type of Leaflet objects. In Leaflet it also adds methods to fire events and turn `off` event handlers. I did not implement those as they would be less relevant within Folium.