### PR TITLE
Issue 1943 allow jscode in options

### DIFF
--- a/folium/elements.py
+++ b/folium/elements.py
@@ -1,8 +1,8 @@
 from typing import List, Tuple
 
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
-from jinja2 import Template
 
+from folium.template import Template
 from folium.utilities import JsCode
 
 

--- a/folium/features.py
+++ b/folium/features.py
@@ -663,7 +663,7 @@ class GeoJson(Layer):
         popup: Optional["GeoJsonPopup"] = None,
         zoom_on_click: bool = False,
         marker: Union[Circle, CircleMarker, Marker, None] = None,
-        **kwargs: TypeJsonValue,
+        **kwargs: Any,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "GeoJson"

--- a/folium/features.py
+++ b/folium/features.py
@@ -14,17 +14,16 @@ import requests
 from branca.colormap import ColorMap, LinearColormap, StepColormap
 from branca.element import Element, Figure, Html, IFrame, JavascriptLink, MacroElement
 from branca.utilities import color_brewer
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import FeatureGroup, Icon, Layer, Marker, Popup, Tooltip
+from folium.template import Template
 from folium.utilities import (
     TypeJsonValue,
     TypeLine,
     TypePathOptions,
     _parse_size,
-    camelize,
     escape_backticks,
     get_bounds,
     get_obj_in_upper_tree,
@@ -32,7 +31,6 @@ from folium.utilities import (
     javascript_identifier_path_to_array_notation,
     none_max,
     none_min,
-    parse_options,
     validate_locations,
 )
 from folium.vector_layers import Circle, CircleMarker, PolyLine, path_options
@@ -68,7 +66,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.RegularPolygonMarker(
                 {{ this.location|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
@@ -95,7 +93,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
         self._name = "RegularPolygonMarker"
         self.options = path_options(line=False, radius=radius, **kwargs)
         self.options.update(
-            parse_options(
+            dict(
                 number_of_sides=number_of_sides,
                 rotation=rotation,
             )
@@ -627,9 +625,7 @@ class GeoJson(Layer):
             {%- if this.marker %}
                 pointToLayer: {{ this.get_name() }}_pointToLayer,
             {%- endif %}
-            {%- for key, value in this.options.items() %}
-                {{ key }}: {{ value|tojson }},
-            {%- endfor %}
+            ...{{this.options | tojavascript }}
         });
 
         function {{ this.get_name() }}_add (data) {
@@ -692,7 +688,7 @@ class GeoJson(Layer):
         self.popup_keep_highlighted = popup_keep_highlighted
 
         self.marker = marker
-        self.options = parse_options(**kwargs)
+        self.options = kwargs
 
         self.data = self.process_data(data)
 
@@ -1267,7 +1263,7 @@ class GeoJsonTooltip(GeoJsonDetail):
     {% macro script(this, kwargs) %}
     {{ this._parent.get_name() }}.bindTooltip("""
         + GeoJsonDetail.base_template
-        + """,{{ this.tooltip_options | tojson | safe }});
+        + """,{{ this.tooltip_options | tojavascript }});
                      {% endmacro %}
                      """
     )
@@ -1293,7 +1289,7 @@ class GeoJsonTooltip(GeoJsonDetail):
         )
         self._name = "GeoJsonTooltip"
         kwargs.update({"sticky": sticky, "class_name": class_name})
-        self.tooltip_options = {camelize(key): kwargs[key] for key in kwargs.keys()}
+        self.tooltip_options = kwargs
 
 
 class GeoJsonPopup(GeoJsonDetail):
@@ -1335,7 +1331,7 @@ class GeoJsonPopup(GeoJsonDetail):
     {% macro script(this, kwargs) %}
     {{ this._parent.get_name() }}.bindPopup("""
         + GeoJsonDetail.base_template
-        + """,{{ this.popup_options | tojson | safe }});
+        + """,{{ this.popup_options | tojavascript }});
                      {% endmacro %}
                      """
     )
@@ -1360,7 +1356,7 @@ class GeoJsonPopup(GeoJsonDetail):
         )
         self._name = "GeoJsonPopup"
         kwargs.update({"class_name": self.class_name})
-        self.popup_options = {camelize(key): value for key, value in kwargs.items()}
+        self.popup_options = kwargs
 
 
 class Choropleth(FeatureGroup):
@@ -1703,7 +1699,7 @@ class DivIcon(MacroElement):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-            var {{ this.get_name() }} = L.divIcon({{ this.options|tojson }});
+            var {{ this.get_name() }} = L.divIcon({{ this.options|tojavascript }});
             {{this._parent.get_name()}}.setIcon({{this.get_name()}});
         {% endmacro %}
         """
@@ -1719,7 +1715,7 @@ class DivIcon(MacroElement):
     ):
         super().__init__()
         self._name = "DivIcon"
-        self.options = parse_options(
+        self.options = dict(
             html=html,
             icon_size=icon_size,
             icon_anchor=icon_anchor,
@@ -1880,7 +1876,7 @@ class CustomIcon(Icon):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-        var {{ this.get_name() }} = L.icon({{ this.options|tojson }});
+        var {{ this.get_name() }} = L.icon({{ this.options|tojavascript }});
         {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
@@ -1898,7 +1894,7 @@ class CustomIcon(Icon):
     ):
         super(Icon, self).__init__()
         self._name = "CustomIcon"
-        self.options = parse_options(
+        self.options = dict(
             icon_url=image_to_url(icon_image),
             icon_size=icon_size,
             icon_anchor=icon_anchor,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -8,17 +8,16 @@ import webbrowser
 from typing import Any, List, Optional, Sequence, Union
 
 from branca.element import Element, Figure
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import Evented, FitBounds, Layer
 from folium.raster_layers import TileLayer
+from folium.template import Template
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
     _parse_size,
     parse_font_size,
-    parse_options,
     temp_html_filepath,
     validate_location,
 )
@@ -204,9 +203,8 @@ class Map(JSCSSMixin, Evented):
                 {
                     center: {{ this.location|tojson }},
                     crs: L.CRS.{{ this.crs }},
-                    {%- for key, value in this.options.items() %}
-                    {{ key }}: {{ value|tojson }},
-                    {%- endfor %}
+                    ...{{this.options|tojavascript}}
+
                 }
             );
 
@@ -305,7 +303,7 @@ class Map(JSCSSMixin, Evented):
         else:
             self.zoom_control_position = False
 
-        self.options = parse_options(
+        self.options = dict(
             max_bounds=max_bounds_array,
             zoom=zoom_start,
             zoom_control=False if self.zoom_control_position else zoom_control,

--- a/folium/plugins/antpath.py
+++ b/folium/plugins/antpath.py
@@ -1,6 +1,5 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
+from folium.template import Template
 from folium.vector_layers import BaseMultiLocation, path_options
 
 
@@ -31,7 +30,7 @@ class AntPath(JSCSSMixin, BaseMultiLocation):
         {% macro script(this, kwargs) %}
             {{ this.get_name() }} = L.polyline.antPath(
               {{ this.locations|tojson }},
-              {{ this.options|tojson }}
+              {{ this.options|tojavascript }}
         ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class BeautifyIcon(JSCSSMixin, MacroElement):
@@ -56,7 +55,7 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.BeautifyIcon.icon(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             )
             {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
@@ -100,7 +99,7 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
         super().__init__()
         self._name = "BeautifyIcon"
 
-        self.options = parse_options(
+        self.options = dict(
             icon=icon,
             icon_shape=icon_shape,
             border_width=border_width,

--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -94,7 +94,7 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
         inner_icon_style="",
         spin=False,
         number=None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "BeautifyIcon"
@@ -110,5 +110,5 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
             spin=spin,
             isAlphaNumericIcon=number is not None,
             text=number,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -1,8 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Marker
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class BoatMarker(JSCSSMixin, Marker):
@@ -30,7 +28,7 @@ class BoatMarker(JSCSSMixin, Marker):
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.boatMarker(
                 {{ this.location|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             ).addTo({{ this._parent.get_name() }});
             {% if this.wind_heading is not none -%}
             {{ this.get_name() }}.setHeadingWind(
@@ -67,4 +65,4 @@ class BoatMarker(JSCSSMixin, Marker):
         self.heading = heading
         self.wind_heading = wind_heading
         self.wind_speed = wind_speed
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)

--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -1,7 +1,7 @@
 from branca.element import Element, Figure, MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class Draw(JSCSSMixin, MacroElement):

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -1,9 +1,9 @@
 from branca.element import Figure, MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
 from folium.map import LayerControl
+from folium.template import Template
 from folium.utilities import deep_copy
 
 

--- a/folium/plugins/encoded.py
+++ b/folium/plugins/encoded.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import MacroElement
+from folium.template import Template
 from folium.vector_layers import path_options
 
 
@@ -28,7 +27,7 @@ class _BaseFromEncoded(JSCSSMixin, MacroElement, ABC):
 
             var {{ this.get_name() }} = L.{{ this._encoding_type }}.fromEncoded(
                 {{ this.encoded|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             ).addTo({{ this._parent.get_name() }});
 
         {% endmacro %}

--- a/folium/plugins/fast_marker_cluster.py
+++ b/folium/plugins/fast_marker_cluster.py
@@ -1,6 +1,5 @@
-from jinja2 import Template
-
 from folium.plugins.marker_cluster import MarkerCluster
+from folium.template import Template
 from folium.utilities import if_pandas_df_convert_to_numpy, validate_location
 
 
@@ -50,7 +49,7 @@ class FastMarkerCluster(MarkerCluster):
                 {{ this.callback }}
 
                 var data = {{ this.data|tojson }};
-                var cluster = L.markerClusterGroup({{ this.options|tojson }});
+                var cluster = L.markerClusterGroup({{ this.options|tojavascript }});
                 {%- if this.icon_create_function is not none %}
                 cluster.options.iconCreateFunction =
                     {{ this.icon_create_function.strip() }};

--- a/folium/plugins/feature_group_sub_group.py
+++ b/folium/plugins/feature_group_sub_group.py
@@ -1,7 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 
 
 class FeatureGroupSubGroup(JSCSSMixin, Layer):

--- a/folium/plugins/float_image.py
+++ b/folium/plugins/float_image.py
@@ -1,5 +1,6 @@
 from branca.element import MacroElement
-from jinja2 import Template
+
+from folium.template import Template
 
 
 class FloatImage(MacroElement):

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class Fullscreen(JSCSSMixin, MacroElement):
@@ -31,7 +30,7 @@ class Fullscreen(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             L.control.fullscreen(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
@@ -56,14 +55,14 @@ class Fullscreen(JSCSSMixin, MacroElement):
         title="Full Screen",
         title_cancel="Exit Full Screen",
         force_separate_button=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Fullscreen"
-        self.options = parse_options(
+        self.options = dict(
             position=position,
             title=title,
             title_cancel=title_cancel,
             force_separate_button=force_separate_button,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -55,7 +55,7 @@ class Fullscreen(JSCSSMixin, MacroElement):
         title="Full Screen",
         title_cancel="Exit Full Screen",
         force_separate_button=False,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "Fullscreen"
@@ -64,5 +64,5 @@ class Fullscreen(JSCSSMixin, MacroElement):
             title=title,
             title_cancel=title_cancel,
             force_separate_button=force_separate_button,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class Geocoder(JSCSSMixin, MacroElement):
@@ -36,7 +35,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
 
-            var geocoderOpts_{{ this.get_name() }} = {{ this.options|tojson }};
+            var geocoderOpts_{{ this.get_name() }} = {{ this.options|tojavascript }};
 
             // note: geocoder name should start with lowercase
             var geocoderName_{{ this.get_name() }} = geocoderOpts_{{ this.get_name() }}["provider"];
@@ -78,16 +77,16 @@ class Geocoder(JSCSSMixin, MacroElement):
         zoom: Optional[int] = 11,
         provider: str = "nominatim",
         provider_options: dict = {},
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Geocoder"
-        self.options = parse_options(
+        self.options = dict(
             collapsed=collapsed,
             position=position,
             default_mark_geocode=add_marker,
             zoom=zoom,
             provider=provider,
             provider_options=provider_options,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -77,7 +77,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         zoom: Optional[int] = 11,
         provider: str = "nominatim",
         provider_options: dict = {},
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "Geocoder"
@@ -88,5 +88,5 @@ class Geocoder(JSCSSMixin, MacroElement):
             zoom=zoom,
             provider=provider,
             provider_options=provider_options,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/groupedlayercontrol.py
+++ b/folium/plugins/groupedlayercontrol.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class GroupedLayerControl(JSCSSMixin, MacroElement):
@@ -55,7 +54,7 @@ class GroupedLayerControl(JSCSSMixin, MacroElement):
                     },
                     {%- endfor %}
                 },
-                {{ this.options|tojson }},
+                {{ this.options|tojavascript }},
             ).addTo({{this._parent.get_name()}});
 
             {%- for val in this.layers_untoggle %}
@@ -69,7 +68,7 @@ class GroupedLayerControl(JSCSSMixin, MacroElement):
     def __init__(self, groups, exclusive_groups=True, **kwargs):
         super().__init__()
         self._name = "GroupedLayerControl"
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
         if exclusive_groups:
             self.options["exclusiveGroups"] = list(groups.keys())
         self.layers_untoggle = set()

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -73,7 +73,7 @@ class HeatMap(JSCSSMixin, Layer):
         overlay=True,
         control=True,
         show=True,
-        **kwargs,
+        **kwargs
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "HeatMap"
@@ -95,7 +95,7 @@ class HeatMap(JSCSSMixin, Layer):
             radius=radius,
             blur=blur,
             gradient=gradient,
-            **kwargs,
+            **kwargs
         )
 
     def _get_self_bounds(self):

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -1,15 +1,14 @@
 import warnings
 
 import numpy as np
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import (
     if_pandas_df_convert_to_numpy,
     none_max,
     none_min,
-    parse_options,
     validate_location,
 )
 
@@ -49,7 +48,7 @@ class HeatMap(JSCSSMixin, Layer):
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.heatLayer(
                 {{ this.data|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
         {% endmacro %}
         """
@@ -74,7 +73,7 @@ class HeatMap(JSCSSMixin, Layer):
         overlay=True,
         control=True,
         show=True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "HeatMap"
@@ -90,13 +89,13 @@ class HeatMap(JSCSSMixin, Layer):
                 "The largest intensity is calculated automatically.",
                 stacklevel=2,
             )
