### PR TITLE
Remove dead #map CSS rule from Map template

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -210,15 +210,6 @@ class Map(JSCSSMixin, Evented):
             }
             </style>
 
-            <style>#map {
-                position:absolute;
-                top:0;
-                bottom:0;
-                right:0;
-                left:0;
-                }
-            </style>
-
             <script>
                 L_NO_TOUCH = {{ this.global_switches.no_touch |tojson}};
                 L_DISABLE_3D = {{ this.global_switches.disable_3d|tojson }};


### PR DESCRIPTION
## Issue

In `folium.py`, the `#map` functioned as a selector. The actual rendered IDs of maps are formatted as `map_<hash>`, so `#map` never references anything. `#{{ this.get_name() }}` functions as the rule that handles map styles, so the removal of `#map` does not impact the actual map style.

Also, a page using `<div id="map">` would be forced to have `position:absolute` due to this.


## Verification

I ran tests using three map configurations, and none of them returned with any html with `id="map"`. git grep -n on `'id="map"'`, `"'map'"`, and `'id="map"' main` returned no results, while git grep -n `'id=.map.'` referenced `tests/test_issue_2186.py:98`, which was a comment about the old rule being deleted. 

## Previous PR
#2229 PR deleted this, but `#map` remained due to the removal being dropped by Kakarot35 when they restored folium.py to match upstream to resolve an unrelated issue about WebDriverWait. Due to this reversion, `#map` still causes 2186 (test_dead_map_id_rule_absent) to fail. 

## Testing

After removing `#map` from the HTML styles in folium.py, test 2186 passes. `pytest tests --ignore=tests/selenium --ignore=tests/playwright --ignore=tests/snapshots` returned 260 passed tests and 4 failed ones. Prior to my fix, it returned 259 passed and 5 failed. All pre-commit hooks pass, and the 4 failures are unrelated. 3 are test_repr.py PNG tests and 1 is test_icon_invalid_marker_colors, which failed on both the modified and unmodified checkouts.

Note: tests/selenium and tests/snapshots were not run locally, as selenium has no manager binary for Windows ARM64, but the CI covers both.