### PR TITLE
Fix numeric keys for dict inputs in tojavascript

### DIFF
--- a/folium/template.py
+++ b/folium/template.py
@@ -15,7 +15,10 @@ def tojavascript(obj: Union[str, JsCode, dict, list, Element]) -> str:
     elif isinstance(obj, dict):
         out = ["{\n"]
         for key, value in obj.items():
-            out.append(f'  "{camelize(key)}": ')
+            if isinstance(key, str):
+                out.append(f'  "{camelize(key)}": ')
+            else:
+                out.append(f"  {key}: ")
             out.append(tojavascript(value))
             out.append(",\n")
         out.append("}")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -19,6 +19,12 @@ def test_tojavascript_with_dict():
     assert tojavascript(dict_obj) == '{\n  "key": "value",\n}'
 
 
+def test_tojavascript_with_dict_with_mixed_key_types():
+    dict_obj = {"key": "value", 1: "another value", 3.14: "pi"}
+    expected = '{\n  "key": "value",\n  1: "another value",\n  3.14: "pi",\n}'
+    assert tojavascript(dict_obj) == expected
+
+
 def test_tojavascript_with_list():
     list_obj = ["value1", "value2"]
     assert tojavascript(list_obj) == '[\n"value1",\n"value2",\n]'


### PR DESCRIPTION
Even though json cannot have numeric keys in dicts, javascript can. This change handles that case.

Closes #2098