### PR TITLE
Fix type hints after adding Branca type checking

### DIFF
--- a/folium/elements.py
+++ b/folium/elements.py
@@ -12,7 +12,7 @@ class JSCSSMixin(Element):
     default_js: List[Tuple[str, str]] = []
     default_css: List[Tuple[str, str]] = []
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         figure = self.get_root()
         assert isinstance(
             figure, Figure

--- a/folium/features.py
+++ b/folium/features.py
@@ -165,7 +165,7 @@ class Vega(JSCSSMixin, Element):
         self.top = _parse_size(top)
         self.position = position
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         super().render(**kwargs)
 
@@ -284,7 +284,7 @@ class VegaLite(Element):
         self.top = _parse_size(top)
         self.position = position
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         self._parent.html.add_child(
             Element(
@@ -820,7 +820,7 @@ class GeoJson(Layer):
         """
         return get_bounds(self.data, lonlat=True)
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         self.parent_map = get_obj_in_upper_tree(self, Map)
         # Need at least one feature, otherwise style mapping fails
         if (self.style or self.highlight) and self.data["features"]:
@@ -1041,7 +1041,7 @@ class TopoJson(JSCSSMixin, Layer):
                 self.style_function(feature)
             )  # noqa
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         self.style_data()
         super().render(**kwargs)
@@ -1160,7 +1160,7 @@ class GeoJsonDetail(MacroElement):
                 UserWarning,
             )
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         figure = self.get_root()
         if isinstance(self._parent, GeoJson):
@@ -1657,7 +1657,7 @@ class Choropleth(FeatureGroup):
         else:
             return value
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Render the GeoJson/TopoJson and color scale objects."""
         if self.color_scale:
             # ColorMap needs Map as its parent

--- a/folium/features.py
+++ b/folium/features.py
@@ -12,7 +12,15 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 import numpy as np
 import requests
 from branca.colormap import ColorMap, LinearColormap, StepColormap
-from branca.element import Div, Element, Figure, Html, IFrame, JavascriptLink, MacroElement
+from branca.element import (
+    Div,
+    Element,
+    Figure,
+    Html,
+    IFrame,
+    JavascriptLink,
+    MacroElement,
+)
 from branca.utilities import color_brewer
 
 from folium.elements import JSCSSMixin
@@ -290,7 +298,9 @@ class VegaLite(Element):
         """Renders the HTML representation of the element."""
         parent = self._parent
         if not isinstance(parent, (Figure, Div, Popup)):
-            raise TypeError("VegaLite elements can only be added to a Figure, Div, or Popup")
+            raise TypeError(
+                "VegaLite elements can only be added to a Figure, Div, or Popup"
+            )
 
         parent.html.add_child(
             Element(
@@ -1973,7 +1983,9 @@ class ColorLine(FeatureGroup):
         elif isinstance(colormap, StepColormap):
             cm = colormap
         else:
-            raise TypeError(f"Unexpected type for argument `colormap`: {type(colormap)}")
+            raise TypeError(
+                f"Unexpected type for argument `colormap`: {type(colormap)}"
+            )
 
         out: Dict[str, List[List[List[float]]]] = {}
         for (lat1, lng1), (lat2, lng2), color in zip(coords[:-1], coords[1:], colors):

--- a/folium/features.py
+++ b/folium/features.py
@@ -1150,6 +1150,7 @@ class GeoJsonDetail(MacroElement):
 
     def warn_for_geometry_collections(self) -> None:
         """Checks for GeoJson GeometryCollection features to warn user about incompatibility."""
+        assert isinstance(self._parent, GeoJson)
         geom_collections = [
             feature.get("properties") if feature.get("properties") is not None else key
             for key, feature in enumerate(self._parent.data["features"])

--- a/folium/features.py
+++ b/folium/features.py
@@ -1630,7 +1630,7 @@ class Choropleth(FeatureGroup):
             return {"weight": line_weight + 2, "fillOpacity": fill_opacity + 0.2}
 
         if topojson:
-            self.geojson = TopoJson(
+            self.geojson: Union[TopoJson, GeoJson] = TopoJson(
                 geo_data,
                 topojson,
                 style_function=style_function,

--- a/folium/features.py
+++ b/folium/features.py
@@ -32,7 +32,7 @@ from folium.utilities import (
     none_max,
     none_min,
     remove_empty,
-    validate_locations,
+    validate_locations, TypeBoundsReturn,
 )
 from folium.vector_layers import Circle, CircleMarker, PolyLine, path_options
 
@@ -1046,7 +1046,7 @@ class TopoJson(JSCSSMixin, Layer):
         self.style_data()
         super().render(**kwargs)
 
-    def get_bounds(self) -> List[List[float]]:
+    def get_bounds(self) -> TypeBoundsReturn:
         """
         Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]]

--- a/folium/features.py
+++ b/folium/features.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 import numpy as np
 import requests
 from branca.colormap import ColorMap, LinearColormap, StepColormap
-from branca.element import Element, Figure, Html, IFrame, JavascriptLink, MacroElement, Div
+from branca.element import Div, Element, Figure, Html, IFrame, JavascriptLink, MacroElement
 from branca.utilities import color_brewer
 
 from folium.elements import JSCSSMixin
@@ -20,6 +20,8 @@ from folium.folium import Map
 from folium.map import FeatureGroup, Icon, Layer, Marker, Popup, Tooltip
 from folium.template import Template
 from folium.utilities import (
+    TypeBoundsReturn,
+    TypeContainer,
     TypeJsonValue,
     TypeLine,
     TypePathOptions,
@@ -32,7 +34,7 @@ from folium.utilities import (
     none_max,
     none_min,
     remove_empty,
-    validate_locations, TypeBoundsReturn, TypeContainer,
+    validate_locations,
 )
 from folium.vector_layers import Circle, CircleMarker, PolyLine, path_options
 

--- a/folium/features.py
+++ b/folium/features.py
@@ -1968,8 +1968,11 @@ class ColorLine(FeatureGroup):
                 vmin=min(colors),
                 vmax=max(colors),
             ).to_step(nb_steps)
-        else:
+        elif isinstance(colormap, StepColormap):
             cm = colormap
+        else:
+            raise TypeError(f"Unexpected type for argument `colormap`: {type(colormap)}")
+
         out: Dict[str, List[List[List[float]]]] = {}
         for (lat1, lng1), (lat2, lng2), color in zip(coords[:-1], coords[1:], colors):
             out.setdefault(cm(color), []).append([[lat1, lng1], [lat2, lng2]])

--- a/folium/features.py
+++ b/folium/features.py
@@ -1570,7 +1570,7 @@ class Choropleth(FeatureGroup):
             color_range = color_brewer(fill_color, n=nb_bins)
             self.color_scale = StepColormap(
                 color_range,
-                index=bin_edges,
+                index=list(bin_edges),
                 vmin=bins_min,
                 vmax=bins_max,
                 caption=legend_name,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -377,7 +377,7 @@ class Map(JSCSSMixin, Evented):
             return None
         return self._to_png()
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         figure = self.get_root()
         assert isinstance(

--- a/folium/map.py
+++ b/folium/map.py
@@ -5,7 +5,7 @@ Classes for drawing maps.
 
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Optional, Sequence, Union, cast
 
 from branca.element import Element, Figure, Html, MacroElement
 
@@ -14,11 +14,12 @@ from folium.template import Template
 from folium.utilities import (
     JsCode,
     TypeBounds,
+    TypeBoundsReturn,
     TypeJsonValue,
     escape_backticks,
     parse_options,
     remove_empty,
-    validate_location, TypeBoundsReturn,
+    validate_location,
 )
 
 if TYPE_CHECKING:

--- a/folium/map.py
+++ b/folium/map.py
@@ -221,7 +221,7 @@ class LayerControl(MacroElement):
         self.base_layers = OrderedDict()
         self.overlays = OrderedDict()
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         self.reset()
         for item in self._parent._children.values():
@@ -404,7 +404,7 @@ class Marker(MacroElement):
         assert self.location is not None
         return [self.location, self.location]
 
-    def render(self) -> None:
+    def render(self):
         if self.location is None:
             raise ValueError(
                 f"{self._name} location must be assigned when added directly to map."
@@ -492,7 +492,7 @@ class Popup(Element):
             **kwargs,
         )
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         for name, child in self._children.items():
             child.render(**kwargs)

--- a/folium/map.py
+++ b/folium/map.py
@@ -18,7 +18,7 @@ from folium.utilities import (
     escape_backticks,
     parse_options,
     remove_empty,
-    validate_location,
+    validate_location, TypeBoundsReturn,
 )
 
 if TYPE_CHECKING:
@@ -396,7 +396,7 @@ class Marker(MacroElement):
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
 
-    def _get_self_bounds(self) -> TypeBounds:
+    def _get_self_bounds(self) -> TypeBoundsReturn:
         """Computes the bounds of the object itself.
 
         Because a marker has only single coordinates, we repeat them.

--- a/folium/map.py
+++ b/folium/map.py
@@ -5,7 +5,7 @@ Classes for drawing maps.
 
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
 from branca.element import Element, Figure, Html, MacroElement
 
@@ -402,7 +402,7 @@ class Marker(MacroElement):
         Because a marker has only single coordinates, we repeat them.
         """
         assert self.location is not None
-        return [self.location, self.location]
+        return cast(TypeBoundsReturn, [self.location, self.location])
 
     def render(self):
         if self.location is None:

--- a/folium/map.py
+++ b/folium/map.py
@@ -396,7 +396,7 @@ class Marker(MacroElement):
                 tooltip if isinstance(tooltip, Tooltip) else Tooltip(str(tooltip))
             )
 
-    def _get_self_bounds(self) -> List[List[float]]:
+    def _get_self_bounds(self) -> TypeBounds:
         """Computes the bounds of the object itself.
 
         Because a marker has only single coordinates, we repeat them.

--- a/folium/plugins/overlapping_marker_spiderfier.py
+++ b/folium/plugins/overlapping_marker_spiderfier.py
@@ -92,7 +92,7 @@ class OverlappingMarkerSpiderfier(JSCSSMixin, MacroElement):
     ) -> Element:
         self._parent = parent
         self.markers = self._get_all_markers(parent)
-        super().add_to(parent, name=name, index=index)
+        return super().add_to(parent, name=name, index=index)
 
     def _get_all_markers(self, element: Element) -> list:
         markers = []

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -319,7 +319,7 @@ class ImageOverlay(Layer):
 
         self.url = image_to_url(image, origin=origin, colormap=colormap)
 
-    def render(self, **kwargs) -> None:
+    def render(self, **kwargs):
         super().render()
 
         figure = self.get_root()

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -16,7 +16,7 @@ from folium.utilities import (
     image_to_url,
     mercator_transform,
     parse_options,
-    remove_empty,
+    remove_empty, TypeBoundsReturn,
 )
 
 
@@ -344,7 +344,7 @@ class ImageOverlay(Layer):
                 Element(pixelated), name="leaflet-image-layer"
             )  # noqa
 
-    def _get_self_bounds(self) -> TypeBounds:
+    def _get_self_bounds(self) -> TypeBoundsReturn:
         """
         Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]].
@@ -411,7 +411,7 @@ class VideoOverlay(Layer):
         self.bounds = bounds
         self.options = remove_empty(autoplay=autoplay, loop=loop, **kwargs)
 
-    def _get_self_bounds(self) -> TypeBounds:
+    def _get_self_bounds(self) -> TypeBoundsReturn:
         """
         Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]]

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -3,7 +3,7 @@ Wraps leaflet TileLayer, WmsTileLayer (TileLayer.WMS), ImageOverlay, and VideoOv
 
 """
 
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Union
 
 import xyzservices
 from branca.element import Element, Figure
@@ -12,11 +12,13 @@ from folium.map import Layer
 from folium.template import Template
 from folium.utilities import (
     TypeBounds,
+    TypeBoundsReturn,
     TypeJsonValue,
     image_to_url,
     mercator_transform,
+    normalize_bounds_type,
     parse_options,
-    remove_empty, TypeBoundsReturn, normalize_bounds_type,
+    remove_empty,
 )
 
 

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -3,7 +3,7 @@ Wraps leaflet TileLayer, WmsTileLayer (TileLayer.WMS), ImageOverlay, and VideoOv
 
 """
 
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, cast
 
 import xyzservices
 from branca.element import Element, Figure
@@ -16,7 +16,7 @@ from folium.utilities import (
     image_to_url,
     mercator_transform,
     parse_options,
-    remove_empty, TypeBoundsReturn,
+    remove_empty, TypeBoundsReturn, normalize_bounds_type,
 )
 
 
@@ -246,7 +246,7 @@ class ImageOverlay(Layer):
         * If string, it will be written directly in the output file.
         * If file, it's content will be converted as embedded in the output file.
         * If array-like, it will be converted to PNG base64 string and embedded in the output.
-    bounds: list
+    bounds: list/tuple of list/tuple of float
         Image bounds on the map in the form
          [[lat_min, lon_min], [lat_max, lon_max]]
     opacity: float, default Leaflet's default (1.0)
@@ -350,7 +350,7 @@ class ImageOverlay(Layer):
         in the form [[lat_min, lon_min], [lat_max, lon_max]].
 
         """
-        return self.bounds
+        return normalize_bounds_type(self.bounds)
 
 
 class VideoOverlay(Layer):
@@ -361,7 +361,7 @@ class VideoOverlay(Layer):
     ----------
     video_url: str
         URL of the video
-    bounds: list
+    bounds: list/tuple of list/tuple of float
         Video bounds on the map in the form
          [[lat_min, lon_min], [lat_max, lon_max]]
     autoplay: bool, default True
@@ -417,4 +417,4 @@ class VideoOverlay(Layer):
         in the form [[lat_min, lon_min], [lat_max, lon_max]]
 
         """
-        return self.bounds
+        return normalize_bounds_type(self.bounds)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -49,7 +49,8 @@ TypeJsonValue = Union[TypeJsonValueNoNone, None]
 
 TypePathOptions = Union[bool, str, float, None]
 
-TypeBounds = List[List[Optional[float]]]
+TypeBounds = Sequence[Sequence[float]]
+TypeBoundsReturn = List[List[Optional[float]]]
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -9,6 +9,7 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -35,12 +36,13 @@ from branca.utilities import (  # noqa F401
     write_png,
 )
 
-from folium import Popup
-
 try:
     import pandas as pd
 except ImportError:
     pd = None
+
+if TYPE_CHECKING:
+    from .features import Popup
 
 
 TypeLine = Iterable[Sequence[float]]
@@ -54,7 +56,7 @@ TypePathOptions = Union[bool, str, float, None]
 TypeBounds = Sequence[Sequence[float]]
 TypeBoundsReturn = List[List[Optional[float]]]
 
-TypeContainer = Union[Figure, Div, Popup]
+TypeContainer = Union[Figure, Div, "Popup"]
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -326,6 +326,10 @@ def get_bounds(
     return bounds
 
 
+def normalize_bounds_type(bounds: TypeBounds) -> TypeBoundsReturn:
+    return [[float(x) if x is not None else None for x in y] for y in bounds]
+
+
 def camelize(key: str) -> str:
     """Convert a python_style_variable_name to lowerCamelCase.
 

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -49,7 +49,7 @@ TypeJsonValue = Union[TypeJsonValueNoNone, None]
 
 TypePathOptions = Union[bool, str, float, None]
 
-TypeBounds = Sequence[Sequence[float]]
+TypeBounds = List[List[Optional[float]]]
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -24,7 +24,9 @@ from typing import (
 from urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 
 import numpy as np
-from branca.element import Element, Figure
+from folium import Popup
+
+from branca.element import Element, Figure, Div
 
 # import here for backwards compatibility
 from branca.utilities import (  # noqa F401
@@ -51,6 +53,8 @@ TypePathOptions = Union[bool, str, float, None]
 
 TypeBounds = Sequence[Sequence[float]]
 TypeBoundsReturn = List[List[Optional[float]]]
+
+TypeContainer = Union[Figure, Div, Popup]
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -24,9 +24,7 @@ from typing import (
 from urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 
 import numpy as np
-from folium import Popup
-
-from branca.element import Element, Figure, Div
+from branca.element import Div, Element, Figure
 
 # import here for backwards compatibility
 from branca.utilities import (  # noqa F401
@@ -36,6 +34,8 @@ from branca.utilities import (  # noqa F401
     none_min,
     write_png,
 )
+
+from folium import Popup
 
 try:
     import pandas as pd

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -16,7 +16,7 @@ from folium.utilities import (
     parse_options,
     validate_location,
     validate_locations,
-    validate_multi_locations,
+    validate_multi_locations, normalize_bounds_type,
 )
 
 
@@ -131,6 +131,20 @@ def test_if_pandas_df_convert_to_numpy():
     # Also check if it ignores things that are not Pandas DataFrame:
     assert if_pandas_df_convert_to_numpy(data) is data
     assert if_pandas_df_convert_to_numpy(expected) is expected
+
+
+@pytest.mark.parametrize(
+    "bounds, expected",
+    [
+        ([[1, 2], [3, 4]], [[1.0, 2.0], [3.0, 4.0]]),
+        ([[None, 2], [3, None]], [[None, 2.0], [3.0, None]]),
+        ([[1.1, 2.2], [3.3, 4.4]], [[1.1, 2.2], [3.3, 4.4]]),
+        ([[None, None], [None, None]], [[None, None], [None, None]]),
+        ([[0, -1], [-2, 3]], [[0.0, -1.0], [-2.0, 3.0]]),
+    ],
+)
+def test_normalize_bounds_type(bounds, expected):
+    assert normalize_bounds_type(bounds) == expected
 
 
 def test_camelize():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -12,11 +12,12 @@ from folium.utilities import (
     get_obj_in_upper_tree,
     if_pandas_df_convert_to_numpy,
     javascript_identifier_path_to_array_notation,
+    normalize_bounds_type,
     parse_font_size,
     parse_options,
     validate_location,
     validate_locations,
-    validate_multi_locations, normalize_bounds_type,
+    validate_multi_locations,
 )
 
 


### PR DESCRIPTION
In the recent Branca release we enabled type checking. This leads to issues when type checking Folium, since it relies on Branca. This PR addresses these issues.

Each commit in this PR contains a single fix, so you can walk through the commits to see what changes.

## Render function
Note about the `render` function: I removed the return type, which effectively disables type checking. This is unfortunately necessary. In Branca we specify this function should return a string, but that's not what's done in `MacroElement` and so basically everything in Folium. We should update the type in Branca, do a release, then add the types back in Folium. This is a lot of trouble so maybe not worth the effort.

## Bounds
The return type of bounds functions should allow for None values to be consistent. Even if we're sure a function returns floats not None, we still need to type it as optional. That's because the values are returned in a list, which is mutable.

Another thing is that some functions accept a `bounds` argument, which can be a list or tuple, but must have non-None values. Those types are distinct from bounds as return values, which should be list of list of optional float. Split the two in distinct types.

## VegaLite
In practice, a `VegaLite` only works if it's added to a `Figure`, `Div` or `Popup`. We only have examples of that in our documentation, but it's not explicitly listed. Update the code to raise a meaningful error when this element is added to the wrong parent. This also then satisfies Mypy.