### PR TITLE
Fix TopoJson rendering for single-geometry objects

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -1053,9 +1053,14 @@ class TopoJson(JSCSSMixin, Layer):
             else:
                 return data
 
-        geometries = recursive_get(self.data, self.object_path.split("."))[
-            "geometries"
-        ]  # noqa
+        obj = recursive_get(self.data, self.object_path.split("."))
+        # A TopoJSON object is either a GeometryCollection (with a "geometries"
+        # list) or a single geometry (Polygon, MultiPolygon, ...) that has no
+        # "geometries" key and is itself the feature to style. See GH-1816.
+        if obj.get("type") == "GeometryCollection":
+            geometries = obj["geometries"]
+        else:
+            geometries = [obj]
         for feature in geometries:
             feature.setdefault("properties", {}).setdefault("style", {}).update(
                 self.style_function(feature)

--- a/tests/test_folium.py
+++ b/tests/test_folium.py
@@ -208,6 +208,25 @@ class TestFolium:
         topojson_str = topo_json._template.module.script(topo_json)
         assert "".join(topojson_str.split())[:-1] in "".join(out.split())
 
+    def test_topo_json_single_geometry(self):
+        """TopoJSON objects may be a single geometry rather than a
+        GeometryCollection, in which case there is no ``geometries`` key and
+        the object itself is the feature to style (GH-1816)."""
+        topo = {
+            "type": "Topology",
+            "transform": {"scale": [1, 1], "translate": [0, 0]},
+            "objects": {"A": {"type": "Polygon", "id": "A", "arcs": [[0]]}},
+            "arcs": [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]],
+        }
+        topo_json = folium.TopoJson(
+            topo, "objects.A", style_function=lambda _: {"color": "red"}
+        )
+        folium.Map().add_child(topo_json).render()
+
+        # The style function must be applied to the single geometry itself.
+        styled = topo_json.data["objects"]["A"]["properties"]["style"]
+        assert styled["color"] == "red"
+
     def test_choropleth_features(self):
         """Test to make sure that Choropleth function doesn't allow
         values outside of the domain defined by bins.


### PR DESCRIPTION
Closes #1816.

### The bug

A TopoJSON object can be either a `GeometryCollection` (which has a `geometries` list) or a **single geometry** — `Polygon`, `MultiPolygon`, `LineString`, etc. — which has no `geometries` key and is itself the feature. `TopoJson.style_data()` assumed the former and did `resolved_object["geometries"]` unconditionally, so any single-geometry object crashed on render:

```
File ".../folium/features.py", line 981, in style_data
    geometries = recursive_get(self.data, self.object_path.split("."))["geometries"]
KeyError: 'geometries'
```

Minimal reproducer (from the issue, trimmed):

```python
import folium

topo = {
    "type": "Topology",
    "transform": {"scale": [1, 1], "translate": [0, 0]},
    "objects": {"A": {"type": "Polygon", "id": "A", "arcs": [[0]]}},
    "arcs": [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]],
}
folium.TopoJson(topo, "objects.A").add_to(folium.Map())  # KeyError: 'geometries' on render
```

### The fix

Branch on the object's `type`: iterate `geometries` for a `GeometryCollection` (unchanged), otherwise treat the object itself as the single feature to style. The JS side (`topojson.feature`) already handles both shapes, so only the Python styling pass needed the guard.

### Tests

Added `test_topo_json_single_geometry`, which renders a single-`Polygon` TopoJSON and asserts the `style_function` is applied to the geometry. It fails with `KeyError` on `main` and passes with this change; the existing `GeometryCollection` path is unchanged and still covered.
