### PR TITLE
Fix duplicate HTML when map.save() is called repeatedly

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -4,7 +4,6 @@ from branca.element import (
     CssLink,
     Div,
     Element,
-    Figure,
     Html,
     IFrame,
     JavascriptLink,
@@ -29,6 +28,7 @@ from folium.features import (
     Vega,
     VegaLite,
 )
+from folium.figure import Figure
 from folium.folium import Map
 from folium.map import (
     FeatureGroup,

--- a/folium/elements.py
+++ b/folium/elements.py
@@ -149,6 +149,18 @@ class ElementAddToElement(MacroElement):
         self.element_name = element_name
         self.element_parent_name = element_parent_name
 
+    def render(self, **kwargs):
+        figure = self.get_root()
+        assert isinstance(
+            figure, Figure
+        ), "You cannot render this Element if it is not in a Figure."
+        script = self._template.module.__dict__.get("script", None)
+        if script is not None:
+            figure.script.add_child(
+                Element(script(self, kwargs)),
+                name=f"{self.element_name}_add_to_{self.element_parent_name}",
+            )
+
 
 class IncludeStatement(MacroElement):
     """Generate an include statement on a class."""

--- a/folium/figure.py
+++ b/folium/figure.py
@@ -1,0 +1,23 @@
+"""Folium-specific Figure subclass."""
+
+from branca.element import Figure as BrancaFigure
+
+
+class Figure(BrancaFigure):
+    """Figure that supports repeated rendering without duplicating output.
+
+    Branca elements populate ``header``, ``html``, and ``script`` during
+    ``render()``. Some folium elements create new child nodes on every render
+    call, which causes repeated ``save()`` calls to accumulate duplicate HTML
+    and JavaScript. Clearing the rendered sections before each render makes
+    output idempotent while preserving static header content from ``__init__``.
+    """
+
+    def render(self, **kwargs):
+        meta = self.header._children.pop("meta_http", None)
+        self.header._children.clear()
+        if meta is not None:
+            self.header._children["meta_http"] = meta
+        self.html._children.clear()
+        self.script._children.clear()
+        return super().render(**kwargs)

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -8,9 +8,10 @@ import webbrowser
 from collections.abc import Sequence
 from typing import Any, Optional, Union
 
-from branca.element import Element, Figure
+from branca.element import Element
 
 from folium.elements import JSCSSMixin
+from folium.figure import Figure
 from folium.map import Evented, FitBounds, Layer
 from folium.raster_layers import TileLayer
 from folium.template import Template

--- a/folium/map.py
+++ b/folium/map.py
@@ -517,6 +517,18 @@ class Marker(MacroElement):
             self.marker = marker
             self.icon = icon
 
+        def render(self, **kwargs):
+            figure = self.get_root()
+            assert isinstance(
+                figure, Figure
+            ), "You cannot render this Element if it is not in a Figure."
+            script = self._template.module.__dict__.get("script", None)
+            if script is not None:
+                figure.script.add_child(
+                    Element(script(self, kwargs)),
+                    name=f"{self.marker.get_name()}_set_icon",
+                )
+
     def __init__(
         self,
         location: Optional[Sequence[float]] = None,
@@ -557,7 +569,7 @@ class Marker(MacroElement):
                 f"{self._name} location must be assigned when added directly to map."
             )
         if self.icon:
-            self.add_child(self.SetIcon(marker=self, icon=self.icon))
+            self.add_child(self.SetIcon(marker=self, icon=self.icon), name="set_icon")
         super().render()
 
     def set_icon(self, icon):

--- a/folium/plugins/dual_map.py
+++ b/folium/plugins/dual_map.py
@@ -1,6 +1,7 @@
-from branca.element import Figure, MacroElement
+from branca.element import MacroElement
 
 from folium.elements import EventHandler, JSCSSMixin
+from folium.figure import Figure
 from folium.folium import Map
 from folium.map import LayerControl
 from folium.template import Template

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -290,3 +290,27 @@ def test_icon_invalid_marker_colors():
     pytest.warns(UserWarning, Icon, color="lila")
     pytest.warns(UserWarning, Icon, color=42)
     pytest.warns(UserWarning, Icon, color=None)
+
+
+def test_repeated_save_produces_identical_html(tmp_path):
+    """Regression test for https://github.com/python-visualization/folium/issues/2237"""
+    m = Map(location=[40.75, -73.98], zoom_start=13)
+    locations = [
+        [40.7829, -73.9654],
+        [40.7484, -73.9857],
+        [40.7580, -73.9855],
+    ]
+    for lat, lon in locations:
+        Marker([lat, lon], icon=Icon(color="blue", icon="info-sign")).add_to(m)
+
+    path1 = tmp_path / "1.html"
+    path2 = tmp_path / "2.html"
+    path3 = tmp_path / "3.html"
+    m.save(path1)
+    m.save(path2)
+    m.save(path3)
+
+    html1 = path1.read_text()
+    html2 = path2.read_text()
+    html3 = path3.read_text()
+    assert html1 == html2 == html3


### PR DESCRIPTION
## Summary
- Make `Figure.render()` idempotent by clearing `header`, `html`, and `script` output sections before each render (preserving the static `meta_http` tag)
- Use stable script names for `SetIcon` and `ElementAddToElement` so repeated renders replace instead of append
- Add regression test ensuring multiple `save()` calls produce identical HTML

Fixes #2237

## Test plan
- [x] `pytest tests/test_map.py::test_repeated_save_produces_identical_html`
- [x] `pytest tests --ignore=tests/selenium` (259 passed; 6 failures are pre-existing/environmental: selenium snapshots, PNG sizing, dead CSS rule test on current main)
- [x] `pre-commit run` on changed files (black skipped locally due to Python 3.12.5; CI should run black)


Made with [Cursor](https://cursor.com)