### PR TITLE
Fix sleeping before taking a screenshot in Map._to_png

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -392,11 +392,16 @@ class Map(JSCSSMixin, Evented):
                     *size,
                 )
                 driver.set_window_size(*window_size)
+            from selenium.webdriver.support.ui import WebDriverWait
+
             html = self.get_root().render()
             with temp_html_filepath(html) as fname:
                 # We need the tempfile to avoid JS security issues.
                 driver.get(f"file:///{fname}")
-                time.sleep(delay)
+                WebDriverWait(driver, delay).until(
+                    lambda _driver: _driver.execute_script("return document.readyState")
+                    == "complete"
+                )
                 div = driver.find_element("class name", "folium-map")
                 png = div.screenshot_as_png
                 driver.quit()

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -368,7 +368,7 @@ class Map(JSCSSMixin, Evented):
         Examples
         --------
         >>> m._to_png()
-        >>> m._to_png(time=10)  # Wait 10 seconds between render and snapshot.
+        >>> m._to_png(delay=10)  # Wait 10 seconds between render and snapshot.
 
         """
 


### PR DESCRIPTION
In the experimental `Map._to_png`, currently a selenium `WebDriver` opens the local HTML file and `time.sleep()` is used to wait for the folium `Map` to load before taking the screenshot. In this PR, I replaced `time.sleep` with `WebDriverWait`, which actually awaits the `Map` loading in JavaScript.

The `delay` variable now specifies the _maximum_ of time to wait, the `WebDriverSleep` object stops waiting once the page actually loaded.


Also fixed a small typo in the docstring of `_to_png`.