### PR TITLE
Add py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ package_data = {
         "templates/*.html",
         "templates/*.js",
         "templates/*.txt",
+        "py.typed",
     ]
     + walk_subpkg("templates/tiles")
 }


### PR DESCRIPTION
Follow up to #1677
Closes #1559

This tells type checkers like mypy that this package contains type hints so that other projects can type check their code that imports folium. See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages