### PR TITLE
fix popup sticky options

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -483,8 +483,8 @@ class Popup(Element):
         self.lazy = lazy
         self.options = dict(
             max_width=max_width,
-            autoClose=False if show or sticky else None,
-            closeOnClick=False if sticky else None,
+            autoClose=not (show or sticky),
+            closeOnClick=not sticky,
             **kwargs,
         )
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -134,7 +134,7 @@ def test_popup_show():
     rendered = popup._template.render(this=popup, kwargs={})
     expected = """
     var {popup_name} = L.popup({{
-        "maxWidth": "100%","autoClose": false,"closeOnClick": null,
+        "maxWidth": "100%","autoClose": false,"closeOnClick": true,
     }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">Some text.</div>`)[0];
     {popup_name}.setContent({html_name});
@@ -155,8 +155,8 @@ def test_popup_backticks():
     expected = """
     var {popup_name} = L.popup({{
         "maxWidth": "100%",
-        "autoClose": null,
-        "closeOnClick": null,
+        "autoClose": true,
+        "closeOnClick": true,
     }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">back\\`tick\\`tick</div>`)[0];
     {popup_name}.setContent({html_name});
@@ -176,8 +176,8 @@ def test_popup_backticks_already_escaped():
     expected = """
     var {popup_name} = L.popup({{
         "maxWidth": "100%",
-        "autoClose": null,
-        "closeOnClick": null,
+        "autoClose": true,
+        "closeOnClick": true,
     }});
     var {html_name} = $(`<div id="{html_name}" style="width: 100.0%; height: 100.0%;">back\\`tick</div>`)[0];
     {popup_name}.setContent({html_name});


### PR DESCRIPTION
Fix https://github.com/python-visualization/folium/issues/2047

This is a similar issue to https://github.com/python-visualization/folium/issues/2043, happening after the v0.19.0 release, caused by changes in https://github.com/python-visualization/folium/pull/2029/.

Fix it by using proper boolean values for these options on Popup, not None values.