### PR TITLE
Add event handlers to the Draw plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 branca>=0.6.0
 jinja2>=2.9
-numpy
+numpy==1.*
 requests
 xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 branca>=0.6.0
 jinja2>=2.9
-numpy==1.*
+numpy
 requests
 xyzservices


### PR DESCRIPTION
This makes the draw plugin more dynamic. It allows the user to add `JsCode` event handlers to the generated layers.

Also removed duplicate actions for the "draw:created" event.