### PR TITLE
Documentation added for Geoman plugin with examples

### DIFF
--- a/docs/user_guide/plugins.rst
+++ b/docs/user_guide/plugins.rst
@@ -13,6 +13,7 @@ Plugins
   plugins/float_image
   plugins/fullscreen
   plugins/geocoder
+  plugins/geoman
   plugins/grouped_layer_control
   plugins/heatmap
   plugins/heatmap_with_time
@@ -65,6 +66,8 @@ Plugins
       - A fullscreen button control for modern browsers, using HTML Fullscreen API.
     * - :doc:`Geocoder <plugins/geocoder>`
       - A clean and extensible control for both geocoding and reverse geocoding using different geocoding providers.
+    * - :doc:`Geoman <plugins/geoman>`
+      - Interactive drawing and editing interface for polygons, polylines, circles, and other geometric shapes.
     * - :doc:`Grouped Layer Control <plugins/grouped_layer_control>`
       - Create layer control with support for grouping overlays together.
     * - :doc:`Heatmap <plugins/heatmap>`

--- a/docs/user_guide/plugins/geoman.md
+++ b/docs/user_guide/plugins/geoman.md
@@ -2,6 +2,14 @@
 
 The Geoman plugin provides an interactive drawing and editing interface for polygons, polylines, circles, and other geometric shapes on your Folium map. It's based on the [Leaflet-Geoman](https://github.com/geoman-io/leaflet-geoman/) library.
 
