### PR TITLE
Upgrade Leaflet from 1.9.3 to 1.9.4

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -25,7 +25,7 @@ from folium.utilities import (
 )
 
 _default_js = [
-    ("leaflet", "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"),
+    ("leaflet", "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"),
     ("jquery", "https://code.jquery.com/jquery-3.7.1.min.js"),
     (
         "bootstrap",
@@ -38,7 +38,7 @@ _default_js = [
 ]
 
 _default_css = [
-    ("leaflet_css", "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"),
+    ("leaflet_css", "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css"),
     (
         "bootstrap_css",
         "https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css",

--- a/tests/selenium/test_multipoints_tooltip_selenium.py
+++ b/tests/selenium/test_multipoints_tooltip_selenium.py
@@ -59,7 +59,4 @@ def test_geojson_multipoint_tooltip(driver):
         tooltip = driver.wait_until(".leaflet-tooltip.foliumtooltip")
         assert "multipoint" in tooltip.text
 
-    # No verify_js_logs() here: Leaflet 1.9.3 (our pin) throws
-    # "t.getElement is not a function" from _addFocusListenersOnLayer for any
-    # GeoJSON layer containing a nested FeatureGroup, independent of this fix.
-    # Guarded upstream in 1.9.4.
+        driver.verify_js_logs()


### PR DESCRIPTION
As requested in https://github.com/python-visualization/folium/pull/2263#issuecomment-5409714983.

Bumps the pinned Leaflet 1.9.3 → 1.9.4, and restores the `verify_js_logs()` call in `tests/selenium/test_multipoints_tooltip_selenium.py` that #2263 had to omit. 

1.9.4 guards the unchecked `layer.getElement()` in `_addFocusListenersOnLayer` (`Tooltip.js:396`): https://github.com/Leaflet/Leaflet/compare/v1.9.3...v1.9.4

The failing test is `test_notebook[coordinate_ordering.md]`, but the error doesn't originate there since that page has no tooltips, and in 1.9.3 only `Tooltip.js` calls `getElement()`, from the focus-listener path that runs only when a tooltip is bound. It's the MultiPoint test from #2263 that throws. Because that test skipped `verify_js_logs()`, the uncaught error stayed in the session-scoped driver's console log and surfaced in whichever later test read it first.

Worth noting for future selenium tests in this repo: skipping `verify_js_logs()` doesn't contain an error locally, it defers it to another test.

Reproducible on `main`: `coordinate_ordering` passes alone and fails when run after the MultiPoint test.

```
pytest tests/selenium/test_multipoints_tooltip_selenium.py \
       tests/selenium/test_selenium.py -k "multipoint or coordinate_ordering"
```

Locally on 1.9.4: `tests/selenium` 76 passed, 1 xfailed — including the heatmap
pixel-diff test, so no rendering changes.