### PR TITLE
Cleanup make MacroElements from Elements

### DIFF
--- a/folium/elements.py
+++ b/folium/elements.py
@@ -1,6 +1,12 @@
 from typing import List, Tuple
 
-from branca.element import CssLink, Figure, JavascriptLink, MacroElement
+from branca.element import (
+    CssLink,
+    Element,  # NoQA: F401  needed as a reexport
+    Figure,
+    JavascriptLink,
+    MacroElement,
+)
 
 from folium.template import Template
 from folium.utilities import JsCode

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -1,12 +1,12 @@
 from typing import List, Tuple
 
-from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
+from branca.element import CssLink, Figure, JavascriptLink, MacroElement
 
 from folium.template import Template
 from folium.utilities import JsCode
 
 
-class JSCSSMixin(Element):
+class JSCSSMixin(MacroElement):
     """Render links to external Javascript and CSS resources."""
 
     default_js: List[Tuple[str, str]] = []

--- a/folium/features.py
+++ b/folium/features.py
@@ -297,9 +297,6 @@ class VegaLite(MacroElement):
             name=self.get_name(),
         )
 
-        # TODO: this could be rewritten to use the facilities of MacroElement
-        # and the facilities of JSCSSMixin
-
         figure = self.get_root()
         assert isinstance(
             figure, Figure

--- a/folium/features.py
+++ b/folium/features.py
@@ -193,8 +193,6 @@ class Vega(JSCSSMixin):
             name=self.get_name(),
         )
 
-        # TODO: this could be rewritten to use the facilities of MacroElement
-        # and the facilities of JSCSSMixin
         figure = self.get_root()
         assert isinstance(
             figure, Figure

--- a/folium/features.py
+++ b/folium/features.py
@@ -101,7 +101,7 @@ class RegularPolygonMarker(JSCSSMixin, Marker):
         )
 
 
-class Vega(JSCSSMixin, Element):
+class Vega(JSCSSMixin):
     """
     Creates a Vega chart element.
 
@@ -193,6 +193,8 @@ class Vega(JSCSSMixin, Element):
             name=self.get_name(),
         )
 
+        # TODO: this could be rewritten to use the facilities of MacroElement
+        # and the facilities of JSCSSMixin
         figure = self.get_root()
         assert isinstance(
             figure, Figure
@@ -224,7 +226,7 @@ class Vega(JSCSSMixin, Element):
         )
 
 
-class VegaLite(Element):
+class VegaLite(MacroElement):
     """
     Creates a Vega-Lite chart element.
 
@@ -296,6 +298,9 @@ class VegaLite(Element):
             ),
             name=self.get_name(),
         )
+
+        # TODO: this could be rewritten to use the facilities of MacroElement
+        # and the facilities of JSCSSMixin
 
         figure = self.get_root()
         assert isinstance(

--- a/folium/map.py
+++ b/folium/map.py
@@ -409,7 +409,7 @@ class Marker(MacroElement):
         super().render()
 
 
-class Popup(Element):
+class Popup(MacroElement):
     """Create a Popup instance that can be linked to a Layer.
 
     Parameters


### PR DESCRIPTION
This change involves several classes that require being added to a Figure. Since these classes follow the `render` semantics of a MacroElement it makes more sense to make them also inherit from MacroElement.

Excluded from this change is actually making use of the template mechanics of the MacroElement.