### PR TITLE
Docs add text divicon

### DIFF
--- a/docs/user_guide/ui_elements.rst
+++ b/docs/user_guide/ui_elements.rst
@@ -6,5 +6,6 @@ UI elements
 
 
   ui_elements/layer_control
+  ui_elements/control
   ui_elements/popups
   ui_elements/icons

--- a/docs/user_guide/ui_elements/control.md
+++ b/docs/user_guide/ui_elements/control.md
@@ -1,0 +1,54 @@
+```{code-cell} ipython3
+---
+nbsphinx: hidden
+---
+import folium
+from folium.features import Control
+```
+
+# Controls
+
+Leaflet controls are UI elements anchored to the corners of a map (zoom, scale,
+custom buttons, etc.). Folium exposes a generic `Control` class that can render
+any `L.Control.<Name>` class. This is useful when you want to wire up a Leaflet
+plugin directly in user code without creating a new `folium.plugins` class.
+
+## Built-in controls
+
+```{code-cell} ipython3
+m = folium.Map(location=[45, 0], zoom_start=4, zoom_control=False)
+
+Control("Zoom", position="topleft").add_to(m)
+Control("Scale", position="bottomleft").add_to(m)
+
+m
+```
+
+## Leaflet plugin controls
+
+If a Leaflet plugin exposes a `L.Control.<Name>` class, you can wire it up
+directly and attach its JS/CSS assets to the map.
+
+```python
+import folium
+from folium.features import Control
+
+m = folium.Map(location=[45, 0], zoom_start=4)
+
+control = Control(
+    "MyPlugin",
+    position="topright",
+    # Any plugin options become JS options.
+    foo="bar",
+)
+
+# Add the plugin's JS/CSS assets.
+control.add_js_link("my-plugin", "https://example.com/leaflet.my-plugin.min.js")
+control.add_css_link("my-plugin", "https://example.com/leaflet.my-plugin.css")
+
+control.add_to(m)
+m
+```
+
+For reusable plugins, consider creating a dedicated `folium.plugins` class. For
+one-off integrations, `Control` keeps the wiring minimal.

--- a/docs/user_guide/ui_elements/icons.md
+++ b/docs/user_guide/ui_elements/icons.md
@@ -71,4 +71,3 @@ folium.Marker(
 m
 
 ```
-

--- a/docs/user_guide/ui_elements/icons.md
+++ b/docs/user_guide/ui_elements/icons.md
@@ -54,3 +54,21 @@ folium.Marker(
 
 m
 ```
+
+
+## Adding text using DivIcon
+
+You can display custom text on the map using a DivIcon.
+
+```{code-cell} ipython3
+m = folium.Map(location=[0, 0], zoom_start=2)
+
+folium.Marker(
+    [0, 0],
+    icon=folium.DivIcon(html='<div style="font-size: 20px">Hello</div>')
+).add_to(m)
+
+m
+
+```
+


### PR DESCRIPTION
Adds documentation showing how to add text to a map using DivIcon.

Includes:
• Example using folium.DivIcon
• Explanation of use case for text labels
• Placement in user guide under UI elements → icons

Closes #2092