### PR TITLE
Unpin Selenium version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ pycodestyle
 pydata-sphinx-theme
 pytest
 scipy
-selenium<4.27.0
+selenium
 setuptools_scm
 sphinx
 types-requests


### PR DESCRIPTION
Closes https://github.com/python-visualization/folium/issues/2035.

Seems like whatever issue we had with a particular Selenium version has passed, so we can unpin it again.