### PR TITLE
Doc String -- Dictionary key of Gradient Argument -- update heat_map.py -- folium.plugins

### DIFF
--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -36,7 +36,7 @@ class HeatMap(JSCSSMixin, Layer):
         Amount of blur
     gradient : dict, default None
         Color gradient config. Defaults to
-        {.4: "blue", .6: "cyan", .7: "lime", .8: "yellow", 1: "red"}
+        {".4": "blue", ".6": "cyan", ".7": "lime", ".8": "yellow", "1": "red"}
     overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True


### PR DESCRIPTION
In the docstring, the gradient dictionary keys are mentioned as float, but I believe the backend code expects them to be strings. So, I changed the docstring to reflect this, from float values (e.g., .8) to string values (e.g., ".8").