### PR TITLE
Add stroke_dash_array option to TimeSliderChoropleth

### DIFF
--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -35,6 +35,15 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
         `[-L, L-1]`, where `L` is the maximum number of time stamps in
         `styledict`. For example, use `-1` to initialize the slider to the
         latest timestamp.
+    stroke_opacity: float, default 1
+        Opacity of the stroke drawn around each feature.
+    stroke_width: float, default 0.8
+        Width of the stroke drawn around each feature.
+    stroke_color: str, default "#FFFFFF"
+        Color of the stroke drawn around each feature.
+    stroke_dash_array: str, default "5,5"
+        SVG `stroke-dasharray` for the stroke around each feature. The default
+        "5,5" draws a dashed line; pass "0" (or "none") for a solid line.
     """
 
     _template = Template("""
@@ -150,7 +159,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
                 d3.selectAll('path')
                 .attr('stroke', '{{ this.stroke_color }}')
                 .attr('stroke-width', {{ this.stroke_width }})
-                .attr('stroke-dasharray', '5,5')
+                .attr('stroke-dasharray', '{{ this.stroke_dash_array }}')
                 .attr('stroke-opacity', {{ this.stroke_opacity }})
                 .attr('fill-opacity', 0);
 
@@ -191,6 +200,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
         stroke_opacity=1,
         stroke_width=0.8,
         stroke_color="#FFFFFF",
+        stroke_dash_array="5,5",
     ):
         super().__init__(name=name, overlay=overlay, control=control, show=show)
         self.data = GeoJson.process_data(GeoJson({}), data)
@@ -200,6 +210,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
         self.stroke_opacity = stroke_opacity
         self.stroke_width = stroke_width
         self.stroke_color = stroke_color
+        self.stroke_dash_array = stroke_dash_array
 
         if not isinstance(styledict, dict):
             raise ValueError(f"styledict must be a dictionary, got {styledict!r}")

--- a/tests/plugins/test_time_slider_choropleth.py
+++ b/tests/plugins/test_time_slider_choropleth.py
@@ -120,3 +120,43 @@ def test_slider_overlays_map():
     rendered = plugin._template.module.script(plugin)
 
     assert '.style("position", "absolute")' in rendered
+
+
+def _single_feature_plugin(**kwargs):
+    geojson = json.dumps(
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "0",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                    },
+                }
+            ],
+        }
+    )
+    styledict = {"0": {"1420070400": {"color": "#ff0000", "opacity": 0.5}}}
+
+    m = folium.Map((0, 0), zoom_start=2)
+    plugin = TimeSliderChoropleth(geojson, styledict, **kwargs)
+    plugin.add_to(m)
+    return plugin
+
+
+def test_stroke_dash_array_default():
+    # the default keeps the previous dashed stroke, so existing maps are unchanged
+    plugin = _single_feature_plugin()
+    rendered = plugin._template.module.script(plugin)
+    assert ".attr('stroke-dasharray', '5,5')" in rendered
+
+
+def test_stroke_dash_array_custom():
+    # "0" gives a solid line instead of the dashed default
+    plugin = _single_feature_plugin(stroke_dash_array="0")
+    rendered = plugin._template.module.script(plugin)
+    assert ".attr('stroke-dasharray', '0')" in rendered
+    assert ".attr('stroke-dasharray', '5,5')" not in rendered


### PR DESCRIPTION
Follow-up to #1615. That issue asked to make the stroke around `TimeSliderChoropleth` features configurable, and #1838 added `stroke_color`, `stroke_width` and `stroke_opacity`. But the dash pattern is still hard-coded in the template:

```python
.attr('stroke-dasharray', '5,5')
```

So the white dashed line the original reporter wanted to get rid of can be recolored or hidden, but you still can't make it solid. This adds a `stroke_dash_array` argument that feeds straight into the SVG `stroke-dasharray`:

```python
TimeSliderChoropleth(data, styledict, stroke_dash_array="0")  # solid line
```

The default is `"5,5"`, which renders exactly like before, so existing maps are unchanged. I also documented the three earlier stroke options in the docstring while I was there, since they weren't listed yet.

### Testing

Two new tests in `tests/plugins/test_time_slider_choropleth.py`: one checks the default still emits `stroke-dasharray', '5,5'`, the other that `stroke_dash_array="0"` emits `'0'` and no longer the dashed default.

`pytest tests/plugins/test_time_slider_choropleth.py` is 3 passed; the only failure is `test_timedynamic_geo_json`, which needs `geodatasets`/`geopandas` and fails the same way on an unmodified checkout. `ruff`, `black` and `codespell` are clean on both files.
