### PR TITLE
Add a scheduled trigger to the workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,8 @@
 name: Publish Docs
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,8 @@
 name: Publish to PyPI
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,6 +1,8 @@
 name: Code Tests
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -1,6 +1,8 @@
 name: Geopandas tests
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_latest_branca.yml
+++ b/.github/workflows/test_latest_branca.yml
@@ -1,6 +1,8 @@
 name: Code Tests with Latest branca
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_mypy.yml
+++ b/.github/workflows/test_mypy.yml
@@ -1,6 +1,8 @@
 name: Mypy type hint checks
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_selenium.yml
+++ b/.github/workflows/test_selenium.yml
@@ -1,6 +1,8 @@
 name: Selenium Tests
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:

--- a/.github/workflows/test_streamlit_folium.yml
+++ b/.github/workflows/test_streamlit_folium.yml
@@ -1,6 +1,8 @@
 name: Run Streamlit Folium Tests
 
 on:
+  schedule:
+    - cron: "0 13 * * *"
   pull_request:
   push:
     branches:


### PR DESCRIPTION
The purpose of this change is to detect early when a version change has broken our build. Now we only find this out when we create a PR for a new branch.

This change runs the workflows daily. After testing we can reduce the frequency.