### PR TITLE
Fix docs versioning relating to "v" prefix

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,9 +4,13 @@
     "url": "https://python-visualization.github.io/folium/dev/"
   },
   {
-    "name": "latest (0.17.0)",
-    "version": "0.17.0",
+    "name": "latest (0.18.0)",
+    "version": "0.18.0",
     "url": "https://python-visualization.github.io/folium/latest/"
+  },
+  {
+    "version": "0.17.0",
+    "url": "https://python-visualization.github.io/folium/v0.17.0/"
   },
   {
     "version": "0.16.0",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,60 +4,60 @@
     "url": "https://python-visualization.github.io/folium/dev/"
   },
   {
-    "name": "latest (v0.17.0)",
+    "name": "latest (0.17.0)",
     "version": "latest",
     "url": "https://python-visualization.github.io/folium/latest/"
   },
   {
-    "version": "v0.16.0",
+    "version": "0.16.0",
     "url": "https://python-visualization.github.io/folium/v0.16.0/"
   },
   {
-    "version": "v0.15.1",
+    "version": "0.15.1",
     "url": "https://python-visualization.github.io/folium/v0.15.1/"
   },
   {
-    "version": "v0.14.0",
+    "version": "0.14.0",
     "url": "https://python-visualization.github.io/folium/version-v0.14.0/"
   },
   {
-    "version": "v0.12.1",
+    "version": "0.12.1",
     "url": "https://python-visualization.github.io/folium/version-v0.12.1/"
   },
   {
-    "version": "v0.12.0",
+    "version": "0.12.0",
     "url": "https://python-visualization.github.io/folium/version-v0.12.0/"
   },
   {
-    "version": "v0.11.0",
+    "version": "0.11.0",
     "url": "https://python-visualization.github.io/folium/version-v0.11.0/"
   },
   {
-    "version": "v0.10.1",
+    "version": "0.10.1",
     "url": "https://python-visualization.github.io/folium/version-v0.10.1/"
   },
   {
-    "version": "v0.10.0",
+    "version": "0.10.0",
     "url": "https://python-visualization.github.io/folium/version-v0.10.0/"
   },
   {
-    "version": "v0.9.1",
+    "version": "0.9.1",
     "url": "https://python-visualization.github.io/folium/version-v0.9.1/"
   },
   {
-    "version": "v0.9.0",
+    "version": "0.9.0",
     "url": "https://python-visualization.github.io/folium/version-v0.9.0/"
   },
   {
-    "version": "v0.8.3",
+    "version": "0.8.3",
     "url": "https://python-visualization.github.io/folium/version-v0.8.3/"
   },
   {
-    "version": "v0.8.2",
+    "version": "0.8.2",
     "url": "https://python-visualization.github.io/folium/version-v0.8.2/"
   },
   {
-    "version": "v0.8.1",
+    "version": "0.8.1",
     "url": "https://python-visualization.github.io/folium/version-v0.8.1/"
   }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -5,7 +5,7 @@
   },
   {
     "name": "latest (0.17.0)",
-    "version": "latest",
+    "version": "0.17.0",
     "url": "https://python-visualization.github.io/folium/latest/"
   },
   {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ copyright = f"2013-{year}, Rob Story"
 
 import folium
 
+# N.B. this version is without the "v" prefix
 version = release = folium.__version__
 print(f"Version: {version}")
 

--- a/docs/update_switcher.py
+++ b/docs/update_switcher.py
@@ -29,7 +29,9 @@ def main():
             latest_index = i
             previous_version = version["version"]
             if previous_version == new_version_without_prefix:
-                print(f"Version {new_version_without_prefix} already is the latest version. Exiting.")
+                print(
+                    f"Version {new_version_without_prefix} already is the latest version. Exiting."
+                )
                 return
 
             # now replace the name and version of this one with the new version

--- a/docs/update_switcher.py
+++ b/docs/update_switcher.py
@@ -6,7 +6,6 @@ the list of versions and sets the latest version to the new version.
 import argparse
 import json
 import os
-import re
 
 
 def main():

--- a/docs/update_switcher.py
+++ b/docs/update_switcher.py
@@ -16,6 +16,8 @@ def main():
         "--version", "-v", required=True, type=str, help="The new version to add"
     )
     args = parser.parse_args()
+    # drop the "v" prefix
+    new_version_without_prefix = args.version[1:]
 
     # Setup path to switcher.json (relative to this script) and load it
     switcher_path = os.path.join(os.path.dirname(__file__), "_static", "switcher.json")
@@ -24,17 +26,16 @@ def main():
 
     # first we get the version number of the previous version
     for i, version in enumerate(switcher):
-        if version["version"] == "latest":
+        if version.get("name", "").startswith("latest"):
             latest_index = i
-            previous_version = re.search(
-                r"latest \(([v.\d]+)\)", version["name"]
-            ).group(1)
-            if previous_version == args.version:
-                print(f"Version {args.version} already is the latest version. Exiting.")
+            previous_version = version["version"]
+            if previous_version == new_version_without_prefix:
+                print(f"Version {new_version_without_prefix} already is the latest version. Exiting.")
                 return
 
-            # now replace the name of this one with the new version
-            switcher[i]["name"] = f"latest ({args.version})"
+            # now replace the name and version of this one with the new version
+            switcher[i]["name"] = f"latest ({new_version_without_prefix})"
+            switcher[i]["version"] = new_version_without_prefix
             break
     else:
         raise ValueError("'latest' version not found in switcher.json")
@@ -47,7 +48,7 @@ def main():
     else:
         previous_version_entry = {
             "version": previous_version,
-            "url": f"https://python-visualization.github.io/folium/{previous_version}/",
+            "url": f"https://python-visualization.github.io/folium/v{previous_version}/",
         }
         switcher.insert(latest_index + 1, previous_version_entry)
 


### PR DESCRIPTION
Some more tweaks to our docs versioning and the version switcher. Main issue is a mismatch in how the version is put into a string: whether a "v" prefix is included or not. In the git tag we include a "v" prefix, but in `folium.__version__` we don't have that prefix.

In the new situation:
- the git tag will include a `v` prefix
- the folder in `gh-pages` will include a `v` prefix
- all other places are without that prefix

This change is already live on the `gh-pages` branch, including the manually created docs for v0.18.0.