### PR TITLE
Publish docs with Py3.12 for now

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,8 +31,9 @@ jobs:
       with:
         environment-name: TEST
         init-shell: bash
+        # use '3.12' for now while Altair is not 3.13 compatible. Revert to '3' when it is.
         create-args: >-
-          python=3
+          python=3.12
           --file requirements.txt
           --file requirements-dev.txt
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,7 +31,6 @@ jobs:
       with:
         environment-name: TEST
         init-shell: bash
-        # use '3.12' for now while Altair is not 3.13 compatible. Revert to '3' when it is.
         create-args: >-
           python=3.12
           --file requirements.txt


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/2016, Altair package is not working with Py3.13 yet.