-        self.options = parse_options(
+        self.options = dict(
             min_opacity=min_opacity,
             max_zoom=max_zoom,
             radius=radius,
             blur=blur,
             gradient=gradient,
-            **kwargs
+            **kwargs,
         )
 
     def _get_self_bounds(self):

--- a/folium/plugins/heat_map_withtime.py
+++ b/folium/plugins/heat_map_withtime.py
@@ -1,8 +1,8 @@
 from branca.element import Element, Figure
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import none_max, none_min
 
 

--- a/folium/plugins/locate_control.py
+++ b/folium/plugins/locate_control.py
@@ -4,10 +4,9 @@ Based on leaflet plugin: https://github.com/domoritz/leaflet-locatecontrol
 """
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class LocateControl(JSCSSMixin, MacroElement):
@@ -74,4 +73,4 @@ class LocateControl(JSCSSMixin, MacroElement):
         super().__init__()
         self._name = "LocateControl"
         self.auto_start = auto_start
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -86,7 +86,7 @@ class MarkerCluster(JSCSSMixin, Layer):
         show=True,
         icon_create_function=None,
         options=None,
-        **kwargs,
+        **kwargs
     ):
         if options is not None:
             kwargs.update(options)  # options argument is legacy

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -1,8 +1,7 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer, Marker
-from folium.utilities import parse_options, validate_locations
+from folium.template import Template
+from folium.utilities import validate_locations
 
 
 class MarkerCluster(JSCSSMixin, Layer):
@@ -48,7 +47,7 @@ class MarkerCluster(JSCSSMixin, Layer):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.markerClusterGroup(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {%- if this.icon_create_function is not none %}
             {{ this.get_name() }}.options.iconCreateFunction =
@@ -87,7 +86,7 @@ class MarkerCluster(JSCSSMixin, Layer):
         show=True,
         icon_create_function=None,
         options=None,
-        **kwargs
+        **kwargs,
     ):
         if options is not None:
             kwargs.update(options)  # options argument is legacy
@@ -103,7 +102,7 @@ class MarkerCluster(JSCSSMixin, Layer):
                     )
                 )
 
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
         if icon_create_function is not None:
             assert isinstance(icon_create_function, str)
         self.icon_create_function = icon_create_function

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -67,7 +67,7 @@ class MeasureControl(JSCSSMixin, MacroElement):
         secondary_length_unit="miles",
         primary_area_unit="sqmeters",
         secondary_area_unit="acres",
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "MeasureControl"
@@ -78,5 +78,5 @@ class MeasureControl(JSCSSMixin, MacroElement):
             secondary_length_unit=secondary_length_unit,
             primary_area_unit=primary_area_unit,
             secondary_area_unit=secondary_area_unit,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class MeasureControl(JSCSSMixin, MacroElement):
@@ -25,7 +24,7 @@ class MeasureControl(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.Control.Measure(
-                {{ this.options|tojson }});
+                {{ this.options|tojavascript }});
             {{this._parent.get_name()}}.addControl({{this.get_name()}});
 
             // Workaround for using this plugin with Leaflet>=1.8.0
@@ -68,16 +67,16 @@ class MeasureControl(JSCSSMixin, MacroElement):
         secondary_length_unit="miles",
         primary_area_unit="sqmeters",
         secondary_area_unit="acres",
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MeasureControl"
 
-        self.options = parse_options(
+        self.options = dict(
             position=position,
             primary_length_unit=primary_length_unit,
             secondary_length_unit=secondary_length_unit,
             primary_area_unit=primary_area_unit,
             secondary_area_unit=secondary_area_unit,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -1,9 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.raster_layers import TileLayer
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class MiniMap(JSCSSMixin, MacroElement):
@@ -68,7 +67,7 @@ class MiniMap(JSCSSMixin, MacroElement):
             );
             var {{ this.get_name() }} = new L.Control.MiniMap(
                 {{ this.tile_layer.get_name() }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {{ this._parent.get_name() }}.addControl({{ this.get_name() }});
         {% endmacro %}
@@ -103,7 +102,7 @@ class MiniMap(JSCSSMixin, MacroElement):
         toggle_display=False,
         auto_toggle_display=False,
         minimized=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MiniMap"
@@ -115,7 +114,7 @@ class MiniMap(JSCSSMixin, MacroElement):
         else:
             self.tile_layer = TileLayer(tile_layer)
 
-        self.options = parse_options(
+        self.options = dict(
             position=position,
             width=width,
             height=height,
@@ -128,5 +127,5 @@ class MiniMap(JSCSSMixin, MacroElement):
             toggle_display=toggle_display,
             auto_toggle_display=auto_toggle_display,
             minimized=minimized,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -102,7 +102,7 @@ class MiniMap(JSCSSMixin, MacroElement):
         toggle_display=False,
         auto_toggle_display=False,
         minimized=False,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "MiniMap"
@@ -127,5 +127,5 @@ class MiniMap(JSCSSMixin, MacroElement):
             toggle_display=toggle_display,
             auto_toggle_display=auto_toggle_display,
             minimized=minimized,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -82,7 +82,7 @@ class MousePosition(JSCSSMixin, MacroElement):
         prefix="",
         lat_formatter=None,
         lng_formatter=None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "MousePosition"
@@ -94,7 +94,7 @@ class MousePosition(JSCSSMixin, MacroElement):
             lng_first=lng_first,
             num_digits=num_digits,
             prefix=prefix,
-            **kwargs,
+            **kwargs
         )
         self.lat_formatter = lat_formatter or "undefined"
         self.lng_formatter = lng_formatter or "undefined"

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class MousePosition(JSCSSMixin, MacroElement):
@@ -49,7 +48,7 @@ class MousePosition(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.Control.MousePosition(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {{ this.get_name() }}.options["latFormatter"] =
                 {{ this.lat_formatter }};
@@ -83,19 +82,19 @@ class MousePosition(JSCSSMixin, MacroElement):
         prefix="",
         lat_formatter=None,
         lng_formatter=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MousePosition"
 
-        self.options = parse_options(
+        self.options = dict(
             position=position,
             separator=separator,
             empty_string=empty_string,
             lng_first=lng_first,
             num_digits=num_digits,
             prefix=prefix,
-            **kwargs
+            **kwargs,
         )
         self.lat_formatter = lat_formatter or "undefined"
         self.lng_formatter = lng_formatter or "undefined"

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -55,7 +55,7 @@ class StripePattern(JSCSSMixin, MacroElement):
         space_color="#ffffff",
         opacity=0.75,
         space_opacity=0.0,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "StripePattern"
@@ -67,7 +67,7 @@ class StripePattern(JSCSSMixin, MacroElement):
             space_color=space_color,
             opacity=opacity,
             space_opacity=space_opacity,
-            **kwargs,
+            **kwargs
         )
         self.parent_map = None
 

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -1,9 +1,9 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
-from folium.utilities import get_obj_in_upper_tree, parse_options
+from folium.template import Template
+from folium.utilities import get_obj_in_upper_tree
 
 
 class StripePattern(JSCSSMixin, MacroElement):
@@ -35,7 +35,7 @@ class StripePattern(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = new L.StripePattern(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {{ this.get_name() }}.addTo({{ this.parent_map.get_name() }});
         {% endmacro %}
@@ -55,11 +55,11 @@ class StripePattern(JSCSSMixin, MacroElement):
         space_color="#ffffff",
         opacity=0.75,
         space_opacity=0.0,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "StripePattern"
-        self.options = parse_options(
+        self.options = dict(
             angle=angle,
             weight=weight,
             space_weight=space_weight,
@@ -67,7 +67,7 @@ class StripePattern(JSCSSMixin, MacroElement):
             space_color=space_color,
             opacity=opacity,
             space_opacity=space_opacity,
-            **kwargs
+            **kwargs,
         )
         self.parent_map = None
 
@@ -107,10 +107,10 @@ class CirclePattern(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }}_shape = new L.PatternCircle(
-                {{ this.options_pattern_circle|tojson }}
+                {{ this.options_pattern_circle|tojavascript }}
             );
             var {{ this.get_name() }} = new L.Pattern(
-                {{ this.options_pattern|tojson }}
+                {{ this.options_pattern|tojavascript }}
             );
             {{ this.get_name() }}.addShape({{ this.get_name() }}_shape);
             {{ this.get_name() }}.addTo({{ this.parent_map }});
@@ -135,7 +135,7 @@ class CirclePattern(JSCSSMixin, MacroElement):
     ):
         super().__init__()
         self._name = "CirclePattern"
-        self.options_pattern_circle = parse_options(
+        self.options_pattern_circle = dict(
             x=radius + 2 * weight,
             y=radius + 2 * weight,
             weight=weight,
@@ -146,7 +146,7 @@ class CirclePattern(JSCSSMixin, MacroElement):
             fill_opacity=fill_opacity,
             fill=True,
         )
-        self.options_pattern = parse_options(
+        self.options_pattern = dict(
             width=width,
             height=height,
         )

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -61,7 +61,7 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
         offset=0,
         orientation=0,
         attributes=None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "PolyLineTextPath"
@@ -74,5 +74,5 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
             offset=offset,
             orientation=orientation,
             attributes=attributes,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -1,8 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import MacroElement
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class PolyLineTextPath(JSCSSMixin, MacroElement):
@@ -40,7 +38,7 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
         {% macro script(this, kwargs) %}
             {{ this.polyline.get_name() }}.setText(
                 {{ this.text|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
         {% endmacro %}
         """
@@ -63,18 +61,18 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
         offset=0,
         orientation=0,
         attributes=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "PolyLineTextPath"
         self.polyline = polyline
         self.text = text
-        self.options = parse_options(
+        self.options = dict(
             repeat=repeat,
             center=center,
             below=below,
             offset=offset,
             orientation=orientation,
             attributes=attributes,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -100,7 +100,7 @@ class Realtime(JSCSSMixin, FeatureGroup):
         update_feature: Union[JsCode, str, None] = None,
         remove_missing: bool = False,
         container: Optional[Union[FeatureGroup, GeoJson]] = None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "Realtime"

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -1,11 +1,10 @@
 from typing import Optional, Union
 
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import GeoJson
 from folium.map import FeatureGroup
-from folium.utilities import JsCode, camelize, parse_options
+from folium.template import Template
+from folium.utilities import JsCode
 
 
 class Realtime(JSCSSMixin, FeatureGroup):
@@ -70,26 +69,17 @@ class Realtime(JSCSSMixin, FeatureGroup):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-            var {{ this.get_name() }}_options = {{ this.options|tojson }};
-            {% for key, value in this.functions.items() %}
-            {{ this.get_name() }}_options["{{key}}"] = {{ value }};
-            {% endfor %}
-
-            {% if this.container -%}
-                {{ this.get_name() }}_options["container"]
-                    = {{ this.container.get_name() }};
-            {% endif -%}
-
             var {{ this.get_name() }} = L.realtime(
             {% if this.src is string or this.src is mapping -%}
                 {{ this.src|tojson }},
             {% else -%}
                 {{ this.src.js_code }},
             {% endif -%}
-                {{ this.get_name() }}_options
+                {{ this.options | tojavascript }}
             );
             {{ this._parent.get_name() }}.addLayer(
-                {{ this.get_name() }}._container);
+                {{ this.get_name() }}._container
+            );
         {% endmacro %}
     """
     )
@@ -110,12 +100,11 @@ class Realtime(JSCSSMixin, FeatureGroup):
         update_feature: Union[JsCode, str, None] = None,
         remove_missing: bool = False,
         container: Optional[Union[FeatureGroup, GeoJson]] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Realtime"
         self.src = source
-        self.container = container
 
         kwargs["start"] = start
         kwargs["interval"] = interval
@@ -124,12 +113,6 @@ class Realtime(JSCSSMixin, FeatureGroup):
         if update_feature is not None:
             kwargs["update_feature"] = JsCode(update_feature)
         kwargs["remove_missing"] = remove_missing
+        kwargs["container"] = container
 
-        # extract JsCode objects
-        self.functions = {}
-        for key, value in list(kwargs.items()):
-            if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value.js_code
-                kwargs.pop(key)
-
-        self.options = parse_options(**kwargs)
+        self.options = kwargs

--- a/folium/plugins/scroll_zoom_toggler.py
+++ b/folium/plugins/scroll_zoom_toggler.py
@@ -1,5 +1,6 @@
 from branca.element import MacroElement
-from jinja2 import Template
+
+from folium.template import Template
 
 
 class ScrollZoomToggler(MacroElement):

--- a/folium/plugins/search.py
+++ b/folium/plugins/search.py
@@ -1,11 +1,10 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium import Map
 from folium.elements import JSCSSMixin
 from folium.features import FeatureGroup, GeoJson, TopoJson
 from folium.plugins import MarkerCluster
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class Search(JSCSSMixin, MacroElement):
@@ -69,7 +68,7 @@ class Search(JSCSSMixin, MacroElement):
                         return feature.properties.style
                     })
                     {% if this.options %}
-                    e.layer.setStyle({{ this.options|tojson }});
+                    e.layer.setStyle({{ this.options|tojavascript }});
                     {% endif %}
                     if(e.layer._popup)
                         e.layer.openPopup();
@@ -122,7 +121,7 @@ class Search(JSCSSMixin, MacroElement):
         self.position = position
         self.placeholder = placeholder
         self.collapsed = collapsed
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
 
     def test_params(self, keys):
         if keys is not None and self.search_label is not None:

--- a/folium/plugins/semicircle.py
+++ b/folium/plugins/semicircle.py
@@ -66,7 +66,7 @@ class SemiCircle(JSCSSMixin, Marker):
         stop_angle=None,
         popup=None,
         tooltip=None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "SemiCircle"

--- a/folium/plugins/semicircle.py
+++ b/folium/plugins/semicircle.py
@@ -1,8 +1,6 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Marker
-from folium.utilities import parse_options
+from folium.template import Template
 from folium.vector_layers import path_options
 
 
@@ -41,7 +39,7 @@ class SemiCircle(JSCSSMixin, Marker):
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.semiCircle(
                 {{ this.location|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
                 )
                 {%- if this.direction %}
                     .setDirection({{ this.direction[0] }}, {{ this.direction[1] }})
@@ -68,7 +66,7 @@ class SemiCircle(JSCSSMixin, Marker):
         stop_angle=None,
         popup=None,
         tooltip=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "SemiCircle"
@@ -77,7 +75,7 @@ class SemiCircle(JSCSSMixin, Marker):
         )
         self.options = path_options(line=False, radius=radius, **kwargs)
         self.options.update(
-            parse_options(
+            dict(
                 start_angle=start_angle,
                 stop_angle=stop_angle,
             )

--- a/folium/plugins/side_by_side.py
+++ b/folium/plugins/side_by_side.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class SideBySideLayers(JSCSSMixin, MacroElement):

--- a/folium/plugins/tag_filter_button.py
+++ b/folium/plugins/tag_filter_button.py
@@ -1,8 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class TagFilterButton(JSCSSMixin, MacroElement):
@@ -44,7 +43,7 @@ class TagFilterButton(JSCSSMixin, MacroElement):
 
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.control.tagFilterButton(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}
         """
@@ -82,15 +81,15 @@ class TagFilterButton(JSCSSMixin, MacroElement):
         clear_text="clear",
         filter_on_every_click=True,
         open_popup_on_hover=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TagFilterButton"
-        self.options = parse_options(
+        self.options = dict(
             data=data,
             icon=icon,
             clear_text=clear_text,
             filter_on_every_click=filter_on_every_click,
             open_popup_on_hover=open_popup_on_hover,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/tag_filter_button.py
+++ b/folium/plugins/tag_filter_button.py
@@ -81,7 +81,7 @@ class TagFilterButton(JSCSSMixin, MacroElement):
         clear_text="clear",
         filter_on_every_click=True,
         open_popup_on_hover=False,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "TagFilterButton"
@@ -91,5 +91,5 @@ class TagFilterButton(JSCSSMixin, MacroElement):
             clear_text=clear_text,
             filter_on_every_click=filter_on_every_click,
             open_popup_on_hover=open_popup_on_hover,
-            **kwargs,
+            **kwargs
         )

--- a/folium/plugins/terminator.py
+++ b/folium/plugins/terminator.py
@@ -1,7 +1,7 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
+from folium.template import Template
 
 
 class Terminator(JSCSSMixin, MacroElement):

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -1,8 +1,7 @@
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.features import GeoJson
 from folium.map import Layer
+from folium.template import Template
 
 
 class TimeSliderChoropleth(JSCSSMixin, Layer):

--- a/folium/plugins/timeline.py
+++ b/folium/plugins/timeline.py
@@ -1,12 +1,12 @@
 from typing import List, Optional, TextIO, Union
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.features import GeoJson
 from folium.folium import Map
-from folium.utilities import JsCode, camelize, get_bounds, parse_options
+from folium.template import Template
+from folium.utilities import JsCode, get_bounds
 
 
 class Timeline(GeoJson):
@@ -83,10 +83,7 @@ class Timeline(GeoJson):
     _template = Template(
         """
         {% macro script(this, kwargs) %}
-          var {{ this.get_name() }}_options = {{ this.options|tojson }};
-          {% for key, value in this.functions.items() %}
-            {{ this.get_name() }}_options["{{key}}"] = {{ value }};
-          {% endfor %}
+          var {{ this.get_name() }}_options = {{ this.options|tojavascript }};
 
           var {{ this.get_name() }} = L.timeline(
               {{ this.data|tojson }},
@@ -112,7 +109,7 @@ class Timeline(GeoJson):
         self,
         data: Union[dict, str, TextIO],
         get_interval: Optional[JsCode] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(data)
         self._name = "Timeline"
@@ -120,14 +117,7 @@ class Timeline(GeoJson):
         if get_interval is not None:
             kwargs["get_interval"] = get_interval
 
-        # extract JsCode objects
-        self.functions = {}
-        for key, value in list(kwargs.items()):
-            if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value.js_code
-                kwargs.pop(key)
-
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
 
     def _get_self_bounds(self):
         """
@@ -191,13 +181,8 @@ class TimelineSlider(JSCSSMixin, MacroElement):
         {% endmacro %}
 
         {% macro script(this, kwargs) %}
-          var {{ this.get_name() }}_options = {{ this.options|tojson }};
-          {% for key, value in this.functions.items() %}
-            {{ this.get_name() }}_options["{{key}}"] = {{ value }};
-          {% endfor %}
-
           var {{ this.get_name() }} = L.timelineSliderControl(
-              {{ this.get_name() }}_options
+              {{ this.options|tojavascript }};
           );
           {{ this.get_name() }}.addTo({{ this._parent.get_name() }});
 
@@ -232,7 +217,7 @@ class TimelineSlider(JSCSSMixin, MacroElement):
         show_ticks: bool = True,
         steps: int = 1000,
         playback_duration: int = 10000,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TimelineSlider"
@@ -257,15 +242,8 @@ class TimelineSlider(JSCSSMixin, MacroElement):
         """
         )
 
-        # extract JsCode objects
-        self.functions = {}
-        for key, value in list(kwargs.items()):
-            if isinstance(value, JsCode):
-                self.functions[camelize(key)] = value.js_code
-                kwargs.pop(key)
-
         self.timelines: List[Timeline] = []
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
 
     def add_timelines(self, *args):
         """Add timelines to the control"""

--- a/folium/plugins/timeline.py
+++ b/folium/plugins/timeline.py
@@ -109,7 +109,7 @@ class Timeline(GeoJson):
         self,
         data: Union[dict, str, TextIO],
         get_interval: Optional[JsCode] = None,
-        **kwargs,
+        **kwargs
     ):
         super().__init__(data)
         self._name = "Timeline"
@@ -217,7 +217,7 @@ class TimelineSlider(JSCSSMixin, MacroElement):
         show_ticks: bool = True,
         steps: int = 1000,
         playback_duration: int = 10000,
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "TimelineSlider"

--- a/folium/plugins/timestamped_geo_json.py
+++ b/folium/plugins/timestamped_geo_json.py
@@ -1,11 +1,11 @@
 import json
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.folium import Map
-from folium.utilities import get_bounds, parse_options
+from folium.template import Template
+from folium.utilities import get_bounds
 
 
 class TimestampedGeoJson(JSCSSMixin, MacroElement):
@@ -94,7 +94,7 @@ class TimestampedGeoJson(JSCSSMixin, MacroElement):
                 }
             );
             var timeDimensionControl = new L.Control.TimeDimensionCustom(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {{this._parent.get_name()}}.addControl(this.timeDimensionControl);
 
@@ -211,7 +211,7 @@ class TimestampedGeoJson(JSCSSMixin, MacroElement):
         self.date_options = date_options
         self.duration = "undefined" if duration is None else '"' + duration + '"'
 
-        self.options = parse_options(
+        self.options = dict(
             position="bottomleft",
             min_speed=min_speed,
             max_speed=max_speed,

--- a/folium/plugins/timestamped_wmstilelayer.py
+++ b/folium/plugins/timestamped_wmstilelayer.py
@@ -1,9 +1,8 @@
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.elements import JSCSSMixin
 from folium.raster_layers import WmsTileLayer
-from folium.utilities import parse_options
+from folium.template import Template
 
 
 class TimestampedWmsTileLayers(JSCSSMixin, MacroElement):
@@ -66,11 +65,11 @@ class TimestampedWmsTileLayers(JSCSSMixin, MacroElement):
         """
         {% macro script(this, kwargs) %}
             {{ this._parent.get_name() }}.timeDimension = L.timeDimension(
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
             {{ this._parent.get_name() }}.timeDimensionControl =
                 L.control.timeDimension(
-                    {{ this.options_control|tojson }}
+                    {{ this.options_control|tojavascript }}
                 );
             {{ this._parent.get_name() }}.addControl(
                 {{ this._parent.get_name() }}.timeDimensionControl
@@ -129,11 +128,11 @@ class TimestampedWmsTileLayers(JSCSSMixin, MacroElement):
     ):
         super().__init__()
         self._name = "TimestampedWmsTileLayers"
-        self.options = parse_options(
+        self.options = dict(
             period=period,
             time_interval=time_interval,
         )
-        self.options_control = parse_options(
+        self.options_control = dict(
             position="bottomleft",
             auto_play=auto_play,
             player_options={

--- a/folium/plugins/treelayercontrol.py
+++ b/folium/plugins/treelayercontrol.py
@@ -4,7 +4,6 @@ from branca.element import MacroElement
 
 from folium.elements import JSCSSMixin
 from folium.template import Template
-from folium.utilities import parse_options
 
 
 class TreeLayerControl(JSCSSMixin, MacroElement):
@@ -128,7 +127,7 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
             L.control.layers.tree(
                 {{this.base_tree|tojavascript}},
                 {{this.overlay_tree|tojavascript}},
-                {{this.options|tojson}}
+                {{this.options|tojavascript}}
             ).addTo({{this._parent.get_name()}});
         {% endmacro %}
         """
@@ -146,7 +145,7 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
         collapse_all: str = "",
         expand_all: str = "",
         label_is_selector: str = "both",
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TreeLayerControl"
@@ -158,6 +157,6 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
         kwargs["collapse_all"] = collapse_all
         kwargs["expand_all"] = expand_all
         kwargs["label_is_selector"] = label_is_selector
-        self.options = parse_options(**kwargs)
+        self.options = dict(**kwargs)
         self.base_tree = base_tree
         self.overlay_tree = overlay_tree

--- a/folium/plugins/treelayercontrol.py
+++ b/folium/plugins/treelayercontrol.py
@@ -145,7 +145,7 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
         collapse_all: str = "",
         expand_all: str = "",
         label_is_selector: str = "both",
-        **kwargs,
+        **kwargs
     ):
         super().__init__()
         self._name = "TreeLayerControl"

--- a/folium/plugins/vectorgrid_protobuf.py
+++ b/folium/plugins/vectorgrid_protobuf.py
@@ -1,9 +1,8 @@
 from typing import Optional, Union
 
-from jinja2 import Template
-
 from folium.elements import JSCSSMixin
 from folium.map import Layer
+from folium.template import Template
 
 
 class VectorGridProtobuf(JSCSSMixin, Layer):
@@ -110,7 +109,7 @@ class VectorGridProtobuf(JSCSSMixin, Layer):
             var {{ this.get_name() }} = L.vectorGrid.protobuf(
                 '{{ this.url }}',
                 {%- if this.options is defined %}
-                    {{ this.options if this.options is string else this.options|tojson }}
+                    {{ this.options if this.options is string else this.options|tojavascript }}
                 {%- endif %}
             );
             {%- endmacro %}

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -7,9 +7,9 @@ from typing import Any, Callable, Optional, Union
 
 import xyzservices
 from branca.element import Element, Figure
-from jinja2 import Template
 
 from folium.map import Layer
+from folium.template import Template
 from folium.utilities import (
     TypeBounds,
     TypeJsonValue,
@@ -82,7 +82,8 @@ class TileLayer(Layer):
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.tileLayer(
                 {{ this.tiles|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
+
             );
         {% endmacro %}
         """
@@ -139,7 +140,7 @@ class TileLayer(Layer):
         if not attr:
             raise ValueError("Custom tiles must have an attribution.")
 
-        self.options = parse_options(
+        self.options = dict(
             min_zoom=min_zoom or 0,
             max_zoom=max_zoom or 18,
             max_native_zoom=max_native_zoom,
@@ -228,8 +229,8 @@ class WmsTileLayer(Layer):
             attribution=attr,
             **kwargs,
         )
+        # special parameter that shouldn't be camelized
         if cql_filter:
-            # special parameter that shouldn't be camelized
             self.options["cql_filter"] = cql_filter
 
 
@@ -286,7 +287,7 @@ class ImageOverlay(Layer):
             var {{ this.get_name() }} = L.imageOverlay(
                 {{ this.url|tojson }},
                 {{ this.bounds|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
         {% endmacro %}
         """
@@ -309,7 +310,7 @@ class ImageOverlay(Layer):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "ImageOverlay"
         self.bounds = bounds
-        self.options = parse_options(**kwargs)
+        self.options = kwargs
         self.pixelated = pixelated
         if mercator_project:
             image = mercator_transform(
@@ -385,7 +386,7 @@ class VideoOverlay(Layer):
             var {{ this.get_name() }} = L.videoOverlay(
                 {{ this.video_url|tojson }},
                 {{ this.bounds|tojson }},
-                {{ this.options|tojson }}
+                {{ this.options|tojavascript }}
             );
         {% endmacro %}
         """
@@ -408,7 +409,7 @@ class VideoOverlay(Layer):
         self.video_url = video_url
 
         self.bounds = bounds
-        self.options = parse_options(autoplay=autoplay, loop=loop, **kwargs)
+        self.options = dict(autoplay=autoplay, loop=loop, **kwargs)
 
     def _get_self_bounds(self) -> TypeBounds:
         """

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -365,8 +365,7 @@ def temp_html_filepath(data: str) -> Iterator[str]:
         yield filepath
     finally:
         if os.path.isfile(filepath):
-            pass
-            # os.remove(filepath)
+            os.remove(filepath)
 
 
 def deep_copy(item_original: Element) -> Element:

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -365,7 +365,8 @@ def temp_html_filepath(data: str) -> Iterator[str]:
         yield filepath
     finally:
         if os.path.isfile(filepath):
-            os.remove(filepath)
+            pass
+            # os.remove(filepath)
 
 
 def deep_copy(item_original: Element) -> Element:

--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -6,9 +6,9 @@ Wraps leaflet Polyline, Polygon, Rectangle, Circle, and CircleMarker
 from typing import List, Optional, Sequence, Union
 
 from branca.element import MacroElement
-from jinja2 import Template
 
 from folium.map import Marker, Popup, Tooltip
+from folium.template import Template
 from folium.utilities import (
     TypeLine,
     TypeMultiLine,
@@ -230,7 +230,7 @@ class Polygon(BaseMultiLocation):
         locations: TypeMultiLine,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
-        **kwargs: TypePathOptions
+        **kwargs: TypePathOptions,
     ):
         super().__init__(locations, popup=popup, tooltip=tooltip)
         self._name = "Polygon"
@@ -272,7 +272,7 @@ class Rectangle(MacroElement):
         bounds: TypeLine,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
-        **kwargs: TypePathOptions
+        **kwargs: TypePathOptions,
     ):
         super().__init__()
         self._name = "rectangle"
@@ -333,7 +333,7 @@ class Circle(Marker):
         radius: float = 50,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
-        **kwargs: TypePathOptions
+        **kwargs: TypePathOptions,
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "circle"
@@ -379,7 +379,7 @@ class CircleMarker(Marker):
         radius: float = 10,
         popup: Union[Popup, str, None] = None,
         tooltip: Union[Tooltip, str, None] = None,
-        **kwargs: TypePathOptions
+        **kwargs: TypePathOptions,
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "CircleMarker"

--- a/tests/plugins/test_antpath.py
+++ b/tests/plugins/test_antpath.py
@@ -3,10 +3,9 @@ Test AntPath
 -------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -46,7 +45,7 @@ def test_antpath():
         """
           {{this.get_name()}} = L.polyline.antPath(
                   {{ this.locations|tojson }},
-                  {{ this.options|tojson }}
+                  {{ this.options|tojavascript }}
                 )
                 .addTo({{this._parent.get_name()}});
         """

--- a/tests/plugins/test_beautify_icon.py
+++ b/tests/plugins/test_beautify_icon.py
@@ -4,10 +4,9 @@ Test BeautifyIcon
 
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -46,7 +45,7 @@ def test_beautify_icon():
     # We verify that the Beautiful Icons are rendered correctly.
     tmpl = Template(
         """
-                var {{this.get_name()}} = new L.BeautifyIcon.icon({{ this.options|tojson }})
+                var {{this.get_name()}} = new L.BeautifyIcon.icon({{ this.options|tojavascript }})
                 {{this._parent.get_name()}}.setIcon({{this.get_name()}});
             """
     )  # noqa

--- a/tests/plugins/test_boat_marker.py
+++ b/tests/plugins/test_boat_marker.py
@@ -4,10 +4,9 @@ Test BoatMarker
 
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -35,7 +34,7 @@ def test_boat_marker():
         """
         var {{ this.get_name() }} = L.boatMarker(
             {{ this.location|tojson }},
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         ).addTo({{ this._parent.get_name() }});
         {{ this.get_name() }}.setHeadingWind(
             {{ this.heading }},
@@ -64,7 +63,7 @@ def test_boat_marker_with_no_wind_speed_or_heading():
         """
         var {{ this.get_name() }} = L.boatMarker(
             {{ this.location|tojson }},
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         ).addTo({{ this._parent.get_name() }});
         {{ this.get_name() }}.setHeading({{ this.heading }});
     """

--- a/tests/plugins/test_dual_map.py
+++ b/tests/plugins/test_dual_map.py
@@ -3,10 +3,9 @@ Test DualMap
 ------------
 """
 
-from jinja2 import Template
-
 import folium
 import folium.plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_encoded.py
+++ b/tests/plugins/test_encoded.py
@@ -1,9 +1,8 @@
 """Test PolyLineFromEncoded Plugin."""
 
-from jinja2 import Template
-
 from folium import Map
 from folium.plugins import PolygonFromEncoded, PolyLineFromEncoded
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -33,7 +32,7 @@ def test_polyline_from_encoded():
         """
         var {{this.get_name()}} = L.Polyline.fromEncoded(
                         {{ this.encoded|tojson }},
-                        {{ this.options|tojson }}
+                        {{ this.options|tojavascript }}
         ).addTo({{this._parent.get_name()}});
         """
     )
@@ -69,7 +68,7 @@ def test_polygon_from_encoded():
         """
         var {{this.get_name()}} = L.Polygon.fromEncoded(
                             {{ this.encoded|tojson }},
-                            {{ this.options|tojson }}
+                            {{ this.options|tojavascript }}
         )
         .addTo({{this._parent.get_name()}});
         """

--- a/tests/plugins/test_fast_marker_cluster.py
+++ b/tests/plugins/test_fast_marker_cluster.py
@@ -6,10 +6,10 @@ Test FastMarkerCluster
 import numpy as np
 import pandas as pd
 import pytest
-from jinja2 import Template
 
 import folium
 from folium.plugins import FastMarkerCluster
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -48,7 +48,7 @@ def test_fast_marker_cluster():
             {{ this.callback }}
 
             var data = {{ this.data|tojson }};
-            var cluster = L.markerClusterGroup({{ this.options|tojson }});
+            var cluster = L.markerClusterGroup({{ this.options|tojavascript }});
             {%- if this.icon_create_function is not none %}
             cluster.options.iconCreateFunction =
                 {{ this.icon_create_function.strip() }};

--- a/tests/plugins/test_feature_group_sub_group.py
+++ b/tests/plugins/test_feature_group_sub_group.py
@@ -3,10 +3,9 @@ Test MarkerCluster
 ------------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_float_image.py
+++ b/tests/plugins/test_float_image.py
@@ -3,10 +3,9 @@ Test FloatImage
 ---------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_fullscreen.py
+++ b/tests/plugins/test_fullscreen.py
@@ -4,10 +4,9 @@ Test Fullscreen
 
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -21,7 +20,7 @@ def test_fullscreen():
     tmpl = Template(
         """
         L.control.fullscreen(
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         ).addTo({{this._parent.get_name()}});
     """
     )

--- a/tests/plugins/test_grouped_layer_control.py
+++ b/tests/plugins/test_grouped_layer_control.py
@@ -16,16 +16,17 @@ def test_grouped_layer_control():
     m.add_child(fg3)
     lc = groupedlayercontrol.GroupedLayerControl(groups={"groups1": [fg1, fg2]})
     lc.add_to(m)
-    out = normalize(m._parent.render())
+    out = m._parent.render()
+    print(out)
+    out = normalize(out)
 
     assert (
         "https://cdnjs.cloudflare.com/ajax/libs/leaflet-groupedlayercontrol/0.6.1/leaflet.groupedlayercontrol.min.js"
         in out
     )
 
-    assert (
-        normalize(
-            f"""
+    expected = normalize(
+        f"""
         L.control.groupedLayers(
             null,
             {{
@@ -34,10 +35,11 @@ def test_grouped_layer_control():
                     "g2" : {fg2.get_name()},
                 }},
             }},
-            {{"exclusiveGroups": ["groups1"]}},
+            {{"exclusiveGroups": ["groups1",],}},
          ).addTo({m.get_name()});
          {fg2.get_name()}.remove();
     """
-        )
-        in out
     )
+    print(out)
+    print(expected)
+    assert expected in out

--- a/tests/plugins/test_grouped_layer_control.py
+++ b/tests/plugins/test_grouped_layer_control.py
@@ -40,6 +40,4 @@ def test_grouped_layer_control():
          {fg2.get_name()}.remove();
     """
     )
-    print(out)
-    print(expected)
     assert expected in out

--- a/tests/plugins/test_heat_map.py
+++ b/tests/plugins/test_heat_map.py
@@ -5,10 +5,10 @@ Test HeatMap
 
 import numpy as np
 import pytest
-from jinja2 import Template
 
 import folium
 from folium.plugins import HeatMap
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_heat_map_withtime.py
+++ b/tests/plugins/test_heat_map_withtime.py
@@ -4,10 +4,10 @@ Test HeatMapWithTime
 """
 
 import numpy as np
-from jinja2 import Template
 
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_marker_cluster.py
+++ b/tests/plugins/test_marker_cluster.py
@@ -4,10 +4,10 @@ Test MarkerCluster
 """
 
 import numpy as np
-from jinja2 import Template
 
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -26,7 +26,7 @@ def test_marker_cluster():
     tmpl_for_expected = Template(
         """
         var {{this.get_name()}} = L.markerClusterGroup(
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         );
         {%- if this.icon_create_function is not none %}
             {{ this.get_name() }}.options.iconCreateFunction =
@@ -36,7 +36,7 @@ def test_marker_cluster():
         {% for marker in this._children.values() %}
             var {{marker.get_name()}} = L.marker(
                 {{ marker.location|tojson }},
-                {}
+                {"draggable": null,"autoPan": null,}
             ).addTo({{this.get_name()}});
         {% endfor %}
 
@@ -61,6 +61,8 @@ def test_marker_cluster():
         in out
     )  # noqa
 
+    print(out)
+    print(expected)
     assert expected in out
 
     bounds = m.get_bounds()

--- a/tests/plugins/test_marker_cluster.py
+++ b/tests/plugins/test_marker_cluster.py
@@ -61,8 +61,6 @@ def test_marker_cluster():
         in out
     )  # noqa
 
-    print(out)
-    print(expected)
     assert expected in out
 
     bounds = m.get_bounds()

--- a/tests/plugins/test_polyline_text_path.py
+++ b/tests/plugins/test_polyline_text_path.py
@@ -3,10 +3,9 @@ Test PolyLineTextPath
 ---------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -52,7 +51,7 @@ def test_polyline_text_path():
         """
         {{ this.polyline.get_name() }}.setText(
             "{{this.text}}",
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         );
         """
     )

--- a/tests/plugins/test_realtime.py
+++ b/tests/plugins/test_realtime.py
@@ -3,10 +3,9 @@ Test Realtime
 ------------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium.plugins import MarkerCluster, Realtime
+from folium.template import Template
 from folium.utilities import JsCode, normalize
 
 
@@ -30,7 +29,7 @@ def test_realtime():
     tmpl_for_expected = Template(
         """
           {% macro script(this, kwargs) %}
-              var {{ this.get_name() }}_options = {{ this.options|tojson }};
+              var {{ this.get_name() }}_options = {{ this.options|tojavascript }};
               {% for key, value in this.functions.items() %}
               {{ this.get_name() }}_options["{{key}}"] = {{ value }};
               {% endfor %}

--- a/tests/plugins/test_scroll_zoom_toggler.py
+++ b/tests/plugins/test_scroll_zoom_toggler.py
@@ -3,10 +3,9 @@ Test ScrollZoomToggler
 ----------------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_semicircle.py
+++ b/tests/plugins/test_semicircle.py
@@ -4,10 +4,9 @@ Test SemiCircle
 
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -49,7 +48,7 @@ def test_semicircle():
         """
         var {{ this.get_name() }} = L.semiCircle(
         {{ this.location|tojson }},
-        {{ this.options | tojson }}
+        {{ this.options|tojavascript }}
         )
             .setDirection{{ this.direction }}
         .addTo({{ this._parent.get_name() }});
@@ -60,7 +59,7 @@ def test_semicircle():
         """
         var {{ this.get_name() }} = L.semiCircle(
         {{ this.location|tojson }},
-        {{ this.options | tojson }}
+        {{ this.options|tojavascript }}
         )
         .addTo({{ this._parent.get_name() }});
     """

--- a/tests/plugins/test_tag_filter_button.py
+++ b/tests/plugins/test_tag_filter_button.py
@@ -6,10 +6,10 @@ Test TagFilterButton
 import random
 
 import numpy as np
-from jinja2 import Template
 
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_terminator.py
+++ b/tests/plugins/test_terminator.py
@@ -3,10 +3,9 @@ Test Terminator
 ---------------
 """
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 

--- a/tests/plugins/test_timeline.py
+++ b/tests/plugins/test_timeline.py
@@ -6,11 +6,10 @@ Test Timeline
 
 import json
 
-from jinja2 import Template
-
 import folium
 from folium import plugins
 from folium.features import GeoJsonPopup
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -63,7 +62,7 @@ def test_timeline():
           {% endmacro %}
 
           {% macro script(this, kwargs) %}
-            var {{ this.get_name() }}_options = {{ this.options|tojson }};
+            var {{ this.get_name() }}_options = {{ this.options|tojavascript }};
             {% for key, value in this.functions.items() %}
               {{ this.get_name() }}_options["{{key}}"] = {{ value }};
             {% endfor %}

--- a/tests/plugins/test_timestamped_geo_json.py
+++ b/tests/plugins/test_timestamped_geo_json.py
@@ -5,10 +5,10 @@ Test TimestampedGeoJson
 """
 
 import numpy as np
-from jinja2 import Template
 
 import folium
 from folium import plugins
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -146,7 +146,7 @@ def test_timestamped_geo_json():
             }
         );
         var timeDimensionControl = new L.Control.TimeDimensionCustom(
-            {{ this.options|tojson }}
+            {{ this.options|tojavascript }}
         );
         {{this._parent.get_name()}}.addControl(this.timeDimensionControl);
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -100,7 +100,7 @@ def test_divicon():
               </svg>"""  # noqa
     div = folium.DivIcon(html=html)
     assert isinstance(div, Element)
-    assert div.options["className"] == "empty"
+    assert div.options["class_name"] == "empty"
     assert div.options["html"] == html
 
 

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -12,12 +12,12 @@ import numpy as np
 import pandas as pd
 import pytest
 import xyzservices.providers as xyz
-from jinja2 import Template
 from jinja2.utils import htmlsafe_json_dumps
 
 import folium
 from folium import TileLayer
 from folium.features import Choropleth, GeoJson
+from folium.template import Template
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
@@ -92,7 +92,7 @@ class TestFolium:
         assert self.m.get_root() == self.m._parent
         assert self.m.location == [45.5236, -122.6750]
         assert self.m.options["zoom"] == 4
-        assert self.m.options["maxBounds"] == [[-90, -180], [90, 180]]
+        assert self.m.options["max_bounds"] == [[-90, -180], [90, 180]]
         assert self.m.position == "relative"
         assert self.m.height == (400, "px")
         assert self.m.width == (900, "px")
@@ -464,28 +464,31 @@ class TestFolium:
         m = folium.Map(prefer_canvas=True)
         out = m._parent.render()
         out_str = "".join(out.split())
-        assert "preferCanvas:true" in out_str
+        for line in out.split("\n"):
+            print(line)
+        print(out_str)
+        assert '"preferCanvas":true' in out_str
         assert not m.global_switches.no_touch
         assert not m.global_switches.disable_3d
 
         m = folium.Map(no_touch=True)
         out = m._parent.render()
         out_str = "".join(out.split())
-        assert "preferCanvas:false" in out_str
+        assert '"preferCanvas":false' in out_str
         assert m.global_switches.no_touch
         assert not m.global_switches.disable_3d
 
         m = folium.Map(disable_3d=True)
         out = m._parent.render()
         out_str = "".join(out.split())
-        assert "preferCanvas:false" in out_str
+        assert '"preferCanvas":false' in out_str
         assert not m.global_switches.no_touch
         assert m.global_switches.disable_3d
 
         m = folium.Map(prefer_canvas=True, no_touch=True, disable_3d=True)
         out = m._parent.render()
         out_str = "".join(out.split())
-        assert "preferCanvas:true" in out_str
+        assert '"preferCanvas":true' in out_str
         assert m.global_switches.no_touch
         assert m.global_switches.disable_3d
 

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -464,9 +464,6 @@ class TestFolium:
         m = folium.Map(prefer_canvas=True)
         out = m._parent.render()
         out_str = "".join(out.split())
-        for line in out.split("\n"):
-            print(line)
-        print(out_str)
         assert '"preferCanvas":true' in out_str
         assert not m.global_switches.no_touch
         assert not m.global_switches.disable_3d

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -112,8 +112,11 @@ def test_popup_sticky():
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
     var {popup_name} = L.popup({{
-        "autoClose": false, "closeOnClick": false, "maxWidth": "100%"
+        "maxWidth": "100%",
+        "autoClose": false,
+        "closeOnClick": false,
     }});
+
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">Some text.</div>`)[0];
     {popup_name}.setContent({html_name});
     {map_name}.bindPopup({popup_name});
@@ -131,7 +134,7 @@ def test_popup_show():
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
     var {popup_name} = L.popup({{
-        "autoClose": false, "maxWidth": "100%"
+        "maxWidth": "100%","autoClose": false,"closeOnClick": null,
     }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">Some text.</div>`)[0];
     {popup_name}.setContent({html_name});
@@ -150,7 +153,11 @@ def test_popup_backticks():
     popup = Popup("back`tick`tick").add_to(m)
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
-    var {popup_name} = L.popup({{"maxWidth": "100%"}});
+    var {popup_name} = L.popup({{
+        "maxWidth": "100%",
+        "autoClose": null,
+        "closeOnClick": null,
+    }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">back\\`tick\\`tick</div>`)[0];
     {popup_name}.setContent({html_name});
     {map_name}.bindPopup({popup_name});
@@ -167,7 +174,11 @@ def test_popup_backticks_already_escaped():
     popup = Popup("back\\`tick").add_to(m)
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
-    var {popup_name} = L.popup({{"maxWidth": "100%"}});
+    var {popup_name} = L.popup({{
+        "maxWidth": "100%",
+        "autoClose": null,
+        "closeOnClick": null,
+    }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">back\\`tick</div>`)[0];
     {popup_name}.setContent({html_name});
     {map_name}.bindPopup({popup_name});

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -65,7 +65,6 @@ def test_wms():
     )
     w.add_to(m)
     html = m.get_root().render()
-    print(html)
 
     # verify this special case wasn't converted to lowerCamelCase
     assert '"cql_filter": "something",' in html

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -6,9 +6,9 @@ Test raster_layers
 
 import pytest
 import xyzservices
-from jinja2 import Template
 
 import folium
+from folium.template import Template
 from folium.utilities import normalize
 
 
@@ -65,6 +65,7 @@ def test_wms():
     )
     w.add_to(m)
     html = m.get_root().render()
+    print(html)
 
     # verify this special case wasn't converted to lowerCamelCase
     assert '"cql_filter": "something",' in html


### PR DESCRIPTION
Boring but big. The leaflet class hierarchy allows all classes to have optional arguments. These optional arguments can contain JavaScript code or references to other Leaflet elements.

To support this in Folium I replaced (almost) all instances of `parse_options` in the constructors with `this.options | tojavascript` in the templates. I left the `parse_options` in case someone outside of Folium uses it.


    