### PR TITLE
Fix Selenium test failure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ pycodestyle
 pydata-sphinx-theme
 pytest
 scipy
-selenium
+selenium<4.27.0
 setuptools_scm
 sphinx
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ pycodestyle
 pydata-sphinx-theme
 pytest
 scipy
-selenium<4.27.0
+selenium
 setuptools_scm
 sphinx
 types-requests

--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -35,4 +35,4 @@ def test_geojson(driver):
     )
     assert control_label.text == "geojson"
     control_input = control_label.find_element(By.CSS_SELECTOR, value="input")
-    assert control_input.get_attribute("checked") is None
+    assert control_input.get_dom_attribute("checked") is None

--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -35,4 +35,4 @@ def test_geojson(driver):
     )
     assert control_label.text == "geojson"
     control_input = control_label.find_element(By.CSS_SELECTOR, value="input")
-    assert control_input.get_property("checked") is False
+    assert control_input.get_dom_attribute("checked") is None

--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -35,4 +35,4 @@ def test_geojson(driver):
     )
     assert control_label.text == "geojson"
     control_input = control_label.find_element(By.CSS_SELECTOR, value="input")
-    assert control_input.get_dom_attribute("checked") is None
+    assert control_input.get_attribute("checked") is None

--- a/tests/selenium/test_geojson_selenium.py
+++ b/tests/selenium/test_geojson_selenium.py
@@ -35,4 +35,4 @@ def test_geojson(driver):
     )
     assert control_label.text == "geojson"
     control_input = control_label.find_element(By.CSS_SELECTOR, value="input")
-    assert control_input.get_dom_attribute("checked") is None
+    assert control_input.get_property("checked") is False


### PR DESCRIPTION
Verified that the Selenium tests work when pinning the version of `selenium` to `<4.27.0`. In the release notes for 4.27.0 I found a mention of deprecation of `GetAttribute`, which corresponds to the error message we are seeing. They deprecated a method call we do in the geojson tests, see https://github.com/SeleniumHQ/selenium/issues/13334.

I tried to fix it by changing that method call, but that didn't work out.

I don't have time to dive into this further, so for now just pin the Selenium version to <4.27.0. 

At a glance it looks like they are grappling with something adjacent as well on the Selenium side (see https://github.com/SeleniumHQ/selenium/pull/14808 and https://github.com/SeleniumHQ/selenium/issues/14800) so might be best to sit tight and see in a few weeks what they came up with.