### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -720,28 +720,27 @@ class GeoJson(Layer):
         if isinstance(data, dict):
             self.embed = True
             return data
-        elif isinstance(data, str):
+        if isinstance(data, str):
             if data.lower().startswith(("http:", "ftp:", "https:")):
                 if not self.embed:
                     self.embed_link = data
                 return self.get_geojson_from_web(data)
-            elif data.lstrip()[0] in "[{":  # This is a GeoJSON inline string
+            if data.lstrip()[0] in "[{":  # This is a GeoJSON inline string
                 self.embed = True
                 return json.loads(data)
-            else:  # This is a filename
-                if not self.embed:
-                    self.embed_link = data
-                with open(data) as f:
-                    return json.loads(f.read())
-        elif hasattr(data, "__geo_interface__"):
+            # This is a filename
+            if not self.embed:
+                self.embed_link = data
+            with open(data) as f:
+                return json.loads(f.read())
+        if hasattr(data, "__geo_interface__"):
             self.embed = True
             if hasattr(data, "to_crs"):
                 data = data.to_crs("EPSG:4326")
             return json.loads(json.dumps(data.__geo_interface__))
-        else:
-            raise ValueError(
-                "Cannot render objects with any missing geometries" f": {data!r}"
-            )
+        raise ValueError(
+            "Cannot render objects with any missing geometries" f": {data!r}"
+        )
 
     def get_geojson_from_web(self, url: str) -> dict:
         return requests.get(url).json()
@@ -1033,8 +1032,7 @@ class TopoJson(JSCSSMixin, Layer):
         def recursive_get(data, keys):
             if len(keys):
                 return recursive_get(data.get(keys[0]), keys[1:])
-            else:
-                return data
+            return data
 
         geometries = recursive_get(self.data, self.object_path.split("."))[
             "geometries"
@@ -1657,8 +1655,7 @@ class Choropleth(FeatureGroup):
         if len(key_parts) > 1:
             new_key = ".".join(key_parts[1:])
             return cls._get_by_key(value, new_key)
-        else:
-            return value
+        return value
 
     def render(self, **kwargs) -> None:
         """Render the GeoJson/TopoJson and color scale objects."""

--- a/folium/template.py
+++ b/folium/template.py
@@ -10,9 +10,9 @@ from folium.utilities import JsCode, TypeJsonValue, camelize
 def tojavascript(obj: Union[str, JsCode, dict, list, Element]) -> str:
     if isinstance(obj, JsCode):
         return obj.js_code
-    elif isinstance(obj, Element):
+    if isinstance(obj, Element):
         return obj.get_name()
-    elif isinstance(obj, dict):
+    if isinstance(obj, dict):
         out = ["{\n"]
         for key, value in obj.items():
             out.append(f'  "{camelize(key)}": ')
@@ -20,15 +20,14 @@ def tojavascript(obj: Union[str, JsCode, dict, list, Element]) -> str:
             out.append(",\n")
         out.append("}")
         return "".join(out)
-    elif isinstance(obj, list):
+    if isinstance(obj, list):
         out = ["[\n"]
         for value in obj:
             out.append(tojavascript(value))
             out.append(",\n")
         out.append("]")
         return "".join(out)
-    else:
-        return _to_escaped_json(obj)
+    return _to_escaped_json(obj)
 
 
 def _to_escaped_json(obj: TypeJsonValue) -> str:

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -135,9 +135,7 @@ def validate_multi_locations(
     except (TypeError, StopIteration):
         # locations is a list of coordinate pairs
         return [validate_location(coord_pair) for coord_pair in locations]  # type: ignore
-    else:
-        # locations is a list of a list of coordinate pairs, recurse
-        return [validate_locations(lst) for lst in locations]  # type: ignore
+    return [validate_locations(lst) for lst in locations]  # type: ignore
 
 
 def if_pandas_df_convert_to_numpy(obj: Any) -> Any:
@@ -148,8 +146,7 @@ def if_pandas_df_convert_to_numpy(obj: Any) -> Any:
     """
     if pd is not None and isinstance(obj, pd.DataFrame):
         return obj.values
-    else:
-        return obj
+    return obj
 
 
 def image_to_url(


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.