### PR TITLE
Forward unrecognised Leaflet options in path_options

### DIFF
--- a/folium/vector_layers.py
+++ b/folium/vector_layers.py
@@ -123,6 +123,11 @@ def path_options(
         "bubblingMouseEvents": kwargs.pop("bubblingMouseEvents", True),
     }
     default.update(extra_options)
+    # Pass any remaining options straight through to Leaflet, matching how
+    # the other folium option builders forward **kwargs. Without this, Path
+    # options such as ``interactive``, ``pane`` or ``renderer`` were silently
+    # dropped from vector overlays.
+    default.update(kwargs)
     return default
 
 

--- a/tests/test_vector_layers.py
+++ b/tests/test_vector_layers.py
@@ -404,3 +404,31 @@ def test_path_options_lower_camel_case():
     options = path_options(fill_color="red", fillOpacity=0.3)
     assert options["fillColor"] == "red"
     assert options["fillOpacity"] == 0.3
+
+
+def test_path_options_passes_through_extra_leaflet_options():
+    """Leaflet Path options not named explicitly should not be dropped.
+
+    ``interactive``, ``pane``, ``renderer`` and friends used to vanish from
+    vector overlays even though the other folium option builders forward
+    arbitrary **kwargs to Leaflet.
+    """
+    options = path_options(
+        line=False,
+        radius=10,
+        interactive=False,
+        pane="overlayPane",
+        custom_option="x",
+    )
+    assert options["interactive"] is False
+    assert options["pane"] == "overlayPane"
+    # snake_case is camelised like the named options
+    assert options["customOption"] == "x"
+
+
+def test_circle_marker_forwards_interactive():
+    m = Map()
+    marker = CircleMarker(location=[0, 0], radius=5, interactive=False)
+    marker.add_to(m)
+    rendered = normalize(m._parent.render())
+    assert '"interactive": false' in rendered


### PR DESCRIPTION
`path_options()` (shared by `Circle`, `CircleMarker`, `PolyLine`, `Polygon`, `Rectangle`) pops the options it names explicitly and builds the result from those, but never forwards the remaining `kwargs`. So any Leaflet [Path](https://leafletjs.com/reference.html#path) option it doesn't list — `interactive`, `pane`, `renderer`, `attribution`, … — is silently dropped:

```python
from folium.vector_layers import path_options
"interactive" in path_options(radius=10, interactive=False)   # -> False on main
```

A common case is `interactive=False` to make a shape non-clickable — on `main` it just vanishes.

This is inconsistent with the rest of folium: `FeatureGroup`, `LayerGroup`, `TileLayer`, `VideoOverlay` and `GeoJson` all forward `**kwargs` to Leaflet through `remove_empty(**kwargs)`. And `path_options` already special-cases `tags`, `className` and `gradient`, which shows the intent was to support Leaflet options — the general pass-through was just never added.

The fix forwards the leftover options after the named ones:

```python
    default.update(extra_options)
    default.update(kwargs)   # <- pass remaining Leaflet options through
    return default
```

The remaining keys are already camelised at the top of the function, so `interactive`/`pane`/`renderer` and snake_case extras (`my_option` → `myOption`) all arrive correctly, and named options are unaffected because they were already popped.

### Testing

Two new tests in `tests/test_vector_layers.py`: one asserting `path_options` forwards `interactive`/`pane`/a custom option, one asserting `CircleMarker(..., interactive=False)` renders `"interactive": false`. Both fail on `main` and pass here.

`tests/test_vector_layers.py` is 9 passed; the existing 7 are unchanged. `ruff check` and `codespell` are clean. Across `test_features.py`, `test_map.py` and `tests/plugins/`, the only failures are `test_icon_invalid_marker_colors` and `test_timedynamic_geo_json`, which fail identically on an unmodified checkout.