### PR TITLE
TileLayer: max_native_zoom cannot be null

### DIFF
--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -122,7 +122,6 @@ class TileLayer(Layer):
             attr = attr if attr else tiles.html_attribution  # type: ignore
             min_zoom = min_zoom or tiles.get("min_zoom")
             max_zoom = max_zoom or tiles.get("max_zoom")
-            max_native_zoom = max_native_zoom or tiles.get("max_zoom")
             subdomains = tiles.get("subdomains", subdomains)
             if name is None:
                 name = tiles.name.replace(".", "").lower()
@@ -143,7 +142,7 @@ class TileLayer(Layer):
         self.options = dict(
             min_zoom=min_zoom or 0,
             max_zoom=max_zoom or 18,
-            max_native_zoom=max_native_zoom,
+            max_native_zoom=max_native_zoom or max_zoom or 18,
             no_wrap=no_wrap,
             attribution=attr,
             subdomains=subdomains,

--- a/folium/template.py
+++ b/folium/template.py
@@ -15,6 +15,8 @@ def tojavascript(obj: Union[str, JsCode, dict, list, Element]) -> str:
     elif isinstance(obj, dict):
         out = ["{\n"]
         for key, value in obj.items():
+            if value is None:
+                continue
             out.append(f'  "{camelize(key)}": ')
             out.append(tojavascript(value))
             out.append(",\n")

--- a/folium/template.py
+++ b/folium/template.py
@@ -15,8 +15,6 @@ def tojavascript(obj: Union[str, JsCode, dict, list, Element]) -> str:
     elif isinstance(obj, dict):
         out = ["{\n"]
         for key, value in obj.items():
-            if value is None:
-                continue
             out.append(f'  "{camelize(key)}": ')
             out.append(tojavascript(value))
             out.append(",\n")


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/2043.

In https://github.com/python-visualization/folium/pull/2029 we changed the way we parse options. Before, in `parse_options`, None values would be discarded. In the `tojavascript` filter this doesn't happen. This leads to different outcomes, and issues like some tile layers not rendering.

I first looked at removing all None values like before, but that seems heavy handed and might lead to other issues. Instead, do a targeted fix that just makes sure `max_native_zoom` always has an integer value. If it's not available, we can set it to max_zoom, which has the same effect as not including it at all.