### PR TITLE
Make DivIcon and CustomIcon work with the new Marker approach

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1718,7 +1718,6 @@ class DivIcon(MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.divIcon({{ this.options|tojavascript }});
-            {{this._parent.get_name()}}.setIcon({{this.get_name()}});
         {% endmacro %}
         """
     )  # noqa
@@ -1895,7 +1894,6 @@ class CustomIcon(Icon):
         """
         {% macro script(this, kwargs) %}
         var {{ this.get_name() }} = L.icon({{ this.options|tojavascript }});
-        {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
     )  # noqa

--- a/folium/map.py
+++ b/folium/map.py
@@ -382,7 +382,9 @@ class Marker(MacroElement):
         """
         )
 
-        def __init__(self, marker: "Marker", icon: "Icon"):
+        def __init__(
+            self, marker: "Marker", icon: Union[Icon, "CustomIcon", "DivIcon"]
+        ):
             super().__init__()
             self._name = "SetIcon"
             self.marker = marker


### PR DESCRIPTION
Earlier we made this change for `Marker` and `Icon` (https://github.com/python-visualization/folium/pull/2068), where the `Icon` template no longer adds itself to its parent. Instead, the `Marker` contains code to add its icon to itself. This makes it so that an icon can be reused for multiple markers.

At the time we didn't also apply this to `DivIcon` and `CustomIcon`. But it works for them in the same way and solves the same issue.

This should close https://github.com/python-visualization/folium/issues/744 and also close https://github.com/python-visualization/folium/issues/1885.

## TODO

- [ ] This PR should fix the regression introduced by https://github.com/python-visualization/folium/pull/2086, where marker.add_child(icon) broke.

- [ ] This PR needs some rigorous tests to make sure it works robustly for all cases, like passing icon as a parameter, or doing `marker.add_child(icon)` or `icon.add_to(marker)`. 
