### PR TITLE
Make DivIcon and CustomIcon work with the new Marker approach

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1718,7 +1718,6 @@ class DivIcon(MacroElement):
         """
         {% macro script(this, kwargs) %}
             var {{ this.get_name() }} = L.divIcon({{ this.options|tojavascript }});
-            {{this._parent.get_name()}}.setIcon({{this.get_name()}});
         {% endmacro %}
         """
     )  # noqa
@@ -1895,7 +1894,6 @@ class CustomIcon(Icon):
         """
         {% macro script(this, kwargs) %}
         var {{ this.get_name() }} = L.icon({{ this.options|tojavascript }});
-        {{ this._parent.get_name() }}.setIcon({{ this.get_name() }});
         {% endmacro %}
         """
     )  # noqa

--- a/folium/map.py
+++ b/folium/map.py
@@ -382,7 +382,9 @@ class Marker(MacroElement):
         """
         )
 
-        def __init__(self, marker: "Marker", icon: "Icon"):
+        def __init__(
+            self, marker: "Marker", icon: Union[Icon, "CustomIcon", "DivIcon"]
+        ):
             super().__init__()
             self._name = "SetIcon"
             self.marker = marker

--- a/folium/map.py
+++ b/folium/map.py
@@ -433,7 +433,7 @@ class Marker(MacroElement):
             self.add_child(self.SetIcon(marker=self, icon=self.icon))
         super().render()
 
-    def set_icon(self, icon: Union[Icon, "CustomIcon", "DivIcon"]):
+    def set_icon(self, icon):
         """Set the icon for this Marker"""
         super().add_child(icon)
         self.icon = icon

--- a/folium/map.py
+++ b/folium/map.py
@@ -408,8 +408,7 @@ class Marker(MacroElement):
         # this attribute is not used by Marker, but by GeoJson
         self.icon = None
         if icon is not None:
-            self.add_child(icon)
-            self.icon = icon
+            self.set_icon(icon)
         if popup is not None:
             self.add_child(popup if isinstance(popup, Popup) else Popup(str(popup)))
         if tooltip is not None:
@@ -433,6 +432,19 @@ class Marker(MacroElement):
         if self.icon:
             self.add_child(self.SetIcon(marker=self, icon=self.icon))
         super().render()
+
+    def set_icon(self, icon: Union[Icon, "CustomIcon", "DivIcon"]):
+        """Set the icon for this Marker"""
+        super().add_child(icon)
+        self.icon = icon
+
+    def add_child(self, child, name=None, index=None):
+        import folium.features as features
+
+        if isinstance(child, (Icon, features.CustomIcon, features.DivIcon)):
+            self.set_icon(child)
+        else:
+            super().add_child(child, name, index)
 
 
 class Popup(MacroElement):


### PR DESCRIPTION
This is a continuation of the PR by @conengmo.

To make the PR more robust against uses from other flows (like `add_child` and `add_to`), we check the ways that we can add children and catch setting the icon there.

The tests for this are included in the `playwright_tests` branch, for which there is another PR open.