### PR TITLE
fix test with proj 9.8.1

### DIFF
--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -269,7 +269,7 @@ class TestFolium:
             geo_data = json.load(f)
 
         geo_data_frame = gpd.GeoDataFrame.from_features(geo_data["features"])
-        geo_data_frame = geo_data_frame.set_crs("epsg: 4326")
+        geo_data_frame = geo_data_frame.set_crs("epsg:4326")
         fill_color = "BuPu"
         key_on = "feature.id"
 
@@ -300,7 +300,7 @@ class TestFolium:
             geo_data = json.load(f)
 
         geo_data_frame = gpd.GeoDataFrame.from_features(geo_data["features"])
-        geo_data_frame = geo_data_frame.set_crs("epsg: 4326")
+        geo_data_frame = geo_data_frame.set_crs("epsg:4326")
         data = pd.DataFrame(
             {
                 "idx": {"0": 0, "1": "1", "2": 2, "3": 3, "4": 4, "5": 5},
@@ -346,7 +346,7 @@ class TestFolium:
             geo_data = json.load(f)
 
         geo_data_frame = gpd.GeoDataFrame.from_features(geo_data["features"])
-        geo_data_frame = geo_data_frame.set_crs("epsg: 4326")
+        geo_data_frame = geo_data_frame.set_crs("epsg:4326")
         data = pd.DataFrame(
             {
                 "idx": {"0": "0", "1": "1", "2": "2", "3": "3", "4": "4", "5": "5"},


### PR DESCRIPTION
Apparently newest proj doesn't accept `epsg: 4326` (with a space) any more. This is not yet visible everywhere because current pyproj ships proj 9.5.1 on pypi, but on nixpkgs, the proj version is already 9.8.1.

Thanks!