### PR TITLE
fix: correct RST docstring formatting in GroupedLayerControl (fixes #2233)

### DIFF
--- a/folium/plugins/groupedlayercontrol.py
+++ b/folium/plugins/groupedlayercontrol.py
@@ -13,13 +13,14 @@ class GroupedLayerControl(JSCSSMixin, MacroElement):
     ----------
     groups : dict
         A dictionary where the keys are group names and the values are lists
-        of layer objects. E.g.
-        {
-            "Group 1": [layer1, layer2],
-            "Group 2": [layer3, layer4]
-        }
+        of layer objects. For example::
 
-    exclusive_groups: bool, default True
+            {
+                "Group 1": [layer1, layer2],
+                "Group 2": [layer3, layer4]
+            }
+
+    exclusive_groups : bool, default True
         Whether to use radio buttons (default) or checkboxes.
         If you want to use both, use two separate instances of this class.
     **kwargs


### PR DESCRIPTION
Fixes #2233

## Problem
The docstring in `folium/plugins/groupedlayercontrol.py` had improper 
RST formatting causing Sphinx to fail during docs build with:

ERROR: Unexpected indentation at line 6
WARNING: Block quote ends without a blank line; unexpected unindent at line 8

## Changes
- Changed `E.g.` to `For example::` to create a proper RST code block
- Added blank lines before and after the example block
- Fixed `exclusive_groups:` to `exclusive_groups :` (space before colon)