### PR TITLE
Docs: `utilities.image_to_url()` `'image'` and related docstrings

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1862,13 +1862,13 @@ class CustomIcon(Icon):
 
     Parameters
     ----------
-    icon_image :  string, file or array-like object
-        The data you want to use as an icon.
-        * If string, it will be written directly in the output file.
-        * If file, it's content will be converted as embedded in the
-        output file.
-        * If array-like, it will be converted to PNG base64 string
-        and embedded in the output.
+    icon_image : string or array-like object
+        The data to use as an icon.
+        *   If string is a path to an image file, its content will be converted and
+            embedded.
+        *   If string is a URL, it will be linked.
+        *   Otherwise a string will be assumed to be JSON and embedded.
+        *   If array-like, it will be converted to PNG base64 string and embedded.
 
     icon_size : tuple of 2 int, optional
         Size of the icon image in pixels.

--- a/folium/features.py
+++ b/folium/features.py
@@ -1864,12 +1864,12 @@ class CustomIcon(Icon):
     ----------
     icon_image : string or array-like object
         The data to use as an icon.
-        *   If string is a path to an image file, its content will be converted and
-            embedded.
-        *   If string is a URL, it will be linked.
-        *   Otherwise a string will be assumed to be JSON and embedded.
-        *   If array-like, it will be converted to PNG base64 string and embedded.
 
+        * If string is a path to an image file, its content will be converted and
+          embedded.
+        * If string is a URL, it will be linked.
+        * Otherwise a string will be assumed to be JSON and embedded.
+        * If array-like, it will be converted to PNG base64 string and embedded.
     icon_size : tuple of 2 int, optional
         Size of the icon image in pixels.
     icon_anchor : tuple of 2 int, optional

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -245,14 +245,15 @@ class ImageOverlay(Layer):
     ----------
     image: string or array-like object
         The data to overlay as an image.
-        *   If string is a path to an image file, its content will be converted and
-            embedded.
-        *   If string is a URL, it will be linked.
-        *   Otherwise a string will be assumed to be JSON and embedded.
-        *   If array-like, it will be converted to PNG base64 string and embedded.
+
+        * If string is a path to an image file, its content will be converted and
+          embedded.
+        * If string is a URL, it will be linked.
+        * Otherwise a string will be assumed to be JSON and embedded.
+        * If array-like, it will be converted to PNG base64 string and embedded.
     bounds: list/tuple of list/tuple of float
         Image bounds on the map in the form
-         [[lat_min, lon_min], [lat_max, lon_max]]
+        [[lat_min, lon_min], [lat_max, lon_max]]
     opacity: float, default Leaflet's default (1.0)
     alt: string, default Leaflet's default ('')
     origin: ['upper' | 'lower'], optional, default 'upper'

--- a/folium/raster_layers.py
+++ b/folium/raster_layers.py
@@ -243,11 +243,13 @@ class ImageOverlay(Layer):
 
     Parameters
     ----------
-    image: string, file or array-like object
-        The data you want to draw on the map.
-        * If string, it will be written directly in the output file.
-        * If file, it's content will be converted as embedded in the output file.
-        * If array-like, it will be converted to PNG base64 string and embedded in the output.
+    image: string or array-like object
+        The data to overlay as an image.
+        *   If string is a path to an image file, its content will be converted and
+            embedded.
+        *   If string is a URL, it will be linked.
+        *   Otherwise a string will be assumed to be JSON and embedded.
+        *   If array-like, it will be converted to PNG base64 string and embedded.
     bounds: list/tuple of list/tuple of float
         Image bounds on the map in the form
          [[lat_min, lon_min], [lat_max, lon_max]]

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -170,14 +170,13 @@ def image_to_url(
     Parameters
     ----------
     image: string or array-like object
-        *   If string is a path to an image file, its content will be converted and
-            embedded in the output URL.
-        *   If string is a URL, it will be linked in the output URL.
-        *   Otherwise a string will be assumed to be JSON and embedded in the
-            output URL.
-        *   If array-like, it will be converted to PNG base64 string and embedded in the
-            output URL.
-
+        *  If string is a path to an image file, its content will be converted and
+           embedded in the output URL.
+        *  If string is a URL, it will be linked in the output URL.
+        *  Otherwise a string will be assumed to be JSON and embedded in the
+           output URL.
+        *  If array-like, it will be converted to PNG base64 string and embedded in the
+           output URL.
     origin: ['upper' | 'lower'], optional, default 'upper'
         Place the [0, 0] index of the array in the upper left or
         lower left corner of the axes.

--- a/folium/utilities.py
+++ b/folium/utilities.py
@@ -169,12 +169,15 @@ def image_to_url(
 
     Parameters
     ----------
-    image: string, file or array-like object
-        * If string, it will be written directly in the output file.
-        * If file, it's content will be converted as embedded in the
-          output file.
-        * If array-like, it will be converted to PNG base64 string and
-          embedded in the output.
+    image: string or array-like object
+        *   If string is a path to an image file, its content will be converted and
+            embedded in the output URL.
+        *   If string is a URL, it will be linked in the output URL.
+        *   Otherwise a string will be assumed to be JSON and embedded in the
+            output URL.
+        *   If array-like, it will be converted to PNG base64 string and embedded in the
+            output URL.
+
     origin: ['upper' | 'lower'], optional, default 'upper'
         Place the [0, 0] index of the array in the upper left or
         lower left corner of the axes.


### PR DESCRIPTION
Fixes #2905.

- Amends docstring for `utilities.image_to_url()` `'image'` parameter (not part of publicly documented API)
- Adapts this amend for these members of publicly documented API, depending on context:
  - `features.CustomIcon` `'icon_image'` parameter/attributes
  - `raster_layers.ImageOverlay` `'image'` parameter/attributes
- Uses more consistent indenting