### PR TITLE
Give each Draw export button a unique element id

### DIFF
--- a/folium/plugins/draw.py
+++ b/folium/plugins/draw.py
@@ -58,9 +58,8 @@ class Draw(JSCSSMixin, MacroElement):
         {% macro html(this, kwargs) %}
             {% if this.export %}
             <style>
-                #export {
+                #export_{{ this.get_name() }} {
                     position: absolute;
-                    top: 5px;
                     right: 10px;
                     z-index: 999;
                     background: white;
@@ -74,7 +73,7 @@ class Draw(JSCSSMixin, MacroElement):
                     top: 90px;
                 }
             </style>
-            <a href='#' id='export'>Export</a>
+            <a href='#' id='export_{{ this.get_name() }}'>Export</a>
             {% endif %}
         {% endmacro %}
 
@@ -123,14 +122,14 @@ class Draw(JSCSSMixin, MacroElement):
             });
 
             {% if this.export %}
-            document.getElementById('export').onclick = function(e) {
+            document.getElementById('export_{{ this.get_name() }}').onclick = function(e) {
                 var data = drawnItems_{{ this.get_name() }}.toGeoJSON();
                 var convertedData = 'text/json;charset=utf-8,'
                     + encodeURIComponent(JSON.stringify(data));
-                document.getElementById('export').setAttribute(
+                document.getElementById('export_{{ this.get_name() }}').setAttribute(
                     'href', 'data:' + convertedData
                 );
-                document.getElementById('export').setAttribute(
+                document.getElementById('export_{{ this.get_name() }}').setAttribute(
                     'download', {{ this.filename|tojson }}
                 );
             }

--- a/tests/plugins/test_draw.py
+++ b/tests/plugins/test_draw.py
@@ -1,0 +1,70 @@
+"""
+Test Draw
+---------
+"""
+
+import re
+
+import folium
+from folium import plugins
+from folium.template import Template
+from folium.utilities import normalize
+
+
+def test_draw():
+    m = folium.Map([45.0, 3.0], zoom_start=4)
+    draw = plugins.Draw(export=True, filename="my_data.geojson")
+    m.add_child(draw)
+
+    out = normalize(m._parent.render())
+
+    # Verify that the export button has been created with a unique id.
+    tmpl = Template("<a href='#' id='export_{{this.get_name()}}'>Export</a>")
+    assert normalize(tmpl.render(this=draw)) in out
+
+    # Verify that the style targets that same id.
+    assert normalize(f"#export_{draw.get_name()} {{") in out
+
+    # Verify that the click handler is wired to that same id.
+    assert (
+        normalize(f"document.getElementById('export_{draw.get_name()}').onclick") in out
+    )
+
+
+def test_draw_no_export():
+    m = folium.Map([45.0, 3.0], zoom_start=4)
+    draw = plugins.Draw()
+    m.add_child(draw)
+
+    out = normalize(m._parent.render())
+
+    assert "Export</a>" not in out
+    assert f"export_{draw.get_name()}" not in out
+
+
+def test_two_draw_controls_get_unique_export_ids():
+    """Each Draw gets its own export button, wired to its own layers.
+
+    A hard-coded ``id='export'`` made the second button dead and pointed the
+    first at the wrong FeatureGroup.
+    """
+    m = folium.Map([45.0, 3.0], zoom_start=4)
+    first = plugins.Draw(export=True, filename="first.geojson")
+    second = plugins.Draw(export=True, filename="second.geojson")
+    m.add_child(first)
+    m.add_child(second)
+
+    out = m._parent.render()
+
+    ids = re.findall(r"id='(export_[^']+)'", out)
+    assert len(ids) == 2
+    assert len(set(ids)) == 2, f"export button ids are not unique: {ids}"
+
+    # Each handler must reference its own element, layers and filename.
+    for draw, filename in ((first, "first.geojson"), (second, "second.geojson")):
+        element_id = f"export_{draw.get_name()}"
+        assert f"id='{element_id}'" in out
+        start = out.index(f"document.getElementById('{element_id}').onclick")
+        handler = out[start : out.index("}", start) + 1]
+        assert f"drawnItems_{draw.get_name()}.toGeoJSON()" in handler
+        assert filename in handler


### PR DESCRIPTION
The `Draw` export button is hard-coded as `id='export'`, and its click handler looks it up with `document.getElementById('export')`. Adding two `Draw` controls with `export=True` emits two elements sharing one id — invalid HTML, and the feature breaks:

```python
import folium
from folium.plugins import Draw

m = folium.Map()
Draw(export=True, filename="a.geojson").add_to(m)
Draw(export=True, filename="b.geojson").add_to(m)
m.save("out.html")
```

On `main` that renders two `<a id='export'>` elements. Every `getElementById('export')` call resolves to the first one, so the second `onclick` assignment overwrites the first. The result is that the **first** button exports the **second** control's `FeatureGroup` under the second control's filename, and the second button does nothing at all.

This derives the id from `get_name()` instead, which is what the other plugins injecting their own elements already do — `ScrollZoomToggler` and `FloatImage` both use `id="{{this.get_name()}}"`.

I also dropped the duplicated `top: 5px` from the button's CSS. `top: 90px` is declared later in the same block and already won, so it was dead code — the rendered position is unchanged.

### On the id change

The id is not documented as public API, but anyone currently styling the button with a `#export { ... }` rule would need to switch to targeting the element another way. Happy to keep a stable class alongside the unique id if you'd rather not break that.

I found this while reading the plugin for #1806; this PR doesn't address that request.

### Testing

`tests/plugins/test_draw.py` is new — the Draw plugin had no test coverage. It covers the unique id, the `export=False` case, and two controls each staying wired to their own `FeatureGroup` and filename. The two id-related tests fail on `main` and pass here.

Full suite, excluding `tests/selenium` and `tests/snapshots` (missing `pixelmatch` locally): 258 passed, 6 failed. The same 6 fail identically on an unmodified checkout — `test_timedynamic_geo_json`, `test_dead_map_id_rule_absent`, `test_icon_invalid_marker_colors`, and three `test_repr.py` png tests — so none are from this change.

`ruff` and `codespell` are clean. `black` wants to rewrap the `Template(...)` call in `draw.py`, but it asks for exactly that same rewrap on an unmodified checkout; I get black 25.11.0 locally since 26.5.1 doesn't install on Python 3.9, so I left the formatting alone rather than add unrelated churn.