### PR TITLE
Fix javascript template

### DIFF
--- a/folium/plugins/timeline.py
+++ b/folium/plugins/timeline.py
@@ -182,7 +182,7 @@ class TimelineSlider(JSCSSMixin, MacroElement):
 
         {% macro script(this, kwargs) %}
           var {{ this.get_name() }} = L.timelineSliderControl(
-              {{ this.options|tojavascript }};
+              {{ this.options|tojavascript }}
           );
           {{ this.get_name() }}.addTo({{ this._parent.get_name() }});
 


### PR DESCRIPTION
One too many semi-colons. Closes #2070.