### PR TITLE
CI: run Geopandas tests

### DIFF
--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -1,4 +1,4 @@
-name: Run Geopandas tests
+name: Geopandas tests
 
 on:
   pull_request:

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Checkout Geopandas
       uses: actions/checkout@v4
       with:
+        repository: geopandas/geopandas
         path: geopandas
 
     - name: Install Geopandas dev dependencies
@@ -35,10 +36,12 @@ jobs:
 
     - name: Install folium from source
       run: |
+        cd folium
         pwd && ls -la
-        python -m pip install -e folium/ --no-deps --force-reinstall
+        python -m pip install -e . --no-deps --force-reinstall
 
     - name: Run Geopandas tests
       run: |
+        cd geopandas
         pwd && ls -la
-        pytest geopandas/geopandas/tests/test_explore.py
+        pytest geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -37,11 +37,9 @@ jobs:
     - name: Install folium from source
       run: |
         cd folium
-        pwd && ls -la
         python -m pip install -e . --no-deps --force-reinstall
 
     - name: Run Geopandas tests
       run: |
         cd geopandas
-        pwd && ls -la
-        pytest geopandas/tests/test_explore.py
+        pytest -v -r a -n auto --color=yes geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout Folium
       uses: actions/checkout@v4
+      with:
+        path: main
 
     - name: Setup Micromamba env
       uses: mamba-org/setup-micromamba@v2
@@ -36,9 +38,11 @@ jobs:
     - name: Install folium from source
       shell: bash -l {0}
       run: |
+        pwd && ls -la
         python -m pip install -e . --no-deps --force-reinstall
 
     - name: Run Geopandas tests
       run: |
         cd geopandas
+        pwd && ls -la
         pytest geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout Folium
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         path: folium
 
     - name: Setup Micromamba env

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -1,0 +1,45 @@
+name: Run Geopandas tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Folium
+      uses: actions/checkout@v4
+
+    - name: Setup Micromamba env
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-name: TEST
+        create-args: >-
+          python=3
+          --file requirements.txt
+
+    - name: Install folium from source
+      shell: bash -l {0}
+      run: |
+        python -m pip install -e . --no-deps --force-reinstall
+
+    - name: Checkout Geopandas
+      uses: actions/checkout@v4
+      with:
+        repository: geopandas/geopandas
+        ref: main
+        path: geopandas  # Checkout into a subdirectory
+
+    - name: Install Geopandas dev dependencies
+      run: |
+        cd geopandas
+        pip install -r requirements-dev.txt
+
+    - name: Run Geopandas tests
+      run: |
+        cd geopandas
+        pytest

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Folium
       uses: actions/checkout@v4
       with:
-        path: main
+        path: folium
 
     - name: Setup Micromamba env
       uses: mamba-org/setup-micromamba@v2
@@ -22,14 +22,12 @@ jobs:
         environment-name: TEST
         create-args: >-
           python=3
-          --file requirements.txt
+          --file folium/requirements.txt
 
     - name: Checkout Geopandas
       uses: actions/checkout@v4
       with:
-        repository: geopandas/geopandas
-        ref: main
-        path: geopandas  # Checkout into a subdirectory
+        path: geopandas
 
     - name: Install Geopandas dev dependencies
       run: |
@@ -38,6 +36,7 @@ jobs:
     - name: Install folium from source
       shell: bash -l {0}
       run: |
+        cd folium
         pwd && ls -la
         python -m pip install -e . --no-deps --force-reinstall
 

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Run Geopandas tests
       run: |
         cd geopandas
-        pytest geopandas/tests/test_explore.py
+        pytest -r a geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -22,11 +22,6 @@ jobs:
           python=3
           --file requirements.txt
 
-    - name: Install folium from source
-      shell: bash -l {0}
-      run: |
-        python -m pip install -e . --no-deps --force-reinstall
-
     - name: Checkout Geopandas
       uses: actions/checkout@v4
       with:
@@ -38,6 +33,11 @@ jobs:
       run: |
         cd geopandas
         pip install -r requirements-dev.txt
+
+    - name: Install folium from source
+      shell: bash -l {0}
+      run: |
+        python -m pip install -e . --no-deps --force-reinstall
 
     - name: Run Geopandas tests
       run: |

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Install Geopandas dev dependencies
       run: |
         pip install -r geopandas/requirements-dev.txt
