### PR TITLE
docs: update ImageOverlay with local file example

### DIFF
--- a/docs/user_guide/raster_layers/image_overlay.md
+++ b/docs/user_guide/raster_layers/image_overlay.md
@@ -11,37 +11,31 @@ If you have a static image file on your disk, you can simply draw it on the map.
 import os
 import folium
 
-m = folium.Map([37, 0], zoom_start=1)
-merc = os.path.join("data", "Mercator_projection_SW.png")
+m = folium.Map([0, 0], zoom_start=2)
+image_filepath = os.path.join("..", "..", "_static", "folium_logo.png")
 
+img = folium.raster_layers.ImageOverlay(
+    name="Folium logo",
+    image=image_filepath,
+    bounds=[[-50, -45], [50, 45]],
+    opacity=0.6,
+    interactive=True,
+    cross_origin=False,
+    zindex=1,
+)
 
-if not os.path.isfile(merc):
-    print(f"Could not find {merc}")
-else:
-    img = folium.raster_layers.ImageOverlay(
-        name="Mercator projection SW",
-        image=merc,
-        bounds=[[-82, -180], [82, 180]],
-        opacity=0.6,
-        interactive=True,
-        cross_origin=False,
-        zindex=1,
-    )
+folium.Popup("I am an image").add_to(img)
 
-    folium.Popup("I am an image").add_to(img)
-
-    img.add_to(m)
-    folium.LayerControl().add_to(m)
+img.add_to(m)
+folium.LayerControl().add_to(m)
 
 m
 ```
 
-A few remarks:
+Note that your image has to be in Mercator projection format.
 
-* Note that your image has to be in Mercator projection format.
 
-  The image we've used is based on https://en.wikipedia.org/wiki/File:Mercator_projection_SW.jpg ; that you can find in wikipedia's article on Mercator Projection (https://en.wikipedia.org/wiki/Mercator_projection).
-
+## Using an image from a url
 
 You can also provide simply URL. In this case, the image will not be embedded in folium's output.
 


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/2094

Update the ImageOverlay example in the docs that shows how to use a local file. The previous example file is no longer included after the docs overhaul. This example breaking was not spotted because the code there is robust to the file not existing.

- Use another image that exists in the docs static files: the Folium logo. Easy and for the example it doesn't really matter I think.
- Make it raise an error if the file not exists. That way we will be notified if this example breaks in the future.

### Screenshot

![Capture](https://github.com/user-attachments/assets/171b7246-881f-4397-8c98-a5aea7bbe173)
