### PR TITLE
docs: update switcher.json for v0.19.5 manually

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,9 +4,13 @@
     "url": "https://python-visualization.github.io/folium/dev/"
   },
   {
-    "name": "latest (0.19.4)",
-    "version": "0.19.4",
+    "name": "latest (0.19.5)",
+    "version": "0.19.5",
     "url": "https://python-visualization.github.io/folium/latest/"
+  },
+  {
+    "version": "0.19.4",
+    "url": "https://python-visualization.github.io/folium/v0.19.4/"
   },
   {
     "version": "0.19.3",


### PR DESCRIPTION
Building and pushing the docs failed for v0.19.5 because of a broken link. I manually built the docs for this version and pushed to gh-pages. Now update the switcher.json so they show up in the version dropdown. The broken link has been fixed in the meantime so it should not be an issue in the next release.

Why even do this? The docs didn't change meaningfully from 0.19.4 to 0.19.5, but I think it may be confusing to users if there's a version listed on Pypi/pip that's not in our documentation.