### PR TITLE
fix: export WebGLEarth classes from plugins __init__.py

### DIFF
--- a/folium/plugins/__init__.py
+++ b/folium/plugins/__init__.py
@@ -37,6 +37,7 @@ from folium.plugins.timestamped_geo_json import TimestampedGeoJson
 from folium.plugins.timestamped_wmstilelayer import TimestampedWmsTileLayers
 from folium.plugins.treelayercontrol import TreeLayerControl
 from folium.plugins.vectorgrid_protobuf import VectorGridProtobuf
+from folium.plugins.webgl_earth import WebGLEarth, WebGLEarthMarker, WebGLEarthTileLayer, WebGLEarthRealtime
 
 __all__ = [
     "AntPath",
@@ -79,4 +80,8 @@ __all__ = [
     "TimestampedWmsTileLayers",
     "TreeLayerControl",
     "VectorGridProtobuf",
+    "WebGLEarth",
+    "WebGLEarthMarker",
+    "WebGLEarthTileLayer",
+    "WebGLEarthRealtime",
 ]

--- a/folium/plugins/__init__.py
+++ b/folium/plugins/__init__.py
@@ -37,7 +37,12 @@ from folium.plugins.timestamped_geo_json import TimestampedGeoJson
 from folium.plugins.timestamped_wmstilelayer import TimestampedWmsTileLayers
 from folium.plugins.treelayercontrol import TreeLayerControl
 from folium.plugins.vectorgrid_protobuf import VectorGridProtobuf
-from folium.plugins.webgl_earth import WebGLEarth, WebGLEarthMarker, WebGLEarthTileLayer, WebGLEarthRealtime
+from folium.plugins.webgl_earth import (
+    WebGLEarth,
+    WebGLEarthMarker,
+    WebGLEarthRealtime,
+    WebGLEarthTileLayer,
+)
 
 __all__ = [
     "AntPath",


### PR DESCRIPTION
## Problem
PR #2226 added `folium/plugins/webgl_earth.py` but forgot to export the
classes in `folium/plugins/__init__.py`. This caused the docs build to
fail with:
`ImportError: cannot import name 'WebGLEarth' from 'folium.plugins'`

## Fix
Added import and `__all__` entries for all 4 classes:
- WebGLEarth
- WebGLEarthMarker
- WebGLEarthTileLayer
- WebGLEarthRealtime