### PR TITLE
Correct type annotations in Realtime

### DIFF
--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -95,7 +95,7 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
         inner_icon_style="",
         spin=False,
         number=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "BeautifyIcon"
@@ -111,5 +111,5 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
             spin=spin,
             isAlphaNumericIcon=number is not None,
             text=number,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,14 +1,14 @@
 from typing import Optional, Union
 
-from branca.element import MacroElement
 from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.map import Layer
+from folium.features import GeoJson
+from folium.map import FeatureGroup
 from folium.utilities import JsCode, camelize, parse_options
 
 
-class Realtime(JSCSSMixin, MacroElement):
+class Realtime(JSCSSMixin, FeatureGroup):
     """Put realtime data on a Leaflet map: live tracking GPS units,
     sensor data or just about anything.
 
@@ -109,7 +109,7 @@ class Realtime(JSCSSMixin, MacroElement):
         get_feature_id: Union[JsCode, str, None] = None,
         update_feature: Union[JsCode, str, None] = None,
         remove_missing: bool = False,
-        container: Optional[Layer] = None,
+        container: Optional[Union[FeatureGroup, GeoJson]] = None,
         **kwargs
     ):
         super().__init__()

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -42,7 +42,7 @@ class Realtime(JSCSSMixin, FeatureGroup):
     remove_missing: bool, default False
         Should missing features between updates been automatically
         removed from the layer
-    container: Layer, default GeoJson
+    container: FeatureGroup or GeoJson, default GeoJson
         The container will typically be a `FeatureGroup`, `MarkerCluster` or
         `GeoJson`, but it can be anything that generates a javascript
         L.LayerGroup object, i.e. something that has the methods

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 branca>=0.6.0
+fiona
 jinja2>=2.9
 numpy
 requests


### PR DESCRIPTION
This PR corrects a few type annotations for the `Realtime` plugin.

1. Realtime superclass in leaflet is GeoJson (which is a subclass of featuregroup). In Folium I cannot make Realtime a subclass of GeoJson since GeoJson requires features to be present before rendering. I made it a subclass of FeatureGroup to more clearly document that features can be added to a Realtime layer.

2. The container parameter for Realtime cannot just be any `L.Layer`. It must be a `FeatureGroup` or something that allows adding features.

I created type annotations to reflect this on the Folium side.