### PR TITLE
Add OverlappingMarkerSpiderfier to plugins table

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,8 +116,10 @@ The *final* PR should contain:
 - a new module in `folium/plugins` with the plugin class, with docstring
 - importing that class in `folium/plugins/__init__.py`
 - a test in `tests/plugins/test_[new plugin module].py`
-- listing the plugin in `docs/user_guide/plugins.rst`
 - a documentation module with examples in `docs/user_guide/plugins`
+- listing that module in `docs/user_guide/plugins.rst`
+  - in the toctree
+  - as well as the table lower on the page
 
 Before doing all this work it's a good idea to open a PR with just the plugin
 to discuss whether it's something to include in folium.

--- a/docs/user_guide/plugins.rst
+++ b/docs/user_guide/plugins.rst
@@ -81,6 +81,8 @@ Plugins
       - A small minimap showing the map at a different scale to aid navigation.
     * - :doc:`Mouse Position <plugins/mouse_position>`
       - A control that displays geographic coordinates of the mouse pointer, as it is moved over the map.
+    * - :doc:`Overlapping Marker Spiderifier <plugins/overlapping_marker_spiderfier>`
+      - Help manage overlapping markers by “spiderfying” them when clicked, making it easier to select individual markers.
     * - :doc:`Pattern <plugins/pattern>`
       - Add support for pattern fills on Paths.
     * - :doc:`Polygon Encoded <plugins/polygon_encoded>`


### PR DESCRIPTION
I was looking at the added documentation for the new OverlappingMarkerSpiderfier plugin and noticed it wasn't added to the table on the plugins page. See https://python-visualization.github.io/folium/dev/user_guide/plugins.html. Add it in this PR.

Perhaps the reason why it wasn't there is because the contributing guideline is not explicit enough on this topic. So update that guide as well.