### PR TITLE
Py313

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -12,12 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.12"]
-        experimental: [false]
-        include:
-          - python-version: "3.12"
-            os: "ubuntu-latest"
-            experimental: true
+        python-version: ["3.9", "3.13"]
       fail-fast: false
     defaults:
       run:
@@ -34,10 +29,6 @@ jobs:
           python=${{ matrix.python-version }}
           --file requirements.txt
           --file requirements-dev.txt
-
-    - name: Install nightly versions of dependencies
-      if: matrix.experimental == true
-      run: python -m pip install --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple numpy pandas shapely -U
 
     - name: Install folium from source
       run: python -m pip install -e . --no-deps --force-reinstall

--- a/.github/workflows/test_selenium.yml
+++ b/.github/workflows/test_selenium.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.12" ]
+        python-version: [ "3.9", "3.13" ]
       fail-fast: false
 
     steps:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ nbconvert
 nbsphinx
 nbval
 owslib
-pandas
+pandas >=2
 pillow
 pre-commit
 pycodestyle
@@ -33,7 +33,6 @@ scipy
 selenium
 setuptools_scm
 sphinx
-twine>=3.2.0
 types-requests
 vega_datasets
 vincent

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,11 @@ setup(
     url="https://github.com/python-visualization/folium",
     keywords="data visualization",
     classifiers=[
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Scientific/Engineering :: Visualization",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
We don't need `twine` in the `requirements-dev.txt` filem in fact, if we move to more pre-commits checks, we can remove even more dependencies listed in that file. I also removed the experimental tests, we no longer need them.

This PR should pass in a few hours as soon as jenkspy is available in the conda-forge channel.

xref.: https://github.com/conda-forge/jenkspy-feedstock/pull/31