### PR TITLE
feat: support hexadecimal color codes for Icon marker backgrounds (#1466)

### DIFF
--- a/folium/map.py
+++ b/folium/map.py
@@ -319,6 +319,33 @@ class Icon(MacroElement):
                 {{ this.options|tojavascript }}
             );
         {% endmacro %}
+        
+        {% macro header(this, kwargs) %}
+            {% if this.is_hex %}
+            <style>
+                /* Dynamically generated CSS to replace the sprite image with a colored teardrop */
+                .awesome-marker-icon-{{ this.color_name }} {
+                    background-image: none;
+                    background-color: {{ this.color }};
+                    width: 35px;
+                    height: 35px;
+                    border-radius: 50% 50% 50% 0;
+                    transform: rotate(-45deg);
+                    margin-top: -15px;
+                    margin-left: -17px;
+                    border: 2px solid white;
+                    box-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                }
+                /* Counter-rotate the inner icon so it stands up straight */
+                .awesome-marker-icon-{{ this.color_name }} i {
+                    transform: rotate(45deg);
+                }
+            </style>
+            {% endif %}
+        {% endmacro %}
         """)
     color_options = {
         "red",
@@ -354,16 +381,23 @@ class Icon(MacroElement):
         super().__init__()
         self._name = "Icon"
         
-        # Check if the color is a valid hex code
-        is_hex_color = color.startswith("#") and len(color) in (4, 7)
+        # 1. Determine if the input is a hex color
+        self.is_hex = color.startswith("#") and len(color) in (4, 7)
+        self.color = color
         
-        if color not in self.color_options and not is_hex_color:
+        # 2. Strip the '#' for the CSS class name generation
+        self.color_name = color[1:] if self.is_hex else color
+
+        # 3. Allow hex codes to pass the warning check
+        if color not in self.color_options and not self.is_hex:
             warnings.warn(
-                f"color argument of Icon should be one of: {self.color_options} or a valid hex color (e.g., '#FF0000').",
+                f"color argument of Icon should be one of: {self.color_options} or a valid hex code.",
                 stacklevel=2,
             )
+            
+        # 4. Pass the stripped color_name to the JavaScript options
         self.options = remove_empty(
-            marker_color=color,
+            marker_color=self.color_name,
             icon_color=icon_color,
             icon=icon,
             prefix=prefix,

--- a/folium/map.py
+++ b/folium/map.py
@@ -353,9 +353,13 @@ class Icon(MacroElement):
     ):
         super().__init__()
         self._name = "Icon"
-        if color not in self.color_options:
+        
+        # Check if the color is a valid hex code
+        is_hex_color = color.startswith("#") and len(color) in (4, 7)
+        
+        if color not in self.color_options and not is_hex_color:
             warnings.warn(
-                f"color argument of Icon should be one of: {self.color_options}.",
+                f"color argument of Icon should be one of: {self.color_options} or a valid hex color (e.g., '#FF0000').",
                 stacklevel=2,
             )
         self.options = remove_empty(

--- a/folium/map.py
+++ b/folium/map.py
@@ -319,7 +319,7 @@ class Icon(MacroElement):
                 {{ this.options|tojavascript }}
             );
         {% endmacro %}
-        
+
         {% macro header(this, kwargs) %}
             {% if this.is_hex %}
             <style>
@@ -380,11 +380,11 @@ class Icon(MacroElement):
     ):
         super().__init__()
         self._name = "Icon"
-        
+
         # 1. Determine if the input is a hex color
         self.is_hex = color.startswith("#") and len(color) in (4, 7)
         self.color = color
-        
+
         # 2. Strip the '#' for the CSS class name generation
         self.color_name = color[1:] if self.is_hex else color
 
@@ -394,7 +394,7 @@ class Icon(MacroElement):
                 f"color argument of Icon should be one of: {self.color_options} or a valid hex code.",
                 stacklevel=2,
             )
-            
+
         # 4. Pass the stripped color_name to the JavaScript options
         self.options = remove_empty(
             marker_color=self.color_name,


### PR DESCRIPTION
Resolves #1466 

### Description
This PR adds support for passing hexadecimal color codes (e.g., `#8000ff`) to the `color` argument of `folium.Icon`. Currently, passing a hex code raises a `ValueError` because the underlying `Leaflet.awesome-markers` plugin expects a hardcoded string corresponding to its pre-rendered CSS sprite classes.

**Architectural Approach:**
Because `folium` currently serves `Leaflet.awesome-markers` directly from a CDN (`cdnjs`) via `_default_js` and `_default_css`, we cannot easily patch the underlying JavaScript plugin to support hex colors without vendoring the assets. 

To bypass this limitation cleanly from the Python wrapper, this PR:
1. Updates the `Icon` class in `map.py` to validate and accept hex strings.
2. Dynamically injects a custom `<style>` block via a Jinja2 `header` macro only when a hex color is detected.
3. Uses CSS to override the default background image, mathematically drawing a custom-colored teardrop marker and counter-rotating the inner icon to maintain the correct orientation.

### Changes Made
* **`folium/map.py`**: 
  * Updated `Icon.__init__` to detect hex strings, strip the `#` for safe CSS class generation, and bypass the validation warning.
  * Updated the `_template` to include a `header` macro that writes the dynamically generated CSS into the HTML `<head>`.

### Testing
* Tested locally by recreating the exact code snippet from Issue #1466.
* Passing `color='#8000ff'` successfully suppresses the `ValueError` and renders a properly colored and shaped purple marker with the inner icon intact.