### PR TITLE
Fix geopandas on python 3.14

### DIFF
--- a/.github/workflows/test_geopandas.yml
+++ b/.github/workflows/test_geopandas.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo add-apt-repository ppa:ubuntugis/ppa
+        sudo apt-get update
         sudo apt-get install libproj-dev proj-data proj-bin
         sudo apt-get install libgeos-dev
         sudo apt-get install gdal-bin libgdal-dev


### PR DESCRIPTION
Try to fix the failing geopandas build (and prepare for python 3.14).