### PR TITLE
Add DivIcon and CustomIcon as accepted type of Marker icon

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -373,7 +373,7 @@ class Marker(MacroElement):
         location: Optional[Sequence[float]] = None,
         popup: Union["Popup", str, None] = None,
         tooltip: Union["Tooltip", str, None] = None,
-        icon: Optional[Icon] = None,
+        icon: Optional[Union[Icon, "DivIcon"]] = None,
         draggable: bool = False,
         **kwargs: TypeJsonValue,
     ):

--- a/folium/map.py
+++ b/folium/map.py
@@ -5,7 +5,7 @@ Classes for drawing maps.
 
 import warnings
 from collections import OrderedDict
-from typing import List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 from branca.element import Element, Figure, Html, MacroElement
 
@@ -20,6 +20,9 @@ from folium.utilities import (
     remove_empty,
     validate_location,
 )
+
+if TYPE_CHECKING:
+    from folium.features import CustomIcon, DivIcon
 
 
 class Evented(MacroElement):
@@ -373,7 +376,7 @@ class Marker(MacroElement):
         location: Optional[Sequence[float]] = None,
         popup: Union["Popup", str, None] = None,
         tooltip: Union["Tooltip", str, None] = None,
-        icon: Optional[Union[Icon, "DivIcon"]] = None,
+        icon: Optional[Union[Icon, "CustomIcon", "DivIcon"]] = None,
         draggable: bool = False,
         **kwargs: TypeJsonValue,
     ):


### PR DESCRIPTION
A `DivIcon` works when passed as the `icon` argument of `Marker`, but the argument is annotated as `Optional[Icon]` instead of `Optional[Union[Icon, "DivIcon"]]`.