### PR TITLE
build(pyproject): declare `requires-python` via PEP 621 `[project]` metadata

### DIFF
--- a/folium/plugins/beautify_icon.py
+++ b/folium/plugins/beautify_icon.py
@@ -93,7 +93,7 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
         inner_icon_style="",
         spin=False,
         number=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "BeautifyIcon"
@@ -109,5 +109,5 @@ class BeautifyIcon(JSCSSMixin, MacroElement):
             spin=spin,
             isAlphaNumericIcon=number is not None,
             text=number,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/boat_marker.py
+++ b/folium/plugins/boat_marker.py
@@ -57,7 +57,7 @@ class BoatMarker(JSCSSMixin, Marker):
         heading=0,
         wind_heading=None,
         wind_speed=0,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(location, popup=popup, icon=icon)
         self._name = "BoatMarker"

--- a/folium/plugins/fullscreen.py
+++ b/folium/plugins/fullscreen.py
@@ -54,7 +54,7 @@ class Fullscreen(JSCSSMixin, MacroElement):
         title="Full Screen",
         title_cancel="Exit Full Screen",
         force_separate_button=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Fullscreen"
@@ -63,5 +63,5 @@ class Fullscreen(JSCSSMixin, MacroElement):
             title=title,
             title_cancel=title_cancel,
             force_separate_button=force_separate_button,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/geocoder.py
+++ b/folium/plugins/geocoder.py
@@ -76,7 +76,7 @@ class Geocoder(JSCSSMixin, MacroElement):
         zoom: Optional[int] = 11,
         provider: str = "nominatim",
         provider_options: dict = {},
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Geocoder"
@@ -87,5 +87,5 @@ class Geocoder(JSCSSMixin, MacroElement):
             zoom=zoom,
             provider=provider,
             provider_options=provider_options,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/heat_map.py
+++ b/folium/plugins/heat_map.py
@@ -73,7 +73,7 @@ class HeatMap(JSCSSMixin, Layer):
         overlay=True,
         control=True,
         show=True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self._name = "HeatMap"
@@ -95,7 +95,7 @@ class HeatMap(JSCSSMixin, Layer):
             radius=radius,
             blur=blur,
             gradient=gradient,
-            **kwargs
+            **kwargs,
         )
 
     def _get_self_bounds(self):

--- a/folium/plugins/marker_cluster.py
+++ b/folium/plugins/marker_cluster.py
@@ -84,7 +84,7 @@ class MarkerCluster(JSCSSMixin, Layer):
         show=True,
         icon_create_function=None,
         options=None,
-        **kwargs
+        **kwargs,
     ):
         if options is not None:
             kwargs.update(options)  # options argument is legacy

--- a/folium/plugins/measure_control.py
+++ b/folium/plugins/measure_control.py
@@ -66,7 +66,7 @@ class MeasureControl(JSCSSMixin, MacroElement):
         secondary_length_unit="miles",
         primary_area_unit="sqmeters",
         secondary_area_unit="acres",
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MeasureControl"
@@ -77,5 +77,5 @@ class MeasureControl(JSCSSMixin, MacroElement):
             secondary_length_unit=secondary_length_unit,
             primary_area_unit=primary_area_unit,
             secondary_area_unit=secondary_area_unit,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/minimap.py
+++ b/folium/plugins/minimap.py
@@ -101,7 +101,7 @@ class MiniMap(JSCSSMixin, MacroElement):
         toggle_display=False,
         auto_toggle_display=False,
         minimized=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MiniMap"
@@ -126,5 +126,5 @@ class MiniMap(JSCSSMixin, MacroElement):
             toggle_display=toggle_display,
             auto_toggle_display=auto_toggle_display,
             minimized=minimized,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/mouse_position.py
+++ b/folium/plugins/mouse_position.py
@@ -81,7 +81,7 @@ class MousePosition(JSCSSMixin, MacroElement):
         prefix="",
         lat_formatter=None,
         lng_formatter=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "MousePosition"
@@ -93,7 +93,7 @@ class MousePosition(JSCSSMixin, MacroElement):
             lng_first=lng_first,
             num_digits=num_digits,
             prefix=prefix,
-            **kwargs
+            **kwargs,
         )
         self.lat_formatter = lat_formatter or "undefined"
         self.lng_formatter = lng_formatter or "undefined"

--- a/folium/plugins/overlapping_marker_spiderfier.py
+++ b/folium/plugins/overlapping_marker_spiderfier.py
@@ -73,7 +73,7 @@ class OverlappingMarkerSpiderfier(JSCSSMixin, MacroElement):
         nearby_distance: int = 20,
         leg_weight: float = 1.5,
         circle_spiral_switchover: int = 9,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "OverlappingMarkerSpiderfier"
