### PR TITLE
Add documentation for Control class (issue #2150)

### DIFF
--- a/docs/user_guide/ui_elements.rst
+++ b/docs/user_guide/ui_elements.rst
@@ -6,5 +6,6 @@ UI elements
 
 
   ui_elements/layer_control
+  ui_elements/control
   ui_elements/popups
   ui_elements/icons

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -36,7 +36,7 @@ from folium.features import Control
 m = folium.Map(location=[45, 0], zoom_start=4)
 
 control = Control(
-    "fullscreen",  
+    "fullscreen",
     position="topright",
     # Any plugin options become JS options.
     title="View Fullscreen",

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -36,15 +36,22 @@ from folium.features import Control
 m = folium.Map(location=[45, 0], zoom_start=4)
 
 control = Control(
-    "MyPlugin",
+    "Fullscreen",
     position="topright",
     # Any plugin options become JS options.
-    foo="bar",
+    title="View Fullscreen",
+    titleCancel="Exit Fullscreen",
 )
 
 # Add the plugin's JS/CSS assets.
-control.add_js_link("my-plugin", "https://example.com/leaflet.my-plugin.min.js")
-control.add_css_link("my-plugin", "https://example.com/leaflet.my-plugin.css")
+control.add_js_link(
+    "leaflet-fullscreen",
+    "https://unpkg.com/leaflet.fullscreen@1.6.0/Control.FullScreen.js",
+)
+control.add_css_link(
+    "leaflet-fullscreen",
+    "https://unpkg.com/leaflet.fullscreen@1.6.0/Control.FullScreen.css",
+)
 
 control.add_to(m)
 m

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -1,0 +1,54 @@
+```{code-cell} ipython3
+---
+nbsphinx: hidden
+---
+import folium
+from folium.features import Control
+```
+
+# Controls
+
+Leaflet controls are UI elements anchored to the corners of a map (zoom, scale,
+custom buttons, etc.). Folium exposes a generic `Control` class that can render
+any `L.Control.<Name>` class. This is useful when you want to wire up a Leaflet
+plugin directly in user code without creating a new `folium.plugins` class.
+
+## Built-in controls
+
+```{code-cell} ipython3
+m = folium.Map(location=[45, 0], zoom_start=4, zoom_control=False)
+
+Control("Zoom", position="topleft").add_to(m)
+Control("Scale", position="bottomleft").add_to(m)
+
+m
+```
+
+## Leaflet plugin controls
+
+If a Leaflet plugin exposes a `L.Control.<Name>` class, you can wire it up
+directly and attach its JS/CSS assets to the map.
+
+```python
+import folium
+from folium.features import Control
+
+m = folium.Map(location=[45, 0], zoom_start=4)
+
+control = Control(
+    "MyPlugin",
+    position="topright",
+    # Any plugin options become JS options.
+    foo="bar",
+)
+
+# Add the plugin's JS/CSS assets.
+control.add_js_link("my-plugin", "https://example.com/leaflet.my-plugin.min.js")
+control.add_css_link("my-plugin", "https://example.com/leaflet.my-plugin.css")
+
+control.add_to(m)
+m
+```
+
+For reusable plugins, consider creating a dedicated `folium.plugins` class. For
+one-off integrations, `Control` keeps the wiring minimal.

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -36,7 +36,7 @@ from folium.features import Control
 m = folium.Map(location=[45, 0], zoom_start=4)
 
 control = Control(
-    "Fullscreen",
+    "fullscreen",  
     position="topright",
     # Any plugin options become JS options.
     title="View Fullscreen",
@@ -46,7 +46,7 @@ control = Control(
 # Add the plugin's JS/CSS assets.
 control.add_js_link(
     "leaflet-fullscreen",
-    "https://unpkg.com/leaflet.fullscreen@1.6.0/Control.FullScreen.js",
+    "https://unpkg.com/leaflet-fullscreen@1.6.0/dist/leaflet.fullscreen.umd.js",
 )
 control.add_css_link(
     "leaflet-fullscreen",

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -29,7 +29,7 @@ m
 If a Leaflet plugin exposes a `L.Control.<Name>` class, you can wire it up
 directly and attach its JS/CSS assets to the map.
 
-```python
+```{code-cell} ipython3
 import folium
 from folium.features import Control
 


### PR DESCRIPTION
Adds documentation for the Control class, including examples of built-in controls and wiring custom Leaflet plugin controls.

Closes #2150