### PR TITLE
Fix three stale documented defaults (TopoJson.overlay, TimeSliderChoropleth.overlay, GeoJsonPopup.localize)

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -950,7 +950,7 @@ class TopoJson(JSCSSMixin, Layer):
         A function mapping a TopoJson geometry to a style dict.
     name : string, default None
         The name of the Layer, as it will appear in LayerControls
-    overlay : bool, default False
+    overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.
@@ -1338,7 +1338,7 @@ class GeoJsonPopup(GeoJsonDetail):
         instead of the keys of `fields`.
     labels: bool, default True.
         Set to False to disable displaying the field names or aliases.
-    localize: bool, default False.
+    localize: bool, default True.
         This will use JavaScript's .toLocaleString() to format 'clean' values
         as strings for the user's location; i.e. 1,000,000.00 comma separators,
         float truncation, etc.

--- a/folium/plugins/time_slider_choropleth.py
+++ b/folium/plugins/time_slider_choropleth.py
@@ -24,7 +24,7 @@ class TimeSliderChoropleth(JSCSSMixin, Layer):
         Whether to show a visual effect on mouse hover and click.
     name : string, default None
         The name of the Layer, as it will appear in LayerControls.
-    overlay : bool, default False
+    overlay : bool, default True
         Adds the layer as an optional overlay (True) or the base layer (False).
     control : bool, default True
         Whether the Layer will be included in LayerControls.

--- a/tests/test_docstring_defaults.py
+++ b/tests/test_docstring_defaults.py
@@ -1,0 +1,86 @@
+"""
+Check that documented defaults match the signature defaults.
+
+Several classes override a default inherited from ``Layer`` or from a sibling
+class but keep the parameter description they were copied from, so the
+docstring ends up stating the old default.  Scoped to the boolean flags whose
+documented value is a plain ``True``/``False`` literal, which is what makes the
+comparison unambiguous.
+"""
+
+import inspect
+import pkgutil
+import re
+from importlib import import_module
+
+import pytest
+
+import folium
+
+FLAGS = ("overlay", "control", "show", "localize")
+
+
+def _classes():
+    modules = [folium]
+    for mod in pkgutil.walk_packages(folium.__path__, folium.__name__ + "."):
+        try:
+            modules.append(import_module(mod.name))
+        except ImportError:  # optional dependency
+            continue
+    seen = set()
+    for module in modules:
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if obj.__module__.startswith("folium.") and obj not in seen:
+                seen.add(obj)
+                yield obj
+
+
+def _documented_default(obj, flag):
+    for source in (obj.__init__.__doc__, obj.__doc__):
+        if not source:
+            continue
+        match = re.search(
+            rf"^\s*{flag}\s*:[^\n]*default[ =:]+(True|False)\b",
+            source,
+            re.MULTILINE,
+        )
+        if match:
+            return match.group(1) == "True"
+    return None
+
+
+@pytest.mark.parametrize("cls", sorted(_classes(), key=lambda c: c.__qualname__))
+def test_documented_boolean_defaults_match_signature(cls):
+    try:
+        signature = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        pytest.skip("no introspectable signature")
+    for flag in FLAGS:
+        parameter = signature.parameters.get(flag)
+        if parameter is None or not isinstance(parameter.default, bool):
+            continue
+        documented = _documented_default(cls, flag)
+        if documented is None:
+            continue
+        assert documented == parameter.default, (
+            f"{cls.__qualname__}.{flag} is documented as default "
+            f"{documented} but defaults to {parameter.default}"
+        )
+
+
+def test_the_check_can_actually_fail():
+    """Guard against the check passing because it never reads anything."""
+
+    class Example:
+        """
+        Parameters
+        ----------
+        overlay : bool, default False
+            Doc and signature disagree on purpose.
+        """
+
+        def __init__(self, overlay: bool = True):
+            pass
+
+    assert _documented_default(Example, "overlay") is False
+    assert inspect.signature(Example.__init__).parameters["overlay"].default is True


### PR DESCRIPTION
Three classes override a default and kept the parameter description they were copied from, so the documentation states the old value:

| | documented | actually defaults to |
|---|---|---|
| `TopoJson.overlay` | `False` | `True` |
| `TimeSliderChoropleth.overlay` | `False` | `True` |
| `GeoJsonPopup.localize` | `False` | `True` |

In each case the code is right and the docstring is stale, and the tie is broken by a sibling in the same file rather than by preference:

- `Layer` (`map.py`) both documents and defaults `overlay=False`. `GeoJson` overrides it to `True` **and** documents `True`. `TopoJson` and `TimeSliderChoropleth` override it to `True` and kept `Layer`'s line.
- `GeoJsonTooltip` documents `localize` as `False` and defaults to `False`. `GeoJsonPopup` overrides to `True` and kept the tooltip's line.

`overlay` decides whether a layer shows up in `LayerControl` as a toggleable overlay or as a base layer, so this is a wrong mental model rather than a cosmetic slip.

The new test walks every class in the package — 96 of them — and compares the documented boolean default with the signature default for `overlay`, `control`, `show` and `localize`. It is restricted to those four because a bare `True`/`False` in a docstring is unambiguous to compare, whereas the numeric and string defaults elsewhere are written in too many styles to check mechanically without false positives.

Verification: with the three docstrings reverted to their current text, exactly those three parametrised cases fail and the other 94 pass, so the check is neither vacuous nor over-broad. There is also a small self-check asserting the docstring parser really does detect a mismatch. `black` 26.5.1 and `ruff` 0.16.3 (the versions pinned in `.pre-commit-config.yaml`) report the three files unchanged and clean.

Suite run locally, Python 3.14, excluding `tests/selenium`: 369 passed, 2 failed — `test_icon_invalid_marker_colors` and `test_valid_png_size`, both of which fail identically on unmodified `main` here, so they look like environment rather than regressions. `tests/snapshots` could not be collected at all locally because `pixelmatch` is not installed; that path is untested by me.