+        pip install geodatasets
 
     - name: Install folium from source
       run: |

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Install Geopandas dev dependencies
       run: |
         pip install -r geopandas/requirements-dev.txt
-        pip install geodatasets
 
     - name: Install folium from source
       run: |

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout Folium
       uses: actions/checkout@v4
       with:
+        # needed to get the correct version number for Folium
         fetch-depth: 0
         path: folium
 
@@ -40,10 +41,8 @@ jobs:
       run: |
         cd folium
         python -m pip install -e . --no-deps --force-reinstall
-        python -c "import os; f='folium/_version.py'; print(open(f).read() if os.path.exists(f) else f'File {f} does not exist')"
-        python -c "import folium; print(folium.__version__)"
 
     - name: Run Geopandas tests
       run: |
         cd geopandas
-        pytest -v -r a -n auto --color=yes geopandas/tests/test_explore.py
+        pytest geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -39,6 +39,8 @@ jobs:
       run: |
         cd folium
         python -m pip install -e . --no-deps --force-reinstall
+        python -c "import os; f='folium/_version.py'; print(open(f).read() if os.path.exists(f) else f'File {f} does not exist')"
+        python -c "import folium; print(folium.__version__)"
 
     - name: Run Geopandas tests
       run: |

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -34,14 +34,11 @@ jobs:
         pip install -r geopandas/requirements-dev.txt
 
     - name: Install folium from source
-      shell: bash -l {0}
       run: |
-        cd folium
         pwd && ls -la
-        python -m pip install -e . --no-deps --force-reinstall
+        python -m pip install -e folium/ --no-deps --force-reinstall
 
     - name: Run Geopandas tests
       run: |
-        cd geopandas
         pwd && ls -la
-        pytest geopandas/tests/test_explore.py
+        pytest geopandas/geopandas/tests/test_explore.py

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -31,8 +31,7 @@ jobs:
 
     - name: Install Geopandas dev dependencies
       run: |
-        cd geopandas
-        pip install -r requirements-dev.txt
+        pip install -r geopandas/requirements-dev.txt
 
     - name: Install folium from source
       shell: bash -l {0}
@@ -42,4 +41,4 @@ jobs:
     - name: Run Geopandas tests
       run: |
         cd geopandas
-        pytest
+        pytest geopandas/tests/test_explore.py

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -259,7 +259,7 @@ class Map(JSCSSMixin, Evented):
         no_touch: bool = False,
         disable_3d: bool = False,
         png_enabled: bool = False,
-        zoom_control: Union[bool, str] = True,
+        zoom_control: Union[bool, str] = False,
         font_size: str = "1rem",
         **kwargs: TypeJsonValue,
     ):

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -243,7 +243,7 @@ class Map(JSCSSMixin, Evented):
         left: Union[str, float] = "0%",
         top: Union[str, float] = "0%",
         position: str = "relative",
-        tiles: Union[str, TileLayer, None] = "CartDbPositron",
+        tiles: Union[str, TileLayer, None] = "OpenStreetMap",
         attr: Optional[str] = None,
         min_zoom: Optional[int] = None,
         max_zoom: Optional[int] = None,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -243,7 +243,7 @@ class Map(JSCSSMixin, Evented):
         left: Union[str, float] = "0%",
         top: Union[str, float] = "0%",
         position: str = "relative",
-        tiles: Union[str, TileLayer, None] = "OpenStreetMap",
+        tiles: Union[str, TileLayer, None] = "CartDbPositron",
         attr: Optional[str] = None,
         min_zoom: Optional[int] = None,
         max_zoom: Optional[int] = None,

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -259,7 +259,7 @@ class Map(JSCSSMixin, Evented):
         no_touch: bool = False,
         disable_3d: bool = False,
         png_enabled: bool = False,
-        zoom_control: Union[bool, str] = False,
+        zoom_control: Union[bool, str] = True,
         font_size: str = "1rem",
         **kwargs: TypeJsonValue,
     ):


### PR DESCRIPTION
Add a workflow to run the Geopandas tests on the dev version of Folium.

Verified this works by pushing a commit to Folium that breaks the Geopandas tests, then restoring it of course.