### PR TITLE
don't run this code

### DIFF
--- a/docs/user_guide/plugins/WmsTimeDimension.md
+++ b/docs/user_guide/plugins/WmsTimeDimension.md
@@ -4,9 +4,8 @@ Add a time dimension to a WMS tile layer.
 
 ### Exploring the WMS with OWSLib
 
-```{code-cell} ipython3
+```python
 from owslib.wms import WebMapService
-
 
 url = "https://pae-paha.pacioos.hawaii.edu/thredds/wms/dhw_5km?service=WMS"
 
@@ -17,7 +16,7 @@ print("\n".join(web_map_services.contents.keys()))
 
 ### Layer metadata
 
-```{code-cell} ipython3
+```python
 layer = "CRW_SST"
 wms = web_map_services.contents[layer]
 
@@ -38,7 +37,7 @@ if style not in wms.styles:
 
 ### Map with WmsTileLayer and TimestampedWmsTileLayers
 
-```{code-cell} ipython3
+```python
 import folium
 import folium.plugins
 


### PR DESCRIPTION
@hansthen I think this is the best compromise we can do. We do show the example, but do not run the code. That URL may work sometimes, so users trying it will get to see the plugin in action. Also, usually users looking for the example will replace the URL anyway.