### PR TITLE
Add interactive mapping example and update README with example link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,24 @@ and we'd love to have you hang out in our community.
 
 See `our complete contributor's guide <https://github.com/python-visualization/folium/blob/main/.github/CONTRIBUTING.md>`_ for more info.
 
+Examples
+--------
+
+Explore some use cases and working examples in the ``examples/`` directory:
+
+- `Interactive Map Example <https://github.com/python-visualization/folium/blob/main/examples/interactive_map_example.py>`_: A simple example showing how to create a map with markers and popups using Python.
+- Launch examples in a live environment via |binder|.
+This example shows how to create an interactive map using `folium` with a marker and popup.
+To run this example, navigate to the folium repo root and run:
+
+.. code:: bash
+
+   python examples/interactive_map_example.py
+
+This will create an HTML file called `interactive_map_example.html` that can be opened in any web browser.
+The resulting map is centered on San Francisco and includes a popup marker labeled "San Francisco".
+
+
 
 Changelog
 ---------

--- a/examples/interactive_map_example.py
+++ b/examples/interactive_map_example.py
@@ -1,0 +1,10 @@
+import folium
+
+# Create a basic map
+m = folium.Map(location=[37.7749, -122.4194], zoom_start=12)
+
+# Add a marker
+folium.Marker([37.7749, -122.4194], popup="San Francisco").add_to(m)
+
+# Save to HTML
+m.save("interactive_map_example.html")


### PR DESCRIPTION
### Overview

This PR adds a new example for interactive mapping with Folium, located at `examples/interactive_map_example.py`.

### What's Included

- A script that creates an interactive Leaflet map with markers and popups.
- An update to `README.rst` with:
  - A new "Examples" section
  - Instructions on how to run the script
  - A link to the example script

### Motivation

This contribution demonstrates a common use case — interactive mapping in Python — and includes both code and documentation as part of an open-source contribution task.

Let me know if changes are needed. Thanks!