@@ -82,7 +82,7 @@ class OverlappingMarkerSpiderfier(JSCSSMixin, MacroElement):
             nearby_distance=nearby_distance,
             leg_weight=leg_weight,
             circle_spiral_switchover=circle_spiral_switchover,
-            **kwargs
+            **kwargs,
         )
 
     def add_to(

--- a/folium/plugins/pattern.py
+++ b/folium/plugins/pattern.py
@@ -53,7 +53,7 @@ class StripePattern(JSCSSMixin, MacroElement):
         space_color="#ffffff",
         opacity=0.75,
         space_opacity=0.0,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "StripePattern"
@@ -65,7 +65,7 @@ class StripePattern(JSCSSMixin, MacroElement):
             space_color=space_color,
             opacity=opacity,
             space_opacity=space_opacity,
-            **kwargs
+            **kwargs,
         )
         self.parent_map = None
 

--- a/folium/plugins/polyline_text_path.py
+++ b/folium/plugins/polyline_text_path.py
@@ -60,7 +60,7 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
         offset=0,
         orientation=0,
         attributes=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "PolyLineTextPath"
@@ -73,5 +73,5 @@ class PolyLineTextPath(JSCSSMixin, MacroElement):
             offset=offset,
             orientation=orientation,
             attributes=attributes,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/realtime.py
+++ b/folium/plugins/realtime.py
@@ -98,7 +98,7 @@ class Realtime(JSCSSMixin, FeatureGroup):
         update_feature: Union[JsCode, str, None] = None,
         remove_missing: bool = False,
         container: Optional[Union[FeatureGroup, GeoJson]] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "Realtime"

--- a/folium/plugins/semicircle.py
+++ b/folium/plugins/semicircle.py
@@ -65,7 +65,7 @@ class SemiCircle(JSCSSMixin, Marker):
         stop_angle=None,
         popup=None,
         tooltip=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(location, popup=popup, tooltip=tooltip)
         self._name = "SemiCircle"

--- a/folium/plugins/tag_filter_button.py
+++ b/folium/plugins/tag_filter_button.py
@@ -80,7 +80,7 @@ class TagFilterButton(JSCSSMixin, MacroElement):
         clear_text="clear",
         filter_on_every_click=True,
         open_popup_on_hover=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TagFilterButton"
@@ -90,5 +90,5 @@ class TagFilterButton(JSCSSMixin, MacroElement):
             clear_text=clear_text,
             filter_on_every_click=filter_on_every_click,
             open_popup_on_hover=open_popup_on_hover,
-            **kwargs
+            **kwargs,
         )

--- a/folium/plugins/timeline.py
+++ b/folium/plugins/timeline.py
@@ -105,7 +105,7 @@ class Timeline(GeoJson):
         self,
         data: Union[dict, str, TextIO],
         get_interval: Optional[JsCode] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(data)
         self._name = "Timeline"
@@ -211,7 +211,7 @@ class TimelineSlider(JSCSSMixin, MacroElement):
         show_ticks: bool = True,
         steps: int = 1000,
         playback_duration: int = 10000,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TimelineSlider"

--- a/folium/plugins/treelayercontrol.py
+++ b/folium/plugins/treelayercontrol.py
@@ -144,7 +144,7 @@ class TreeLayerControl(JSCSSMixin, MacroElement):
         collapse_all: str = "",
         expand_all: str = "",
         label_is_selector: str = "both",
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self._name = "TreeLayerControl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,21 @@
 requires = ["setuptools>=41.2", "setuptools_scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "folium"
+dynamic = [
+    "version",
+    "description",
+    "readme",
+    "license",
+    "authors",
+    "keywords",
+    "classifiers",
+    "dependencies",
+    "optional-dependencies",
+]
+requires-python = ">=3.9"
+
 [tool.interrogate]
 ignore-init-method = true
 ignore-init-module = false


### PR DESCRIPTION
  Add a minimal `[project]` table to `pyproject.toml` and set:

  - `requires-python = ">=3.9"`
  - `name = "folium"`
  - `dynamic = [...]` for fields still sourced from `setup.py`

  Why this is needed:

  `python_requires` in `setup.py` is not enough for tools that read interpreter constraints from `pyproject.toml` metadata. Per PEP 621, `requires-python` belongs in `[project]`, which allows `uv` to resolve/lock against the correct Python range instead of defaulting incorrectly (see https://github.com/astral-sh/uv/issues/11424).
