### PR TITLE
Multiple markers with one icon

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -373,13 +373,16 @@ class Marker(MacroElement):
 
     class SetIcon(MacroElement):
         """Set the icon of a marker after both are created."""
-        _template = Template("""
+
+        _template = Template(
+            """
             {% macro script(this, kwargs) %}
                 {{ this.marker.get_name() }}.setIcon({{ this.icon.get_name() }});
             {% endmacro %}
-        """)
+        """
+        )
 
-        def __init__(self, marker: 'Marker', icon: 'Icon'):
+        def __init__(self, marker: "Marker", icon: "Icon"):
             super().__init__()
             self._name = "SetIcon"
             self.marker = marker

--- a/folium/map.py
+++ b/folium/map.py
@@ -372,6 +372,20 @@ class Marker(MacroElement):
         """
     )
 
+    class SetIcon(MacroElement):
+        """Set the icon of a marker after both are created."""
+        _template = Template("""
+            {% macro script(this, kwargs) %}
+                {{ this.marker.get_name() }}.setIcon({{ this.icon.get_name() }});
+            {% endmacro %}
+        """)
+
+        def __init__(self, marker: 'Marker', icon: 'Icon'):
+            super().__init__()
+            self._name = "SetIcon"
+            self.marker = marker
+            self.icon = icon
+
     def __init__(
         self,
         location: Optional[Sequence[float]] = None,
@@ -388,7 +402,8 @@ class Marker(MacroElement):
             draggable=draggable or None, autoPan=draggable or None, **kwargs
         )
         if icon is not None:
-            self.add_child(icon)
+            # this makes sure it is added only once
+            self._parent.add_child(icon, name=icon.get_name(), index=0)
             self.icon = icon
         if popup is not None:
             self.add_child(popup if isinstance(popup, Popup) else Popup(str(popup)))
@@ -406,6 +421,8 @@ class Marker(MacroElement):
         return cast(TypeBoundsReturn, [self.location, self.location])
 
     def render(self):
+        if self.icon:
+            self.add_child(self.SetIcon(marker=self, icon=self.icon))
         if self.location is None:
             raise ValueError(
                 f"{self._name} location must be assigned when added directly to map."

--- a/folium/map.py
+++ b/folium/map.py
@@ -340,7 +340,7 @@ class Marker(MacroElement):
         folium.Popup or a folium.Popup instance.
     tooltip: str or folium.Tooltip, default None
         Display a text when hovering over the object.
-    icon: Icon plugin
+    icon: Icon, CustomIcon or DivIcon, optional
         the Icon plugin to use to render the marker.
     draggable: bool, default False
         Set to True to be able to drag the marker around the map.
@@ -418,12 +418,14 @@ class Marker(MacroElement):
         return cast(TypeBoundsReturn, [self.location, self.location])
 
     def render(self):
+        from .features import CustomIcon, DivIcon
+
         if self.location is None:
             raise ValueError(
                 f"{self._name} location must be assigned when added directly to map."
             )
         for child in list(self._children.values()):
-            if isinstance(child, Icon):
+            if isinstance(child, (Icon, CustomIcon, DivIcon)):
                 self.add_child(self.SetIcon(marker=self, icon=child))
         super().render()
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -275,7 +275,6 @@ class Icon(MacroElement):
             var {{ this.get_name() }} = L.AwesomeMarkers.icon(
                 {{ this.options|tojavascript }}
             );
-            {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
     )
@@ -402,9 +401,7 @@ class Marker(MacroElement):
             draggable=draggable or None, autoPan=draggable or None, **kwargs
         )
         if icon is not None:
-            # this makes sure it is added only once
-            self._parent.add_child(icon, name=icon.get_name(), index=0)
-            self.icon = icon
+            self.add_child(icon)
         if popup is not None:
             self.add_child(popup if isinstance(popup, Popup) else Popup(str(popup)))
         if tooltip is not None:
@@ -421,12 +418,13 @@ class Marker(MacroElement):
         return cast(TypeBoundsReturn, [self.location, self.location])
 
     def render(self):
-        if self.icon:
-            self.add_child(self.SetIcon(marker=self, icon=self.icon))
         if self.location is None:
             raise ValueError(
                 f"{self._name} location must be assigned when added directly to map."
             )
+        for child in list(self._children.values()):
+            if isinstance(child, Icon):
+                self.add_child(self.SetIcon(marker=self, icon=child))
         super().render()
 
 


### PR DESCRIPTION
Based on the comments on #2053 I made a new version that sets the icon from the markers perspective. This is also similar to how `Layer` works.

- Check if a marker has an icon added as a child, if so, add another element that sets the icon on the marker.

Tested it with this case:

```
    m = Map((44, -93), tiles="cartodb dark matter", zoom_start=8)

    icon = Icon(icon='music')
    markers = [
        Marker((52, 5), icon=icon, popup="0"),
        Marker((52, 5.1), icon=icon, popup="1"),
        Marker((52.1, 5)),
        Marker((52.1, 5.1)),
    ]
    Icon(icon="cloud").add_to(markers[-1])
    fg = FeatureGroup(name='group').add_to(m)
    for marker in markers:
        marker.add_to(fg)

    FitOverlays(padding=10).add_to(m)
```

If this approach looks good, I'll generate some test cases.

Not sure how much of a breaking change this is. From a direct user perspective, I don't think there's an issue. Not sure about packages that use Folium internals though.