### PR TITLE
Issue 1520: Propagate feature to child layers of multi-geometries

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -586,6 +586,11 @@ class GeoJson(Layer):
         {%- endif %}
 
         function {{this.get_name()}}_onEachFeature(feature, layer) {
+            if (typeof layer.eachLayer === "function") {
+                layer.eachLayer(function (child) {
+                    if (child.feature === undefined) { child.feature = feature; }
+                });
+            }
             {%- if this.on_each_feature %}
             ({{this.on_each_feature}})(feature, layer);
             {%- endif %}

--- a/folium/features.py
+++ b/folium/features.py
@@ -586,11 +586,13 @@ class GeoJson(Layer):
         {%- endif %}
 
         function {{this.get_name()}}_onEachFeature(feature, layer) {
-            if (typeof layer.eachLayer === "function") {
-                layer.eachLayer(function (child) {
+            (function propagate(parent){
+                if (typeof parent.eachLayer !== "function") {return;}
+                parent.eachLayer(function (child) {
                     if (child.feature === undefined) { child.feature = feature; }
-                });
-            }
+                    propagate(child);
+                })
+            })(layer)
             {%- if this.on_each_feature %}
             ({{this.on_each_feature}})(feature, layer);
             {%- endif %}

--- a/tests/selenium/test_multipoints_tooltip_selenium.py
+++ b/tests/selenium/test_multipoints_tooltip_selenium.py
@@ -1,0 +1,65 @@
+import folium
+from folium import GeoJson, GeoJsonTooltip, Map
+from folium.utilities import temp_html_filepath
+
+# Selenium's pointer actions do not reliably reach Leaflet's SVG paths in
+# headless Chrome, so the hover is dispatched as a DOM event instead. It
+# bubbles through Map._handleDOMEvent exactly as a real pointer hover does.
+HOVER = """
+    const el = arguments[0];
+    const rect = el.getBoundingClientRect();
+    const opts = {
+        bubbles: true,
+        clientX: rect.x + rect.width / 2,
+        clientY: rect.y + rect.height / 2,
+    };
+    el.dispatchEvent(new MouseEvent('mouseover', opts));
+    el.dispatchEvent(new MouseEvent('mousemove', opts));
+"""
+
+
+def build() -> Map:
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "multipoint"},
+                "geometry": {"type": "MultiPoint", "coordinates": [[0.0, 0.0]]},
+            }
+        ],
+    }
+    m = Map((0, 0), zoom_start=10)
+    GeoJson(
+        data,
+        marker=folium.CircleMarker(radius=20),
+        tooltip=GeoJsonTooltip(fields=["name"], labels=False),
+    ).add_to(m)
+    return m
+
+
+def test_geojson_multipoint_tooltip(driver):
+    """A GeoJsonTooltip must render for MultiPoint geometry.
+
+    Leaflet returns a FeatureGroup for MultiPoint and assigns `feature` to
+    that group only, while the tooltip resolves its source to the child
+    layer that fired the event. Without the feature on the children, the
+    tooltip's content function throws and nothing renders.
+
+    https://github.com/python-visualization/folium/issues/1520
+    """
+    html = build().get_root().render()
+    with temp_html_filepath(html) as filepath:
+        driver.get_file(filepath)
+        driver.wait_until(".folium-map")
+
+        marker = driver.wait_until("path.leaflet-interactive")
+        driver.execute_script(HOVER, marker)
+
+        tooltip = driver.wait_until(".leaflet-tooltip.foliumtooltip")
+        assert "multipoint" in tooltip.text
+
+    # No verify_js_logs() here: Leaflet 1.9.3 (our pin) throws
+    # "t.getElement is not a function" from _addFocusListenersOnLayer for any
+    # GeoJSON layer containing a nested FeatureGroup, independent of this fix.
+    # Guarded upstream in 1.9.4.


### PR DESCRIPTION
Leaflet's `geometryToLayer` returns a `FeatureGroup` for `MultiPoint`, and `addData` assigns `feature` to that group only. Tooltips resolve their source to the layer that fired the event, which is a child marker with no `feature`, so the content function throws before rendering. This copies the feature onto child layers in `onEachFeature`, descending recursively so that nested groups — a `GeometryCollection` containing a `MultiPoint` — are also covered.

Verified in Firefox/Chrome against the reporter's snippet and a matrix of all eight geometry types. `MultiLineString` and `MultiPolygon` are unaffected, since Leaflet flattens those into a single layer rather than a group.



| Geometry | Leaflet returns | Before | After |
| --- | --- | --- | --- |
| Point, LineString, Polygon | single layer | works | works |
| MultiLineString, MultiPolygon | single layer (flattened) | works | works |
| MultiPoint | `FeatureGroup` | broken | works |
| GeometryCollection | `FeatureGroup` | broken | works |
| `GeometryCollection` containing `MultiPoint` | nested `FeatureGroup` | broken | works |



<details><summary>Console error before the fix</summary>


```
Uncaught TypeError: can't access property "properties", layer.feature is undefined
    <anonymous> 
    _updateContent DivOverlay.js:277
    update DivOverlay.js:187
    onAdd DivOverlay.js:113
    onAdd Tooltip.js:84
    _layerAdd Layer.js:114
    whenReady Map.js:1477
    addLayer Layer.js:172
    openOn DivOverlay.js:63
    openTooltip Tooltip.js:337
    _openTooltip Tooltip.js:420
    fire Events.js:195
    _propagateEvent Events.js:311
    fire Events.js:204
    _propagateEvent Events.js:311
    fire Events.js:204
    _propagateEvent Events.js:311
    fire Events.js:204
    _fireDOMEvent Map.js:1452
    _handleDOMEvent Map.js:1401
    o DomEvent.js:108
```

</details>



If this approach looks right, the `MultiPoint` limitation in the GeoJSON docs and the `GeometryCollection` warning in `GeoJsonDetail` would need updating. Happy to do that here or in a follow-up.


**Tested with**

- folium `0.20.0` (reproduction) and this branch off `03cb432`
- Leaflet 1.9.3, as pinned in `folium/folium.py`
- Firefox 153.0.1 and Chrome 151 on Linux

Two tests fail on this branch, both of which also fail on clean `main`:

- `tests/test_map.py::test_icon_invalid_marker_colors` — `Icon.__init__` calls `color.startswith("#")` before validating the type, so `color=42` raises `AttributeError` instead of emitting the expected `UserWarning` (`folium/map.py:436`). Unrelated to this change; happy to open a separate issue or PR.

- `tests/plugins/test_time_slider_choropleth.py::test_timedynamic_geo_json` — `geodatasets` not installed locally.


`tests/test_features.py`: 20 passed. `tests/test_map.py` and `tests/plugins`: 91 passed, 2 failed (both above).

Fixes #1520 