### PR TITLE
Fix icon when passing Marker to GeoJson

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -404,7 +404,7 @@ class Marker(MacroElement):
             draggable=draggable or None, autoPan=draggable or None, **kwargs
         )
         # this attribute is not used by Marker, but by GeoJson
-        self.icon: Union[Icon, "CustomIcon", "DivIcon", None] = None
+        self.icon = None
         if icon is not None:
             self.add_child(icon)
             self.icon = icon

--- a/folium/map.py
+++ b/folium/map.py
@@ -424,15 +424,12 @@ class Marker(MacroElement):
         return cast(TypeBoundsReturn, [self.location, self.location])
 
     def render(self):
-        from .features import CustomIcon, DivIcon
-
         if self.location is None:
             raise ValueError(
                 f"{self._name} location must be assigned when added directly to map."
             )
-        for child in list(self._children.values()):
-            if isinstance(child, (Icon, CustomIcon, DivIcon)):
-                self.add_child(self.SetIcon(marker=self, icon=child))
+        if self.icon:
+            self.add_child(self.SetIcon(marker=self, icon=self.icon))
         super().render()
 
 

--- a/folium/map.py
+++ b/folium/map.py
@@ -403,8 +403,11 @@ class Marker(MacroElement):
         self.options = remove_empty(
             draggable=draggable or None, autoPan=draggable or None, **kwargs
         )
+        # this attribute is not used by Marker, but by GeoJson
+        self.icon: Optional[Icon] = None
         if icon is not None:
             self.add_child(icon)
+            self.icon = icon
         if popup is not None:
             self.add_child(popup if isinstance(popup, Popup) else Popup(str(popup)))
         if tooltip is not None:

--- a/folium/map.py
+++ b/folium/map.py
@@ -404,7 +404,7 @@ class Marker(MacroElement):
             draggable=draggable or None, autoPan=draggable or None, **kwargs
         )
         # this attribute is not used by Marker, but by GeoJson
-        self.icon: Optional[Icon] = None
+        self.icon: Union[Icon, "CustomIcon", "DivIcon", None] = None
         if icon is not None:
             self.add_child(icon)
             self.icon = icon


### PR DESCRIPTION
Fixes https://github.com/python-visualization/folium/issues/2084, which is an issue introduced by https://github.com/python-visualization/folium/pull/2068.

We shouldn't have removed `self.icon` in `Marker`. It's not directly visible where it is used, so I added a comment to prevent this from happening again.

