### PR TITLE
Fix TopoJson non-collection geometries

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1053,9 +1053,12 @@ class TopoJson(JSCSSMixin, Layer):
             else:
                 return data
 
-        geometries = recursive_get(self.data, self.object_path.split("."))[
-            "geometries"
-        ]  # noqa
+        geometry = recursive_get(self.data, self.object_path.split("."))
+        geometries = (
+            geometry["geometries"]
+            if geometry["type"] == "GeometryCollection"
+            else [geometry]
+        )
         for feature in geometries:
             feature.setdefault("properties", {}).setdefault("style", {}).update(
                 self.style_function(feature)

--- a/folium/features.py
+++ b/folium/features.py
@@ -1047,6 +1047,14 @@ class TopoJson(JSCSSMixin, Layer):
     def style_data(self) -> None:
         """Applies self.style_function to each feature of self.data."""
 
+        for feature in self._get_geometries():
+            feature.setdefault("properties", {}).setdefault("style", {}).update(
+                self.style_function(feature)
+            )  # noqa
+
+    def _get_geometries(self) -> list:
+        """Return the selected TopoJSON object as a list of geometries."""
+
         def recursive_get(data, keys):
             if len(keys):
                 return recursive_get(data.get(keys[0]), keys[1:])
@@ -1054,15 +1062,7 @@ class TopoJson(JSCSSMixin, Layer):
                 return data
 
         geometry = recursive_get(self.data, self.object_path.split("."))
-        geometries = (
-            geometry["geometries"]
-            if geometry["type"] == "GeometryCollection"
-            else [geometry]
-        )
-        for feature in geometries:
-            feature.setdefault("properties", {}).setdefault("style", {}).update(
-                self.style_function(feature)
-            )  # noqa
+        return geometry["geometries"] if "geometries" in geometry else [geometry]
 
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
@@ -1203,12 +1203,7 @@ class GeoJsonDetail(MacroElement):
             )
             self.warn_for_geometry_collections()
         elif isinstance(self._parent, TopoJson):
-            obj_name = self._parent.object_path.split(".")[-1]
-            keys = tuple(
-                self._parent.data["objects"][obj_name]["geometries"][0][
-                    "properties"
-                ].keys()
-            )
+            keys = tuple(self._parent._get_geometries()[0]["properties"].keys())
         else:
             raise TypeError(
                 f"You cannot add a {self._name} to anything other than a "

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -17,6 +17,27 @@ from folium.elements import EventHandler
 from folium.utilities import JsCode
 
 
+@pytest.mark.parametrize("geometry_type", ["Polygon", "MultiPolygon"])
+def test_topojson_non_collection_geometry(geometry_type):
+    """TopoJson supports objects that are not GeometryCollections."""
+    topology = {
+        "type": "Topology",
+        "objects": {
+            "shape": {
+                "type": geometry_type,
+                "arcs": [[0]] if geometry_type == "Polygon" else [[[0]]],
+            }
+        },
+        "arcs": [[[0, 0], [1, 0], [0, 1], [-1, -1]]],
+        "transform": {"scale": [1, 1], "translate": [0, 0]},
+    }
+
+    map_ = folium.Map()
+    folium.TopoJson(topology, "objects.shape").add_to(map_)
+
+    assert "topojson.feature" in map_.get_root().render()
+
+
 @pytest.fixture
 def tmpl():
     yield ("""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -20,6 +20,7 @@ from folium.utilities import JsCode
 @pytest.mark.parametrize("geometry_type", ["Polygon", "MultiPolygon"])
 def test_topojson_non_collection_geometry(geometry_type):
     """TopoJson supports objects that are not GeometryCollections."""
+    style = {"color": "red"}
     topology = {
         "type": "Topology",
         "objects": {
@@ -33,9 +34,56 @@ def test_topojson_non_collection_geometry(geometry_type):
     }
 
     map_ = folium.Map()
-    folium.TopoJson(topology, "objects.shape").add_to(map_)
+    folium.TopoJson(
+        topology, "objects.shape", style_function=lambda feature: style
+    ).add_to(map_)
 
-    assert "topojson.feature" in map_.get_root().render()
+    map_.get_root().render()
+
+    assert topology["objects"]["shape"]["properties"]["style"] == style
+
+
+def test_topojson_non_collection_geometry_without_type():
+    """TopoJson does not require a type key to apply styles."""
+    topology = {
+        "type": "Topology",
+        "objects": {"shape": {"arcs": [[0]]}},
+        "arcs": [[[0, 0], [1, 0], [0, 1], [-1, -1]]],
+        "transform": {"scale": [1, 1], "translate": [0, 0]},
+    }
+
+    topojson = folium.TopoJson(
+        topology,
+        "objects.shape",
+        style_function=lambda feature: {"color": "red"},
+    )
+
+    topojson.style_data()
+
+    assert topology["objects"]["shape"]["properties"]["style"] == {"color": "red"}
+
+
+@pytest.mark.parametrize("detail_type", [folium.GeoJsonPopup, folium.GeoJsonTooltip])
+def test_topojson_non_collection_geometry_detail(detail_type):
+    """TopoJson popup and tooltip fields support non-collection geometries."""
+    topology = {
+        "type": "Topology",
+        "objects": {
+            "shape": {
+                "type": "Polygon",
+                "arcs": [[0]],
+                "properties": {"name": "A"},
+            }
+        },
+        "arcs": [[[0, 0], [1, 0], [0, 1], [-1, -1]]],
+        "transform": {"scale": [1, 1], "translate": [0, 0]},
+    }
+
+    map_ = folium.Map()
+    topojson = folium.TopoJson(topology, "objects.shape").add_to(map_)
+    detail_type(fields=["name"]).add_to(topojson)
+
+    assert "name" in map_.get_root().render()
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #1816

## Problem
When a TopoJSON's `objects` entry had a `type` of `Polygon` or
`MultiPolygon` (instead of `GeometryCollection`), folium raised:

    KeyError: 'geometries'

This happened because the code assumed every object had a `geometries`
key and didn't handle "bare" geometry objects that store their arcs
directly.

## Fix
Updated the TopoJson handling in `folium/features.py` so it also
supports non-collection geometry types (`Polygon`, `MultiPolygon`,
etc.), not just `GeometryCollection`.

## Testing
Reproduced the exact example from #1816 — it rendered without the
KeyError after this change. Ran the existing test suite locally with
`python -m pytest tests --ignore=tests/selenium` and all tests pass.