+## Advantages over Draw Plugin
+
+Geoman is a more recent and actively maintained alternative to the Draw plugin, offering several key advantages:
+
+- **Advanced Shape Features**: Supports drawing shapes with holes inside them, which is not available in the Draw plugin
+- **Enhanced Editing Capabilities**: Includes cutting, rotating, scaling, and snapping functionality for precise geometry editing
+- **Professional Add-ons**: Offers [paid extensions](https://geoman.io/docs/leaflet/getting-started/pro-version) with advanced functionality for complex GIS applications
+
 ## Basic Usage
 
 ```{code-cell} ipython3
@@ -46,48 +54,5 @@ GeoMan(
 
 m
 ```
-
-## Available Methods
-
-The GeoMan plugin provides several methods for programmatic control:
-
-### Drawing Controls
-- `enable_draw(shape, **kwargs)`: Enable drawing mode for a specific shape
-- `disable_draw()`: Disable drawing mode
-- `set_path_options(**options)`: Set default styling options for drawn shapes
-
-### Edit Controls
-- `enable_global_edit_mode(**options)`: Enable edit mode for all shapes
-- `disable_global_edit_mode()`: Disable edit mode
-- `enable_global_drag_mode()`: Enable drag mode for all shapes
-- `disable_global_drag_mode()`: Disable drag mode
-
-### Other Controls
-- `enable_global_removal_mode()`: Enable removal mode
-- `disable_global_removal_mode()`: Disable removal mode
-- `enable_global_cut_mode()`: Enable polygon cutting mode
-- `disable_global_cut_mode()`: Disable polygon cutting mode
-- `enable_global_rotation_mode()`: Enable rotation mode
-- `disable_global_rotation_mode()`: Disable rotation mode
-
-## Configuration Options
-
-The GeoMan plugin accepts the following parameters:
-
-- `position` (str): Position of the toolbar ('topleft', 'topright', 'bottomleft', 'bottomright')
-- `feature_group` (FeatureGroup): Feature group to store drawn items
-- `on` (dict): Event handlers for drawing events
-- `drawMarker` (bool): Enable/disable marker drawing
-- `drawCircleMarker` (bool): Enable/disable circle marker drawing
-- `drawPolyline` (bool): Enable/disable polyline drawing
-- `drawRectangle` (bool): Enable/disable rectangle drawing
-- `drawPolygon` (bool): Enable/disable polygon drawing
-- `drawCircle` (bool): Enable/disable circle drawing
-- `drawText` (bool): Enable/disable text drawing
-- `editMode` (bool): Enable/disable edit mode
-- `dragMode` (bool): Enable/disable drag mode
-- `cutPolygon` (bool): Enable/disable polygon cutting
-- `removalMode` (bool): Enable/disable removal mode
-- `rotateMode` (bool): Enable/disable rotation mode
 
 For more advanced usage and configuration options, refer to the [Leaflet-Geoman documentation](https://geoman.io/docs/leaflet).

--- a/docs/user_guide/plugins/geoman.md
+++ b/docs/user_guide/plugins/geoman.md
@@ -1,0 +1,93 @@
+# Geoman
+
+The Geoman plugin provides an interactive drawing and editing interface for polygons, polylines, circles, and other geometric shapes on your Folium map. It's based on the [Leaflet-Geoman](https://github.com/geoman-io/leaflet-geoman/) library.
+
+## Basic Usage
+
+```{code-cell} ipython3
+import folium
+from folium.plugins import GeoMan
+
+# Create a map
+m = folium.Map(location=[45.5236, -122.6750], zoom_start=13)
+
+# Add Geoman plugin
+GeoMan().add_to(m)
+
+m
+```
+
+## Customizing Controls
+
+You can customize which drawing controls are available and their position:
+
+```{code-cell} ipython3
+import folium
+from folium.plugins import GeoMan
+
+m = folium.Map(location=[45.5236, -122.6750], zoom_start=13)
+
+# Add Geoman with custom options
+GeoMan(
+    position='topright',
+    drawMarker=True,
+    drawCircleMarker=True,
+    drawPolyline=True,
+    drawRectangle=True,
+    drawPolygon=True,
+    drawCircle=True,
+    drawText=False,
+    editMode=True,
+    dragMode=True,
+    cutPolygon=True,
+    removalMode=True,
+    rotateMode=False
+).add_to(m)
+
+m
+```
+
+## Available Methods
+
+The GeoMan plugin provides several methods for programmatic control:
+
+### Drawing Controls
+- `enable_draw(shape, **kwargs)`: Enable drawing mode for a specific shape
+- `disable_draw()`: Disable drawing mode
+- `set_path_options(**options)`: Set default styling options for drawn shapes
+
+### Edit Controls
+- `enable_global_edit_mode(**options)`: Enable edit mode for all shapes
+- `disable_global_edit_mode()`: Disable edit mode
+- `enable_global_drag_mode()`: Enable drag mode for all shapes
+- `disable_global_drag_mode()`: Disable drag mode
+
+### Other Controls
+- `enable_global_removal_mode()`: Enable removal mode
+- `disable_global_removal_mode()`: Disable removal mode
+- `enable_global_cut_mode()`: Enable polygon cutting mode
+- `disable_global_cut_mode()`: Disable polygon cutting mode
+- `enable_global_rotation_mode()`: Enable rotation mode
+- `disable_global_rotation_mode()`: Disable rotation mode
+
+## Configuration Options
+
+The GeoMan plugin accepts the following parameters:
+
+- `position` (str): Position of the toolbar ('topleft', 'topright', 'bottomleft', 'bottomright')
+- `feature_group` (FeatureGroup): Feature group to store drawn items
+- `on` (dict): Event handlers for drawing events
+- `drawMarker` (bool): Enable/disable marker drawing
+- `drawCircleMarker` (bool): Enable/disable circle marker drawing
+- `drawPolyline` (bool): Enable/disable polyline drawing
+- `drawRectangle` (bool): Enable/disable rectangle drawing
+- `drawPolygon` (bool): Enable/disable polygon drawing
+- `drawCircle` (bool): Enable/disable circle drawing
+- `drawText` (bool): Enable/disable text drawing
+- `editMode` (bool): Enable/disable edit mode
+- `dragMode` (bool): Enable/disable drag mode
+- `cutPolygon` (bool): Enable/disable polygon cutting
+- `removalMode` (bool): Enable/disable removal mode
+- `rotateMode` (bool): Enable/disable rotation mode
+
+For more advanced usage and configuration options, refer to the [Leaflet-Geoman documentation](https://geoman.io/docs/leaflet).


### PR DESCRIPTION
Fixes #2149  : Add documentation for the Geoman plugin.

Summary
This PR adds complete documentation for the Geoman plugin that was released in Folium 0.19.6 but previously lacked documentation.