### PR TITLE
Fix issue #1980: opened_symbol option

### DIFF
--- a/folium/plugins/treelayercontrol.py
+++ b/folium/plugins/treelayercontrol.py
@@ -151,7 +151,7 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
         super().__init__()
         self._name = "TreeLayerControl"
         kwargs["closed_symbol"] = closed_symbol
-        kwargs["openened_symbol"] = opened_symbol
+        kwargs["opened_symbol"] = opened_symbol
         kwargs["space_symbol"] = space_symbol
         kwargs["selector_back"] = selector_back
         kwargs["named_toggle"] = named_toggle


### PR DESCRIPTION
Adjusted in treelayercontrol.py

```
kwargs["openened_symbol"] = opened_symbol  
```
to be 
```
kwargs["opened_symbol"] = opened_symbol
```