### PR TITLE
Update copyright in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,6 @@
 Copyright (C) 2013-, Folium developers
+See https://github.com/python-visualization/folium/graphs/contributors for a
+full list of contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013, Rob Story
+Copyright (C) 2013-, Folium developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
See the discussion here: https://github.com/python-visualization/folium/pull/2064

Update the copyright statement to refer to all contributors to the project. Add a hyphen to indicate ongoing development. We don't want to have to update this file every year. Add a link to the list of contributors.

I'm open to other suggestions! Don't care that much to be honest since it's MIT and will stay that way, just don't want this to be a yearly ongoing issue.