### PR TITLE
Docs: User guide LayerControl example doesn't work

### DIFF
--- a/docs/user_guide/ui_elements/layer_control.md
+++ b/docs/user_guide/ui_elements/layer_control.md
@@ -12,8 +12,7 @@ Add a control to the map to show or hide layers.
 ```{code-cell} ipython3
 m = folium.Map(tiles=None)
 
-folium.TileLayer("OpenStreetMap").add_to(m)
-folium.TileLayer(show=False).add_to(m)
+folium.TileLayer("OpenStreetMap", overlay=True).add_to(m)
 
 folium.LayerControl().add_to(m)
 


### PR DESCRIPTION
Makes the `TileLayer` in the first example an overlay instead of base layer, so that it can be hidden as well as shown.